### PR TITLE
fix inverted logic on pid check -- should *NOT* be same pid

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -415,7 +415,8 @@ static void listenCb(uv_stream_t *listener, int status)
 		if (rv != 0) {
 			goto err;
 		}
-		if (cred.pid != getpid()) {
+		// no need to call ourself
+		if (cred.pid == getpid()) {
 			goto err;
 		}
 	}


### PR DESCRIPTION
The logic for listening to unix sockets was rejecting requests unless it was coming from the same pid -- it should be the opposite: reject if *same* pid.

With this change applied I can bring up a local cluster on unix sockets with the goal of being to apply an optional TLS proxy for secured inter-server communications.