### PR TITLE
Check if the node is the leader also when serving SQL exec requests

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -245,6 +245,7 @@ static int handle_exec(struct handle *req, struct cursor *cursor)
 	struct stmt *stmt;
 	int rv;
 	START(exec, result);
+	CHECK_LEADER(req);
 	LOOKUP_DB(request.db_id);
 	LOOKUP_STMT(request.stmt_id);
 	(void)response;
@@ -450,6 +451,7 @@ static int handle_exec_sql(struct handle *req, struct cursor *cursor)
 {
 	struct gateway *g = req->gateway;
 	START(exec_sql, result);
+	CHECK_LEADER(req);
 	LOOKUP_DB(request.db_id);
 	(void)response;
 	assert(g->req == NULL);


### PR DESCRIPTION
Some SQL exec requests such as BEGIN don't actually trigger any raft command, so
we need to explicitly check for leadership when starting to serve the request.