### PR TITLE
fix(command): check for uint64 parse error

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -152,7 +152,8 @@ int command_frames__page_numbers(const struct command_frames *c,
 
 	for (i = 0; i < c->frames.n_pages; i++) {
 		uint64_t pgno;
-		uint64__decode(&cursor, &pgno);
+		int r = uint64__decode(&cursor, &pgno);
+		if (r != 0) return r;
 		(*page_numbers)[i] = pgno;
 	}
 


### PR DESCRIPTION
This adds a check for the result of the parse function.
Without this check, pgno could be used while uninitialized and
compiliation with -Wmaybe-uninitialized issues a warning like so:

```
src/command.c: In function 'command_frames__page_numbers':
src/command.c:156:22: warning: 'pgno' may be used uninitialized in this function [-Wmaybe-uninitialized]
  156 |   (*page_numbers)[i] = pgno;
      |   ~~~~~~~~~~~~~~~~~~~^~~~~~
```