### PR TITLE
vfs: vfs__delete: fix double-unlock of &root->mutex

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -619,7 +619,6 @@ static int vfs__delete_content(struct root *root, const char *filename)
 	/* Check that there are no consumers of this file. */
 	if (content->refcount > 0) {
 		root->error = EBUSY;
-		pthread_mutex_unlock(&root->mutex);
 		rc = SQLITE_IOERR_DELETE;
 		goto err;
 	}
@@ -629,8 +628,6 @@ static int vfs__delete_content(struct root *root, const char *filename)
 
 	/* Reset the file content slot. */
 	*(root->contents + content_index) = NULL;
-
-	pthread_mutex_unlock(&root->mutex);
 
 	return SQLITE_OK;
 

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -639,12 +639,11 @@ err:
 
 static int vfs__x_close(sqlite3_file *file)
 {
+	int rc = SQLITE_OK;
 	struct vfs__file *f = (struct vfs__file *)file;
 	struct root *root = (struct root *)(f->root);
 
 	if (f->temp != NULL) {
-		int rc;
-
 		/* Close the actual temporary file. */
 		rc = f->temp->pMethods->xClose(f->temp);
 		sqlite3_free(f->temp);
@@ -665,12 +664,12 @@ static int vfs__x_close(sqlite3_file *file)
 	}
 
 	if (f->flags & SQLITE_OPEN_DELETEONCLOSE) {
-		vfs__delete_content(root, f->content->filename);
+		rc = vfs__delete_content(root, f->content->filename);
 	}
 
 	pthread_mutex_unlock(&root->mutex);
 
-	return SQLITE_OK;
+	return rc;
 }
 
 static int vfs__read(sqlite3_file *file,


### PR DESCRIPTION
vfs__delete_contents would unlock the passed &root->mutex, but all of
its callers would then also unlock the passed &root->mutex. It turns out
that this works on most architectures without issue, but [apparently][1] on
[some Intel CPUs with TSX enabled][2] this will trigger a general protection
fault.

This was the cause of a [very frustrating bug where LXD would segfault on
start-up][3].

[1]: https://lwn.net/Articles/534758/
[2]: https://software.intel.com/en-us/forums/intel-isa-extensions/topic/675036
[3]: https://bugzilla.opensuse.org/show_bug.cgi?id=1156336

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>