### PR TITLE
Namespace symbols in vfs.c

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -277,7 +277,7 @@ static int encodeDatabase(struct db *db, struct raft_buffer bufs[3])
 	header.filename = db->filename;
 
 	/* Main database file. */
-	rv = vfsFileRead(db->config->name, db->filename, &bufs[1].base,
+	rv = VfsFileRead(db->config->name, db->filename, &bufs[1].base,
 			 &bufs[1].len);
 	if (rv != 0) {
 		goto err_after_wal_filename_alloc;
@@ -285,7 +285,7 @@ static int encodeDatabase(struct db *db, struct raft_buffer bufs[3])
 	header.main_size = bufs[1].len;
 
 	/* WAL file. */
-	rv = vfsFileRead(db->config->name, walFilename, &bufs[2].base,
+	rv = VfsFileRead(db->config->name, walFilename, &bufs[2].base,
 			 &bufs[2].len);
 	if (rv != 0) {
 		goto err_after_main_file_read;
@@ -333,7 +333,7 @@ static int decodeDatabase(struct fsm *f, struct cursor *cursor)
 	if (rv != 0) {
 		return rv;
 	}
-	rv = vfsFileWrite(db->config->name, db->filename, cursor->p,
+	rv = VfsFileWrite(db->config->name, db->filename, cursor->p,
 			  header.main_size);
 	if (rv != 0) {
 		return rv;
@@ -344,7 +344,7 @@ static int decodeDatabase(struct fsm *f, struct cursor *cursor)
 	}
 	cursor->p += header.main_size;
 	if (header.wal_size > 0) {
-		rv = vfsFileWrite(db->config->name, walFilename, cursor->p,
+		rv = VfsFileWrite(db->config->name, walFilename, cursor->p,
 				  header.wal_size);
 		if (rv != 0) {
 			sqlite3_free(walFilename);

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -674,7 +674,7 @@ static int dumpFile(struct gateway *g,
 	uint64_t len;
 	int rv;
 
-	rv = vfsFileRead(g->config->name, filename, &buf, &file_size);
+	rv = VfsFileRead(g->config->name, filename, &buf, &file_size);
 	if (rv != 0) {
 		return rv;
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -27,7 +27,7 @@ int dqlite__init(struct dqlite_node *d,
 	if (rv != 0) {
 		goto err;
 	}
-	rv = vfsInit(&d->vfs, &d->config);
+	rv = vfsInit(&d->vfs, d->config.name);
 	if (rv != 0) {
 		goto err_after_config_init;
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -27,7 +27,7 @@ int dqlite__init(struct dqlite_node *d,
 	if (rv != 0) {
 		goto err;
 	}
-	rv = vfsInit(&d->vfs, d->config.name);
+	rv = VfsInit(&d->vfs, d->config.name);
 	if (rv != 0) {
 		goto err_after_config_init;
 	}
@@ -106,7 +106,7 @@ err_after_raft_transport_init:
 err_after_loop_init:
 	uv_loop_close(&d->loop);
 err_after_vfs_init:
-	vfsClose(&d->vfs);
+	VfsClose(&d->vfs);
 err_after_config_init:
 	config__close(&d->config);
 err:
@@ -128,7 +128,7 @@ void dqlite__close(struct dqlite_node *d)
 	uv_loop_close(&d->loop);
 	raftProxyClose(&d->raft_transport);
 	registry__close(&d->registry);
-	vfsClose(&d->vfs);
+	VfsClose(&d->vfs);
 	config__close(&d->config);
 	if (d->bind_address != NULL) {
 		sqlite3_free(d->bind_address);

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1728,7 +1728,7 @@ static int vfs__get_last_error(sqlite3_vfs *vfs, int x, char *y)
 	return rc;
 }
 
-int vfsInit(struct sqlite3_vfs *vfs, struct config *config)
+int vfsInit(struct sqlite3_vfs *vfs, const char *name)
 {
 	vfs->iVersion = 2;
 	vfs->szOsFile = sizeof(struct vfs__file);
@@ -1753,7 +1753,7 @@ int vfsInit(struct sqlite3_vfs *vfs, struct config *config)
 	vfs->xCurrentTime = vfs__current_time;
 	vfs->xGetLastError = vfs__get_last_error;
 	vfs->xCurrentTimeInt64 = vfs__current_time_int64;
-	vfs->zName = config->name;
+	vfs->zName = name;
 
 	sqlite3_vfs_register(vfs, 0);
 

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -413,14 +413,13 @@ struct vfs__file
  * of all files that were created. */
 struct root
 {
-	struct logger *logger;     /* Send log messages here. */
 	struct content **contents; /* Files content */
 	int contents_len;          /* Number of files */
 	int error;                 /* Last error occurred. */
 };
 
 /* Create a new root object. */
-static struct root *root_create(struct logger *logger)
+static struct root *root_create()
 {
 	struct root *r;
 	int contents_size;
@@ -430,7 +429,6 @@ static struct root *root_create(struct logger *logger)
 		goto oom;
 	}
 
-	r->logger = logger;
 	r->contents_len = VFS__MAX_FILES;
 
 	contents_size = r->contents_len * sizeof *r->contents;
@@ -1737,7 +1735,7 @@ int vfsInit(struct sqlite3_vfs *vfs, struct config *config)
 	vfs->mxPathname = VFS__MAX_PATHNAME;
 	vfs->pNext = NULL;
 
-	vfs->pAppData = root_create(&config->logger);
+	vfs->pAppData = root_create();
 	if (vfs->pAppData == NULL) {
 		return DQLITE_NOMEM;
 	}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -418,8 +418,8 @@ struct vfs
 	int error;                 /* Last error occurred. */
 };
 
-/* Create a new root object. */
-static struct vfs *root_create()
+/* Create a new vfs object. */
+static struct vfs *vfsCreate()
 {
 	struct vfs *r;
 	int contents_size;
@@ -1728,14 +1728,14 @@ static int vfs__get_last_error(sqlite3_vfs *vfs, int x, char *y)
 	return rc;
 }
 
-int vfsInit(struct sqlite3_vfs *vfs, const char *name)
+int VfsInit(struct sqlite3_vfs *vfs, const char *name)
 {
 	vfs->iVersion = 2;
 	vfs->szOsFile = sizeof(struct vfs__file);
 	vfs->mxPathname = VFS__MAX_PATHNAME;
 	vfs->pNext = NULL;
 
-	vfs->pAppData = root_create();
+	vfs->pAppData = vfsCreate();
 	if (vfs->pAppData == NULL) {
 		return DQLITE_NOMEM;
 	}
@@ -1760,7 +1760,7 @@ int vfsInit(struct sqlite3_vfs *vfs, const char *name)
 	return 0;
 }
 
-void vfsClose(struct sqlite3_vfs *vfs)
+void VfsClose(struct sqlite3_vfs *vfs)
 {
 	struct vfs *root;
 	sqlite3_vfs_unregister(vfs);
@@ -1780,7 +1780,7 @@ static int guess_file_type(const char *filename)
 	return FORMAT__DB;
 }
 
-int vfsFileRead(const char *vfs_name,
+int VfsFileRead(const char *vfs_name,
 		const char *filename,
 		void **buf,
 		size_t *len)
@@ -1918,7 +1918,7 @@ err:
 	return rc;
 }
 
-int vfsFileWrite(const char *vfs_name,
+int VfsFileWrite(const char *vfs_name,
 		 const char *filename,
 		 const void *buf,
 		 size_t len)

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -157,13 +157,11 @@ struct content
 
 	struct shm *shm;       /* Shared memory (for db files). */
 	struct content *wal;   /* WAL file content (for db files). */
-	struct logger *logger; /* For error messages. */
 };
 
 /* Create the content structure for a new volatile file. */
 static struct content *content_create(const char *name,
-				      int type,
-				      struct logger *logger)
+				      int type)
 {
 	struct content *c;
 
@@ -175,8 +173,6 @@ static struct content *content_create(const char *name,
 	if (c == NULL) {
 		goto oom;
 	}
-
-	c->logger = logger;
 
 	// Copy the name, since when called from Go, the pointer will be freed.
 	c->filename = sqlite3_malloc(strlen(name) + 1);
@@ -1549,7 +1545,7 @@ static int vfs__open(sqlite3_vfs *vfs,
 			type = FORMAT__OTHER;
 		}
 
-		content = content_create(filename, type, root->logger);
+		content = content_create(filename, type);
 		if (content == NULL) {
 			root->error = ENOMEM;
 			rc = SQLITE_NOMEM;

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -10,19 +10,19 @@
  *
  * This function also automatically register the implementation in the global
  * SQLite registry, using the given @name. */
-int vfsInit(struct sqlite3_vfs *vfs, const char *name);
+int VfsInit(struct sqlite3_vfs *vfs, const char *name);
 
 /* Release all memory associated with the given dqlite in-memory VFS
  * implementation.
  *
  * This function also automatically unregister the implementation from the
  * SQLite global registry. */
-void vfsClose(struct sqlite3_vfs *vfs);
+void VfsClose(struct sqlite3_vfs *vfs);
 
 /* Read the content of a file, using the VFS implementation registered under the
  * given name. Used to take database snapshots using the dqlite in-memory
  * VFS. */
-int vfsFileRead(const char *vfs_name,
+int VfsFileRead(const char *vfs_name,
 		const char *filename,
 		void **buf,
 		size_t *len);
@@ -30,7 +30,7 @@ int vfsFileRead(const char *vfs_name,
 /* Write the content of a file, using the VFS implementation registered under
  * the given name. Used to restore database snapshots against the dqlite
  * in-memory VFS. If the file already exists, it's overwritten. */
-int vfsFileWrite(const char *vfs_name,
+int VfsFileWrite(const char *vfs_name,
 		 const char *filename,
 		 const void *buf,
 		 size_t len);

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -10,7 +10,7 @@
  *
  * This function also automatically register the implementation in the global
  * SQLite registry, using the given @name. */
-int vfsInit(struct sqlite3_vfs *vfs, struct config *config);
+int vfsInit(struct sqlite3_vfs *vfs, const char *name);
 
 /* Release all memory associated with the given dqlite in-memory VFS
  * implementation.

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -1,6 +1,8 @@
 #ifndef VFS_H_
 #define VFS_H_
 
+#include <sqlite3.h>
+
 #include "config.h"
 
 /* Initialize the given SQLite VFS interface with dqlite's in-memory

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -81,7 +81,7 @@ struct server
 		rc = config__init(&s->config, I + 1, address);             \
 		munit_assert_int(rc, ==, 0);                               \
                                                                            \
-		rc = vfsInit(&s->vfs, s->config.name);                     \
+		rc = VfsInit(&s->vfs, s->config.name);                     \
 		munit_assert_int(rc, ==, 0);                               \
                                                                            \
 		registry__init(&s->registry, &s->config);                  \
@@ -111,7 +111,7 @@ struct server
 		replication__close(&s->replication); \
 		fsm__close(fsm);                     \
 		registry__close(&s->registry);       \
-		vfsClose(&s->vfs);                   \
+		VfsClose(&s->vfs);                   \
 		config__close(&s->config);           \
 		test_logger_tear_down(&s->logger);   \
 	}

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -81,7 +81,7 @@ struct server
 		rc = config__init(&s->config, I + 1, address);             \
 		munit_assert_int(rc, ==, 0);                               \
                                                                            \
-		rc = vfsInit(&s->vfs, &s->config);                         \
+		rc = vfsInit(&s->vfs, s->config.name);                     \
 		munit_assert_int(rc, ==, 0);                               \
                                                                            \
 		registry__init(&s->registry, &s->config);                  \

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -1,18 +1,114 @@
-#include "munit.h"
+/* Convenience macros to reduce munit boiler plate. */
 
 #ifndef TEST_RUNNER_H
 #define TEST_RUNNER_H
 
-/* Top-level suites array.
+#include "munit.h"
+
+/* Top-level suites array declaration.
  *
- * These top-level suites will be set as child suites of a root suite created at
- * runtime by the test runner's main().
- */
+ * These top-level suites hold all module-level child suites and must be defined
+ * and then set as child suites of a root suite created at runtime by the test
+ * runner's main(). This can be done using the RUNNER macro. */
 extern MunitSuite _main_suites[];
 extern int _main_suites_n;
 
-/* Maximum number of child suites for or of test cases, for each suite */
-#define TEST__CAP 128
+/* Maximum number of test cases for each suite */
+#define SUITE__CAP 128
+#define TEST__CAP SUITE__CAP
+
+/* Define the top-level suites array and the main() function of the test. */
+#define RUNNER(NAME)                                               \
+    MunitSuite _main_suites[SUITE__CAP];                           \
+    int _main_suites_n = 0;                                        \
+                                                                   \
+    int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc + 1)])    \
+    {                                                              \
+        MunitSuite suite = {(char *)"", NULL, _main_suites, 1, 0}; \
+        return munit_suite_main(&suite, (void *)NAME, argc, argv); \
+    }
+
+/* Declare and register a new test suite #S belonging to the file's test module.
+ *
+ * A test suite is a pair of static variables:
+ *
+ * static MunitTest _##S##_suites[SUITE__CAP]
+ * static MunitTest _##S##_tests[SUITE__CAP]
+ *
+ * The tests and suites attributes of the next available MunitSuite slot in the
+ * _module_suites array will be set to the suite's tests and suites arrays, and
+ * the prefix attribute of the slot will be set to /S. */
+#define SUITE(S)      \
+    SUITE__DECLARE(S) \
+    SUITE__ADD_CHILD(main, #S, S)
+
+/* Declare and register a new test. */
+#define TEST(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)                \
+    static MunitResult test_##S##_##C(const MunitParameter params[], \
+                                      void *data);                   \
+    TEST__ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)      \
+    static MunitResult test_##S##_##C(                               \
+        MUNIT_UNUSED const MunitParameter params[], MUNIT_UNUSED void *data)
+
+#define SKIP_IF_NO_FIXTURE \
+    if (f == NULL) {       \
+        return MUNIT_SKIP; \
+    }
+
+/* Declare the MunitSuite[] and the MunitTest[] arrays that compose the test
+ * suite identified by S. */
+#define SUITE__DECLARE(S)                                      \
+    static MunitSuite _##S##_suites[SUITE__CAP];               \
+    static MunitTest _##S##_tests[SUITE__CAP];                 \
+    static MunitTestSetup _##S##_setup = NULL;                 \
+    static MunitTestTearDown _##S##_tear_down = NULL;          \
+    static int _##S##_suites_n = 0;                            \
+    static int _##S##_tests_n = 0;                             \
+    __attribute__((constructor)) static void _##S##_init(void) \
+    {                                                          \
+        memset(_##S##_suites, 0, sizeof(_##S##_suites));       \
+        memset(_##S##_tests, 0, sizeof(_##S##_tests));         \
+        (void)_##S##_suites_n;                                 \
+        (void)_##S##_tests_n;                                  \
+        (void)_##S##_setup;                                    \
+        (void)_##S##_tear_down;                                \
+    }
+
+/* Set the tests and suites attributes of the next available slot of the
+ * MunitSuite[] array of S1 to the MunitTest[] and MunitSuite[] arrays of S2,
+ * using the given PREXIX. */
+#define SUITE__ADD_CHILD(S1, PREFIX, S2)                               \
+    __attribute__((constructor)) static void _##S1##_##S2##_init(void) \
+    {                                                                  \
+        int n = _##S1##_suites_n;                                      \
+        _##S1##_suites[n].prefix = PREFIX;                             \
+        _##S1##_suites[n].tests = _##S2##_tests;                       \
+        _##S1##_suites[n].suites = _##S2##_suites;                     \
+        _##S1##_suites[n].iterations = 0;                              \
+        _##S1##_suites[n].options = 0;                                 \
+        _##S1##_suites_n = n + 1;                                      \
+    }
+
+/* Add a test case to the MunitTest[] array of suite S. */
+#define TEST__ADD_TO_SUITE(S, C, SETUP, TEAR_DOWN, OPTIONS, PARAMS)            \
+    __attribute__((constructor)) static void _##S##_tests_##C##_init(void)     \
+    {                                                                          \
+        MunitTest *tests = _##S##_tests;                                       \
+        int n = _##S##_tests_n;                                                \
+        TEST__SET_IN_ARRAY(tests, n, "/" #C, test_##S##_##C, SETUP, TEAR_DOWN, \
+                           OPTIONS, PARAMS);                                   \
+        _##S##_tests_n = n + 1;                                                \
+    }
+
+/* Set the values of the I'th test case slot in the given test array */
+#define TEST__SET_IN_ARRAY(TESTS, I, NAME, FUNC, SETUP, TEAR_DOWN, OPTIONS, \
+                           PARAMS)                                          \
+    TESTS[I].name = NAME;                                                   \
+    TESTS[I].test = FUNC;                                                   \
+    TESTS[I].setup = SETUP;                                                 \
+    TESTS[I].tear_down = TEAR_DOWN;                                         \
+    TESTS[I].options = OPTIONS;                                             \
+    TESTS[I].parameters = PARAMS
 
 /**
  * Declare and register a new test module #M.

--- a/test/lib/vfs.h
+++ b/test/lib/vfs.h
@@ -11,10 +11,10 @@
 #define SETUP_VFS                                       \
 	{                                               \
 		int rv_;                                \
-		rv_ = vfsInit(&f->vfs, f->config.name); \
+		rv_ = VfsInit(&f->vfs, f->config.name); \
 		munit_assert_int(rv_, ==, 0);           \
 	}
 
-#define TEAR_DOWN_VFS vfsClose(&f->vfs);
+#define TEAR_DOWN_VFS VfsClose(&f->vfs);
 
 #endif /* TEST_VFS_H */

--- a/test/lib/vfs.h
+++ b/test/lib/vfs.h
@@ -8,11 +8,11 @@
 #include "../../src/vfs.h"
 
 #define FIXTURE_VFS struct sqlite3_vfs vfs;
-#define SETUP_VFS                                   \
-	{                                           \
-		int rv_;                            \
-		rv_ = vfsInit(&f->vfs, &f->config); \
-		munit_assert_int(rv_, ==, 0);       \
+#define SETUP_VFS                                       \
+	{                                               \
+		int rv_;                                \
+		rv_ = vfsInit(&f->vfs, f->config.name); \
+		munit_assert_int(rv_, ==, 0);           \
 	}
 
 #define TEAR_DOWN_VFS vfsClose(&f->vfs);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -1,11 +1,3 @@
-#include "../lib/munit.h"
+#include "../lib/runner.h"
 
-MunitSuite _main_suites[64];
-int _main_suites_n = 0;
-
-/* Test runner executable */
-int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc + 1)])
-{
-	MunitSuite suite = {(char *)"", NULL, _main_suites, 1, 0};
-	return munit_suite_main(&suite, (void *)"µnit", argc, argv);
-}
+RUNNER("unit");

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -31,7 +31,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
 	int rv;
 	SETUP_HEAP;
 	SETUP_SQLITE;
-	rv = vfsInit(&f->vfs, "dqlite");
+	rv = VfsInit(&f->vfs, "dqlite");
 	munit_assert_int(rv, ==, 0);
 	return f;
 }
@@ -39,7 +39,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
 static void tearDown(void *data)
 {
 	struct fixture *f = data;
-	vfsClose(&f->vfs);
+	VfsClose(&f->vfs);
 	TEAR_DOWN_SQLITE;
 	TEAR_DOWN_HEAP;
 	free(f);
@@ -1710,7 +1710,7 @@ TEST(VfsSleep, success, setUp, tearDown, 0, NULL)
 
 /******************************************************************************
  *
- * vfsInit
+ * VfsInit
  *
  ******************************************************************************/
 
@@ -1735,7 +1735,7 @@ TEST(VfsInit, oom, setUp, tearDown, 0, test_create_oom_params)
 
 	test_heap_fault_enable();
 
-	rv = vfsInit(&vfs, "dqlite");
+	rv = VfsInit(&vfs, "dqlite");
 	munit_assert_int(rv, ==, DQLITE_NOMEM);
 
 	return MUNIT_OK;
@@ -2009,7 +2009,7 @@ TEST(VfsFileRead, cantOpen, setUp, tearDown, 0, NULL)
 	size_t len;
 	int rv;
 	(void)params;
-	rv = vfsFileRead(f->vfs.zName, "test.db", &buf, &len);
+	rv = VfsFileRead(f->vfs.zName, "test.db", &buf, &len);
 	munit_assert_int(rv, ==, SQLITE_CANTOPEN);
 	return MUNIT_OK;
 }
@@ -2029,7 +2029,7 @@ TEST(VfsFileRead, empty, setUp, tearDown, 0, NULL)
 	rv = sqlite3_open_v2("test.db", &db, flags, f->vfs.zName);
 	munit_assert_int(rv, ==, SQLITE_OK);
 
-	rv = vfsFileRead(f->vfs.zName, "test.db", &buf, &len);
+	rv = VfsFileRead(f->vfs.zName, "test.db", &buf, &len);
 	munit_assert_int(rv, ==, SQLITE_OK);
 
 	munit_assert_ptr_null(buf);
@@ -2058,13 +2058,13 @@ TEST(VfsFileRead, thenWrite, setUp, tearDown, 0, NULL)
 
 	__db_exec(db, "CREATE TABLE test (n INT)");
 
-	rc = vfsFileRead(f->vfs.zName, "test.db", &buf1, &len1);
+	rc = VfsFileRead(f->vfs.zName, "test.db", &buf1, &len1);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
 	munit_assert_ptr_not_equal(buf1, NULL);
 	munit_assert_int(len1, ==, 512);
 
-	rc = vfsFileRead(f->vfs.zName, "test.db-wal", &buf2, &len2);
+	rc = VfsFileRead(f->vfs.zName, "test.db-wal", &buf2, &len2);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
 	munit_assert_ptr_not_equal(buf2, NULL);
@@ -2073,10 +2073,10 @@ TEST(VfsFileRead, thenWrite, setUp, tearDown, 0, NULL)
 	rc = sqlite3_close(db);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
-	rc = vfsFileWrite(f->vfs.zName, "test.db", buf1, len1);
+	rc = VfsFileWrite(f->vfs.zName, "test.db", buf1, len1);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
-	rc = vfsFileWrite(f->vfs.zName, "test.db-wal", buf2, len2);
+	rc = VfsFileWrite(f->vfs.zName, "test.db-wal", buf2, len2);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
 	raft_free(buf1);
@@ -2122,7 +2122,7 @@ TEST(VfsFileRead, oom, setUp, tearDown, 0, file_read_oom_params)
 
 	test_heap_fault_enable();
 
-	rc = vfsFileRead(f->vfs.zName, "test.db", &buf, &len);
+	rc = VfsFileRead(f->vfs.zName, "test.db", &buf, &len);
 	munit_assert_int(rc, ==, SQLITE_NOMEM);
 
 	rc = sqlite3_close(db);

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -22,7 +22,6 @@
 
 struct fixture
 {
-	FIXTURE_CONFIG;
 	struct sqlite3_vfs vfs;
 };
 
@@ -32,8 +31,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
 	int rv;
 	SETUP_HEAP;
 	SETUP_SQLITE;
-	SETUP_CONFIG;
-	rv = vfsInit(&f->vfs, &f->config);
+	rv = vfsInit(&f->vfs, "dqlite");
 	munit_assert_int(rv, ==, 0);
 	return f;
 }
@@ -42,7 +40,6 @@ static void tearDown(void *data)
 {
 	struct fixture *f = data;
 	vfsClose(&f->vfs);
-	TEAR_DOWN_CONFIG;
 	TEAR_DOWN_SQLITE;
 	TEAR_DOWN_HEAP;
 	free(f);
@@ -165,7 +162,7 @@ static sqlite3 *__db_open()
 	int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
 	int rc;
 
-	rc = sqlite3_open_v2("test.db", &db, flags, "dqlite-1");
+	rc = sqlite3_open_v2("test.db", &db, flags, "dqlite");
 	munit_assert_int(rc, ==, SQLITE_OK);
 
 	__db_exec(db, "PRAGMA page_size=512");
@@ -1730,7 +1727,6 @@ static MunitParameterEnum test_create_oom_params[] = {
 
 TEST(VfsInit, oom, setUp, tearDown, 0, test_create_oom_params)
 {
-	struct fixture *f = data;
 	struct sqlite3_vfs vfs;
 	int rv;
 
@@ -1739,7 +1735,7 @@ TEST(VfsInit, oom, setUp, tearDown, 0, test_create_oom_params)
 
 	test_heap_fault_enable();
 
-	rv = vfsInit(&vfs, &f->config);
+	rv = vfsInit(&vfs, "dqlite");
 	munit_assert_int(rv, ==, DQLITE_NOMEM);
 
 	return MUNIT_OK;

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -14,8 +14,6 @@
 #include "../../src/format.h"
 #include "../../src/vfs.h"
 
-TEST_MODULE(vfs);
-
 /******************************************************************************
  *
  * Fixture
@@ -28,7 +26,7 @@ struct fixture
 	struct sqlite3_vfs vfs;
 };
 
-static void *setup(const MunitParameter params[], void *user_data)
+static void *setUp(const MunitParameter params[], void *user_data)
 {
 	struct fixture *f = munit_malloc(sizeof *f);
 	int rv;
@@ -40,7 +38,7 @@ static void *setup(const MunitParameter params[], void *user_data)
 	return f;
 }
 
-static void tear_down(void *data)
+static void tearDown(void *data)
 {
 	struct fixture *f = data;
 	vfsClose(&f->vfs);
@@ -261,13 +259,11 @@ static int __shm_shared_lock_held(sqlite3 *db, int i)
  *
  ******************************************************************************/
 
-TEST_SUITE(open);
-TEST_SETUP(open, setup);
-TEST_TEAR_DOWN(open, tear_down);
+SUITE(VfsOpen)
 
 /* If the EXCLUSIVE and CREATE flag are given, and the file already exists, an
  * error is returned. */
-TEST_CASE(open, exclusive, NULL)
+TEST(VfsOpen, exclusive, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -295,7 +291,7 @@ TEST_CASE(open, exclusive, NULL)
 
 /* It's possible to open again a previously created file. In that case passing
  * SQLITE_OPEN_CREATE is not necessary. */
-TEST_CASE(open, again, NULL)
+TEST(VfsOpen, again, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -325,7 +321,7 @@ TEST_CASE(open, again, NULL)
 
 /* If the file does not exist and the SQLITE_OPEN_CREATE flag is not passed, an
  * error is returned. */
-TEST_CASE(open, noent, NULL)
+TEST(VfsOpen, noent, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -346,7 +342,7 @@ TEST_CASE(open, noent, NULL)
 }
 
 /* There's an hard-coded limit for the number of files that can be opened. */
-TEST_CASE(open, enfile, NULL)
+TEST(VfsOpen, entfile, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -378,7 +374,7 @@ TEST_CASE(open, enfile, NULL)
 
 /* Trying to open a WAL file before its main database file results in an
  * error. */
-TEST_CASE(open, wal_before_db, NULL)
+TEST(VfsOpen, walBeforeDb, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -400,7 +396,7 @@ TEST_CASE(open, wal_before_db, NULL)
 
 /* Trying to run queries against a database that hasn't turned off the
  * synchronous flag results in an error. */
-TEST_CASE(open, synchronous, NULL)
+TEST(VfsOpen, synchronous, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3 *db;
@@ -431,7 +427,7 @@ TEST_CASE(open, synchronous, NULL)
 }
 
 /* If no page size is set explicitely, the default one is used. */
-TEST_CASE(open, no_page_size, NULL)
+TEST(VfsOpen, noPageSize, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3 *db;
@@ -478,7 +474,7 @@ TEST_CASE(open, no_page_size, NULL)
 }
 
 /* Out of memory when creating the content structure for a new file. */
-TEST_CASE(open, oom, NULL)
+TEST(VfsOpen, oom, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -499,7 +495,7 @@ TEST_CASE(open, oom, NULL)
 }
 
 /* Out of memory when internally copying the filename. */
-TEST_CASE(open, oom_filename, NULL)
+TEST(VfsOpen, oomFilename, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -520,7 +516,7 @@ TEST_CASE(open, oom_filename, NULL)
 }
 
 /* Out of memory when creating the WAL file header. */
-TEST_CASE(open, oom_wal, NULL)
+TEST(VfsOpen, oomWal, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -541,7 +537,7 @@ TEST_CASE(open, oom_wal, NULL)
 }
 
 /* Open a temporary file. */
-TEST_CASE(open, tmp, NULL)
+TEST(VfsOpen, tmp, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -582,12 +578,10 @@ TEST_CASE(open, tmp, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(delete);
-TEST_SETUP(delete, setup);
-TEST_TEAR_DOWN(delete, tear_down);
+SUITE(VfsDelete)
 
 /* Delete a file. */
-TEST_CASE(delete, success, NULL)
+TEST(VfsDelete, success, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -617,7 +611,7 @@ TEST_CASE(delete, success, NULL)
 }
 
 /* Attempt to delete a file with open file descriptors. */
-TEST_CASE(delete, busy, NULL)
+TEST(VfsDelete, busy, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -643,7 +637,7 @@ TEST_CASE(delete, busy, NULL)
 }
 
 /* Trying to delete a non-existing file results in an error. */
-TEST_CASE(delete, enoent, NULL)
+TEST(VfsDelete, enoent, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 
@@ -664,12 +658,10 @@ TEST_CASE(delete, enoent, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(access);
-TEST_SETUP(access, setup);
-TEST_TEAR_DOWN(access, tear_down);
+SUITE(VfsAccess)
 
 /* Accessing an existing file returns true. */
-TEST_CASE(access, success, NULL)
+TEST(VfsAccess, success, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -698,7 +690,7 @@ TEST_CASE(access, success, NULL)
 }
 
 /* Trying to access a non existing file returns false. */
-TEST_CASE(access, noent, NULL)
+TEST(VfsAccess, noent, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 
@@ -721,12 +713,10 @@ TEST_CASE(access, noent, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(full_path_name);
-TEST_SETUP(full_path_name, setup);
-TEST_TEAR_DOWN(full_path_name, tear_down);
+SUITE(VfsFullPathname);
 
 /* The xFullPathname API returns the filename unchanged. */
-TEST_CASE(full_path_name, success, NULL)
+TEST(VfsFullPathname, success, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 
@@ -749,12 +739,10 @@ TEST_CASE(full_path_name, success, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(close);
-TEST_SETUP(close, setup);
-TEST_TEAR_DOWN(close, tear_down);
+SUITE(VfsClose)
 
 /* Closing a file decreases its refcount so it's possible to delete it. */
-TEST_CASE(close, then_delete, NULL)
+TEST(VfsClose, thenDelete, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -784,12 +772,10 @@ TEST_CASE(close, then_delete, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(read);
-TEST_SETUP(read, setup);
-TEST_TEAR_DOWN(read, tear_down);
+SUITE(VfsRead)
 
 /* Trying to read a file that was not written yet, results in an error. */
-TEST_CASE(read, never_written, NULL)
+TEST(VfsRead, neverWritten, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -816,12 +802,10 @@ TEST_CASE(read, never_written, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(write);
-TEST_SETUP(write, setup);
-TEST_TEAR_DOWN(write, tear_down);
+SUITE(VfsWrite)
 
 /* Write the header of the database file. */
-TEST_CASE(write, db_header, NULL)
+TEST(VfsWrite, dbHeader, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -843,7 +827,7 @@ TEST_CASE(write, db_header, NULL)
 
 /* Write the header of the database file, then the full first page and a second
  * page. */
-TEST_CASE(write, and_read_db_pages, NULL)
+TEST(VfsWrite, andReadPages, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -898,7 +882,7 @@ TEST_CASE(write, and_read_db_pages, NULL)
 }
 
 /* Write the header of a WAL file, then two frames. */
-TEST_CASE(write, and_read_wal_frames, NULL)
+TEST(VfsWrite, andReadWalFrames, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file1 = __file_create_main_db(&f->vfs);
@@ -977,7 +961,7 @@ TEST_CASE(write, and_read_wal_frames, NULL)
 }
 
 /* Out of memory when trying to create a new page. */
-TEST_CASE(write, oom_page, NULL)
+TEST(VfsWrite, oomPage, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1004,7 +988,7 @@ TEST_CASE(write, oom_page, NULL)
 
 /* Out of memory when trying to append a new page to the internal page array of
  * the content object. */
-TEST_CASE(write, oom_page_array, NULL)
+TEST(VfsWrite, oomPageArray, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1030,7 +1014,7 @@ TEST_CASE(write, oom_page_array, NULL)
 }
 
 /* Out of memory when trying to create the content buffer of a new page. */
-TEST_CASE(write, oom_page_buf, NULL)
+TEST(VfsWrite, oomPageBuf, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1056,7 +1040,7 @@ TEST_CASE(write, oom_page_buf, NULL)
 }
 
 /* Out of memory when trying to create the header buffer of a new WAL page. */
-TEST_CASE(write, oom_page_hdr, NULL)
+TEST(VfsWrite, oomPageHdr, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file1 = __file_create_main_db(&f->vfs);
@@ -1098,7 +1082,7 @@ TEST_CASE(write, oom_page_hdr, NULL)
 
 /* Trying to write the second page without writing the first results in an
  * error. */
-TEST_CASE(write, beyond_first, NULL)
+TEST(VfsWrite, beyondFirst, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1121,7 +1105,7 @@ TEST_CASE(write, beyond_first, NULL)
 }
 
 /* Trying to write two pages beyond the last one results in an error. */
-TEST_CASE(write, beyond_last, NULL)
+TEST(VfsWrite, beyondLast, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1155,12 +1139,10 @@ TEST_CASE(write, beyond_last, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(truncate);
-TEST_SETUP(truncate, setup);
-TEST_TEAR_DOWN(truncate, tear_down);
+SUITE(VfsTruncate);
 
 /* Truncate the main database file. */
-TEST_CASE(truncate, database, NULL)
+TEST(VfsTruncate, database, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1226,7 +1208,7 @@ TEST_CASE(truncate, database, NULL)
 }
 
 /* Truncate the WAL file. */
-TEST_CASE(truncate, wal, NULL)
+TEST(VfsTruncate, wal, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file1 = __file_create_main_db(&f->vfs);
@@ -1312,7 +1294,7 @@ TEST_CASE(truncate, wal, NULL)
 
 /* Truncating a file which is not the main db file or the WAL file produces an
  * error. */
-TEST_CASE(truncate, unexpected, NULL)
+TEST(VfsTruncate, unexpected, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -1340,7 +1322,7 @@ TEST_CASE(truncate, unexpected, NULL)
 }
 
 /* Truncating an empty file is a no-op. */
-TEST_CASE(truncate, empty, NULL)
+TEST(VfsTruncate, empty, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1364,7 +1346,7 @@ TEST_CASE(truncate, empty, NULL)
 }
 
 /* Trying to grow an empty file produces an error. */
-TEST_CASE(truncate, empty_grow, NULL)
+TEST(VfsTruncate, emptyGrow, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1383,7 +1365,7 @@ TEST_CASE(truncate, empty_grow, NULL)
 
 /* Trying to truncate a main database file to a size which is not a multiple of
  * the page size produces an error. */
-TEST_CASE(truncate, misaligned, NULL)
+TEST(VfsTruncate, misaligned, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1413,9 +1395,7 @@ TEST_CASE(truncate, misaligned, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(shm_map);
-TEST_SETUP(shm_map, setup);
-TEST_TEAR_DOWN(shm_map, tear_down);
+SUITE(VfsShmMap);
 
 static char *test_shm_map_oom_delay[] = {"0", "1", "2", NULL};
 static char *test_shm_map_oom_repeat[] = {"1", NULL};
@@ -1427,7 +1407,7 @@ static MunitParameterEnum test_shm_map_oom_params[] = {
 };
 
 /* Out of memory when trying to initialize the internal VFS shm data struct. */
-TEST_CASE(shm_map, oom, test_shm_map_oom_params)
+TEST(VfsShmMap, oom, setUp, tearDown, 0, test_shm_map_oom_params)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1453,13 +1433,11 @@ TEST_CASE(shm_map, oom, test_shm_map_oom_params)
  *
  ******************************************************************************/
 
-TEST_SUITE(shm_lock);
-TEST_SETUP(shm_lock, setup);
-TEST_TEAR_DOWN(shm_lock, tear_down);
+SUITE(VfsShmLock)
 
 /* If an exclusive lock is in place, getting a shared lock on any index of its
  * range fails. */
-TEST_CASE(shm_lock, shared_busy, NULL)
+TEST(VfsShmLock, sharedBusy, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -1493,7 +1471,7 @@ TEST_CASE(shm_lock, shared_busy, NULL)
 
 /* If a shared lock is in place on any of the indexes of the requested range,
  * getting an exclusive lock fails. */
-TEST_CASE(shm_lock, excl_busy, NULL)
+TEST(VfsShmLock, exclBusy, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -1528,7 +1506,7 @@ TEST_CASE(shm_lock, excl_busy, NULL)
 
 /* The native unix VFS implementation from SQLite allows to release a shared
  * memory lock without acquiring it first. */
-TEST_CASE(shm_lock, release_unix, NULL)
+TEST(VfsShmLock, releaseUnix, setUp, tearDown, 0, NULL)
 {
 	(void)data;
 	struct sqlite3_vfs *vfs = sqlite3_vfs_find("unix");
@@ -1583,7 +1561,7 @@ TEST_CASE(shm_lock, release_unix, NULL)
 /* The dqlite VFS implementation allows to release a shared memory lock without
  * acquiring it first. This is important because at open time sometimes SQLite
  * will do just that (release before acquire). */
-TEST_CASE(shm_lock, release, NULL)
+TEST(VfsShmLock, release, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
@@ -1625,13 +1603,11 @@ TEST_CASE(shm_lock, release, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(file_control);
-TEST_SETUP(file_control, setup);
-TEST_TEAR_DOWN(file_control, tear_down);
+SUITE(VfsFileControl)
 
 /* Trying to set the page size to a value different than the current one
  * produces an error. */
-TEST_CASE(file_control, page_size, NULL)
+TEST(VfsFileControl, pageSize, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1663,7 +1639,7 @@ TEST_CASE(file_control, page_size, NULL)
 
 /* Trying to set the journal mode to anything other than "wal" produces an
  * error. */
-TEST_CASE(file_control, journal, NULL)
+TEST(VfsFileControl, journal, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3_file *file = __file_create_main_db(&f->vfs);
@@ -1694,11 +1670,9 @@ TEST_CASE(file_control, journal, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(current_time);
-TEST_SETUP(current_time, setup);
-TEST_TEAR_DOWN(current_time, tear_down);
+SUITE(VfsCurrentTime)
 
-TEST_CASE(current_time, success, NULL)
+TEST(VfsCurrentTime, success, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	double now;
@@ -1720,12 +1694,10 @@ TEST_CASE(current_time, success, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(sleep);
-TEST_SETUP(sleep, setup);
-TEST_TEAR_DOWN(sleep, tear_down);
+SUITE(VfsSleep)
 
 /* The xSleep implementation is a no-op. */
-TEST_CASE(sleep, success, NULL)
+TEST(VfsSleep, success, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	int microseconds;
@@ -1745,9 +1717,7 @@ TEST_CASE(sleep, success, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(create);
-TEST_SETUP(create, setup);
-TEST_TEAR_DOWN(create, tear_down);
+SUITE(VfsInit);
 
 static char *test_create_oom_delay[] = {"0", "1", NULL};
 static char *test_create_oom_repeat[] = {"1", NULL};
@@ -1758,7 +1728,7 @@ static MunitParameterEnum test_create_oom_params[] = {
     {NULL, NULL},
 };
 
-TEST_CASE(create, oom, test_create_oom_params)
+TEST(VfsInit, oom, setUp, tearDown, 0, test_create_oom_params)
 {
 	struct fixture *f = data;
 	struct sqlite3_vfs vfs;
@@ -1781,13 +1751,11 @@ TEST_CASE(create, oom, test_create_oom_params)
  *
  ******************************************************************************/
 
-TEST_SUITE(integration);
-TEST_SETUP(integration, setup);
-TEST_TEAR_DOWN(integration, tear_down);
+SUITE(VfsIntegration)
 
 /* Integration test, registering an in-memory VFS and performing various
  * database operations. */
-TEST_CASE(integration, db, NULL)
+TEST(VfsIntegration, db, setUp, tearDown, 0, NULL)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -1834,7 +1802,7 @@ TEST_CASE(integration, db, NULL)
 }
 
 /* Test our expections on the memory-mapped WAl index format. */
-TEST_CASE(integration, wal, NULL)
+TEST(VfsIntegration, wal, setUp, tearDown, 0, NULL)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -1935,7 +1903,7 @@ TEST_CASE(integration, wal, NULL)
 }
 
 /* Full checkpoints are possible only when no read mark is set. */
-TEST_CASE(integration, checkpoint, NULL)
+TEST(VfsIntegration, checkpoint, setUp, tearDown, 0, NULL)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -2035,12 +2003,10 @@ TEST_CASE(integration, checkpoint, NULL)
  *
  ******************************************************************************/
 
-TEST_SUITE(file_read);
-TEST_SETUP(file_read, setup);
-TEST_TEAR_DOWN(file_read, tear_down);
+SUITE(VfsFileRead);
 
 /* If the file being read does not exists, an error is returned. */
-TEST_CASE(file_read, cantopen, NULL)
+TEST(VfsFileRead, cantOpen, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	void *buf;
@@ -2053,7 +2019,7 @@ TEST_CASE(file_read, cantopen, NULL)
 }
 
 /* Read the content of an empty file. */
-TEST_CASE(file_read, empty, NULL)
+TEST(VfsFileRead, empty, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3 *db;
@@ -2080,7 +2046,7 @@ TEST_CASE(file_read, empty, NULL)
 }
 
 /* Read the content of a database and WAL files and then write them back. */
-TEST_CASE(file_read, then_write, NULL)
+TEST(VfsFileRead, thenWrite, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	sqlite3 *db = __db_open();
@@ -2146,7 +2112,7 @@ static MunitParameterEnum file_read_oom_params[] = {
 };
 
 /* Test out of memory scenarios. */
-TEST_CASE(file_read, oom, file_read_oom_params)
+TEST(VfsFileRead, oom, setUp, tearDown, 0, file_read_oom_params)
 {
 	struct fixture *f = data;
 	sqlite3 *db = __db_open();


### PR DESCRIPTION
This is a mechanical rename of all symbols in vfs.c to contain a `vfs` prefix for internal symbols and `Vfs` for exported ones. There is no logic change.

Since the resulting names tend to be longer, CamelCase has been used to shorten then. The same convention has been used in libraft to avoid collisions between symbols across files and allow for single-file amalgamation of the whole source.

Tests macros have also been updated to simplify the test hierarchy a bit.