### PR TITLE
Finalize pending SQL statements associated with EXEC_SQL commands

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -30,6 +30,11 @@ void gateway__close(struct gateway *g)
 {
 	stmt__registry_close(&g->stmts);
 	if (g->leader != NULL) {
+		if (g->stmt != NULL) {
+			assert(g->req != NULL);
+			g->exec.cb = NULL;
+			sqlite3_finalize(g->stmt);
+		}
 		leader__close(g->leader);
 		sqlite3_free(g->leader);
 	}

--- a/src/leader.c
+++ b/src/leader.c
@@ -235,6 +235,7 @@ int leader__init(struct leader *l, struct db *db, struct raft *raft)
 
 	l->exec = NULL;
 	l->apply.data = l;
+	l->inflight = NULL;
 	QUEUE__PUSH(&db->leaders, &l->queue);
 	return 0;
 
@@ -249,6 +250,10 @@ void leader__close(struct leader *l)
 	int rc;
 	/* TODO: there shouldn't be any ongoing exec request. */
 	if (l->exec != NULL) {
+		if (l->inflight != NULL) {
+			/* TODO: make leader_close async instead */
+			l->inflight->leader = NULL;
+		}
 		l->exec->done = true;
 		l->exec->status = SQLITE_ERROR;
 		maybeExecDone(l->exec);

--- a/src/leader.h
+++ b/src/leader.h
@@ -5,15 +5,14 @@
 #ifndef LEADER_H_
 #define LEADER_H_
 
-#include <stdbool.h>
-
 #include <libco.h>
 #include <raft.h>
 #include <sqlite3.h>
+#include <stdbool.h>
 
 #include "./lib/queue.h"
-
 #include "db.h"
+#include "replication.h"
 
 struct exec;
 struct barrier;
@@ -32,6 +31,7 @@ struct leader
 	struct exec *exec;       /* Exec request in progress, if any. */
 	struct raft_apply apply; /* To apply checkpoint commands */
 	queue queue;             /* Prev/next leader, used by struct db. */
+	struct apply *inflight;  /* TODO: make leader__close async */
 };
 
 struct barrier

--- a/src/replication.h
+++ b/src/replication.h
@@ -10,6 +10,21 @@
 
 #include "config.h"
 
+/* Wrapper around raft_apply, saving context information. */
+struct apply
+{
+	struct raft_apply req; /* Raft apply request */
+	int status;            /* Raft apply result */
+	struct leader *leader; /* Leader connection that triggered the hook */
+	int type;              /* Command type */
+	union {                /* Command-specific data */
+		struct
+		{
+			bool is_commit;
+		} frames;
+	};
+};
+
 /**
  * Initialize the given SQLite replication interface with dqlite's raft based
  * implementation.


### PR DESCRIPTION
If a connection gets closed while a raft commit associated with a EXEC-SQL
protocol request is in progress, the prepared statement was not being finalized.

Later on, the gateway__close() and leader__close() APIs should be probably be
made asynhronous for cleaner logic.

Fixes #194.