### PR TITLE
Propagate errors originating from raft_barrier()

### DIFF
--- a/src/leader.c
+++ b/src/leader.c
@@ -277,6 +277,7 @@ static void execBarrierCb(struct barrier *barrier, int status)
 	struct leader *l = req->leader;
 	if (status != 0) {
 		l->exec->done = true;
+		l->exec->status = status;
 		maybeExecDone(l->exec);
 		return;
 	}


### PR DESCRIPTION
This might be a case where we don't accurately report errors and end up with a "not an error" message on the client side.