### PR TITLE
Add timestamped debug logging option

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -33,6 +33,7 @@ void db__close(struct db *db)
 		assert(rc == SQLITE_OK);
 	}
 	if (db->tx != NULL) {
+		DEBUG_TX(db->tx, "freeing open transaction");
 		sqlite3_free(db->tx);
 	}
 	sqlite3_free(db->filename);
@@ -47,6 +48,7 @@ int db__open_follower(struct db *db)
 	if (rc != 0) {
 		return rc;
 	}
+	DEBUG_MSG("LEADERSHIP: false");
 	return 0;
 }
 
@@ -63,6 +65,7 @@ int db__create_tx(struct db *db, unsigned long long id, sqlite3 *conn)
 
 void db__delete_tx(struct db *db)
 {
+	DEBUG_TX(db->tx, "deleting");
 	tx__close(db->tx);
 	sqlite3_free(db->tx);
 	db->tx = NULL;

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,22 @@
+#ifdef DEBUG_VERBOSE
+
+void ts (void);
+
+#define DEBUG_MSG(MSG) { 						\
+   ts();								\
+   printf("%s:%d (%s) -- %s\n", __FILE__, __LINE__, __func__, MSG);	\
+   fflush(stdout);							\
+}
+
+#define DEBUG_TX(TX, MSG) { 							\
+   size_t id = 0; 								\
+   if (TX != NULL) {id = ((struct tx*)(TX))->id;}				\
+   ts();									\
+   printf("%s:%d (%s) TX:%09ld -- %s\n", __FILE__, __LINE__, __func__, id, MSG);	\
+   fflush(stdout);								\
+}
+#else
+#define DEBUG_MSG(MSG)
+#define DEBUG_TX(TX, MSG)
+#endif // DEBUG_VERBOSE
+

--- a/src/registry.c
+++ b/src/registry.c
@@ -51,6 +51,7 @@ void registry__db_by_tx_id(struct registry *r, size_t id, struct db **db)
 	{
 		*db = QUEUE__DATA(head, struct db, queue);
 		if ((*db)->tx != NULL && (*db)->tx->id == id) {
+			DEBUG_TX((*db)->tx, "db not found");
 			return;
 		}
 	}

--- a/src/tx.h
+++ b/src/tx.h
@@ -58,4 +58,6 @@ void tx__zombie(struct tx *tx);
  */
 void tx__surrogate(struct tx *tx, sqlite3 *conn);
 
+#include "debug.h"
+
 #endif /* TX_H_*/


### PR DESCRIPTION
Having encountered occasional duplicate writes whilst using go-dqlite (https://github.com/canonical/go-dqlite/pull/76) it seemed like it would be beneficial to have an option to track execution state for further debugging.

The emphasis on the debugging is tracking transactions with leadership changes (either by assigning a new leader or killing the existing one).

I expect that there's stuff that might need improvement (or maybe not acceptable at all), but I figured this could be useful.