### PR TITLE
Separate database and write-ahead-log logic in the custom VFS

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -140,7 +140,12 @@ static void vfsShmClose(struct vfsShm *s)
 	if (s->regions != NULL) {
 		sqlite3_free(s->regions);
 	}
+}
 
+/* Revert the shared mamory to its initial state. */
+static void vfsShmReset(struct vfsShm *s)
+{
+	vfsShmClose(s);
 	vfsShmInit(s);
 }
 
@@ -706,10 +711,9 @@ static int vfsFileClose(sqlite3_file *file)
 	assert(f->content->refcount);
 	f->content->refcount--;
 
-	/* If we got zero references, free the shared memory mapping, if
-	 * present. */
+	/* If we got zero references, reset the shared memory mapping. */
 	if (f->content->refcount == 0 && f->content->type == VFS__DATABASE) {
-		vfsShmClose(&f->content->database.shm);
+		vfsShmReset(&f->content->database.shm);
 	}
 
 	if (f->flags & SQLITE_OPEN_DELETEONCLOSE) {

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -415,7 +415,7 @@ struct vfsFile
 struct vfs
 {
 	struct vfsContent **contents; /* Files content */
-	int contents_len;             /* Number of files */
+	unsigned n_contents;          /* Number of files */
 	int error;                    /* Last error occurred. */
 };
 
@@ -430,9 +430,9 @@ static struct vfs *vfsCreate()
 		goto oom;
 	}
 
-	v->contents_len = VFS__MAX_FILES;
+	v->n_contents = VFS__MAX_FILES;
 
-	contents_size = v->contents_len * sizeof *v->contents;
+	contents_size = v->n_contents * sizeof *v->contents;
 
 	v->contents = sqlite3_malloc(contents_size);
 	if (v->contents == NULL) {
@@ -458,7 +458,7 @@ oom:
 static void vfsDestroy(struct vfs *r)
 {
 	struct vfsContent **cursor; /* Iterator for r->contents */
-	int i;
+	unsigned i;
 
 	assert(r != NULL);
 	assert(r->contents != NULL);
@@ -467,9 +467,9 @@ static void vfsDestroy(struct vfs *r)
 
 	/* The content array has been allocated and has at least one slot. */
 	assert(cursor != NULL);
-	assert(r->contents_len > 0);
+	assert(r->n_contents > 0);
 
-	for (i = 0; i < r->contents_len; i++) {
+	for (i = 0; i < r->n_contents; i++) {
 		struct vfsContent *content = *cursor;
 		if (content != NULL) {
 			vfsContentDestroy(content);
@@ -492,7 +492,7 @@ static int vfsContentLookup(
 )
 {
 	struct vfsContent **cursor; /* Iterator for r->contents */
-	int i;
+	unsigned i;
 
 	/* Index of the content or of a free slot in the contents array. */
 	int free_slot = -1;
@@ -504,9 +504,9 @@ static int vfsContentLookup(
 
 	// The content array has been allocated and has at least one slot.
 	assert(cursor != NULL);
-	assert(r->contents_len > 0);
+	assert(r->n_contents > 0);
 
-	for (i = 0; i < r->contents_len; i++) {
+	for (i = 0; i < r->n_contents; i++) {
 		struct vfsContent *content = *cursor;
 		if (content && strcmp(content->filename, filename) == 0) {
 			// Found matching file.

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1101,6 +1101,7 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fnctl)
 	const char *right;
 
 	assert(f != NULL);
+	assert(f->content->type == VFS__DATABASE);
 	assert(fnctl != NULL);
 
 	left = fnctl[1];

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -144,6 +144,14 @@ static void vfsShmClose(struct vfsShm *s)
 	vfsShmInit(s);
 }
 
+/* Initialize a new database object. */
+static void vfsDatabaseInit(struct vfsDatabase *d)
+{
+	d->pages = NULL;
+	d->n_pages = 0;
+	vfsShmInit(&d->shm);
+}
+
 /* Create the content structure for a new volatile file. */
 static struct vfsContent *vfsContentCreate(const char *name, int type)
 {
@@ -169,12 +177,9 @@ static struct vfsContent *vfsContentCreate(const char *name, int type)
 	c->refcount = 0;
 	c->type = type;
 
-	// For WAL files, also allocate the WAL file header.
 	switch (type) {
 		case VFS__DATABASE:
-			vfsShmInit(&c->database.shm);
-			c->database.pages = NULL;
-			c->database.n_pages = 0;
+			vfsDatabaseInit(&c->database);
 			break;
 		case VFS__WAL:
 			memset(c->wal.hdr, 0, FORMAT__WAL_HDR_SIZE);

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -20,8 +20,8 @@
 /* Hold content for a single page or frame in a volatile file. */
 struct vfsPage
 {
+	uint8_t hdr[FORMAT__WAL_FRAME_HDR_SIZE];
 	void *buf; /* Content of the page. */
-	void *hdr; /* Page header (only for WAL pages). */
 };
 
 /* Create a new volatile page for a database or WAL file.
@@ -46,19 +46,10 @@ static struct vfsPage *vfsPageCreate(int size, int wal)
 	memset(p->buf, 0, size);
 
 	if (wal) {
-		p->hdr = sqlite3_malloc(FORMAT__WAL_FRAME_HDR_SIZE);
-		if (p->hdr == NULL) {
-			goto oom_after_buf_malloc;
-		}
 		memset(p->hdr, 0, FORMAT__WAL_FRAME_HDR_SIZE);
-	} else {
-		p->hdr = NULL;
 	}
 
 	return p;
-
-oom_after_buf_malloc:
-	sqlite3_free(p->buf);
 
 oom_after_page_alloc:
 	sqlite3_free(p);
@@ -74,10 +65,6 @@ static void vfsPageDestroy(struct vfsPage *p)
 	assert(p->buf != NULL);
 
 	sqlite3_free(p->buf);
-
-	if (p->hdr != NULL) {
-		sqlite3_free(p->hdr);
-	}
 
 	sqlite3_free(p);
 }

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -152,6 +152,14 @@ static void vfsDatabaseInit(struct vfsDatabase *d)
 	vfsShmInit(&d->shm);
 }
 
+/* Initialize a new WAL object. */
+static void vfsWalInit(struct vfsWal *w)
+{
+	memset(w->hdr, 0, FORMAT__WAL_HDR_SIZE);
+	w->frames = NULL;
+	w->n_frames = 0;
+}
+
 /* Create the content structure for a new volatile file. */
 static struct vfsContent *vfsContentCreate(const char *name, int type)
 {
@@ -182,9 +190,7 @@ static struct vfsContent *vfsContentCreate(const char *name, int type)
 			vfsDatabaseInit(&c->database);
 			break;
 		case VFS__WAL:
-			memset(c->wal.hdr, 0, FORMAT__WAL_HDR_SIZE);
-			c->wal.frames = NULL;
-			c->wal.n_frames = 0;
+			vfsWalInit(&c->wal);
 			break;
 	}
 
@@ -192,7 +198,6 @@ static struct vfsContent *vfsContentCreate(const char *name, int type)
 
 oom_after_content_malloc:
 	sqlite3_free(c);
-
 oom:
 	return NULL;
 }

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -119,16 +119,15 @@ enum vfsContentType {
 struct vfsContent
 {
 	char *filename;           /* Name of the file. */
+	enum vfsContentType type; /* Content type (either main db or WAL). */
 	unsigned page_size;       /* Page size of each page. */
 	unsigned refcount;        /* N. of files referencing this content. */
-	enum vfsContentType type; /* Content type (either main db or WAL). */
 	union {
 		struct /* VFS__DATABASE */
 		{
 			void **pages;      /* All pages in the file. */
 			unsigned n_pages;  /* Number of pages in the file. */
 			struct vfsShm shm; /* Shared memory. */
-			struct vfsContent *wal; /* WAL content. */
 		};
 		struct /* VFS__WAL */
 		{
@@ -170,7 +169,6 @@ static struct vfsContent *vfsContentCreate(const char *name, int type)
 			vfsShmInit(&c->shm);
 			c->pages = NULL;
 			c->n_pages = 0;
-			c->wal = NULL;
 			break;
 		case VFS__WAL:
 			memset(c->hdr, 0, FORMAT__WAL_HDR_SIZE);
@@ -1575,7 +1573,6 @@ static int vfsOpen(sqlite3_vfs *vfs,
 				v->error = ENOMEM;
 				goto err_after_vfs_content_create;
 			}
-			database->wal = content;
 		}
 
 		v->contents[n - 1] = content;

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -149,17 +149,15 @@ enum vfsContentType {
 /* Hold content for a single file in the volatile file system. */
 struct vfsContent
 {
-	char *filename;         /* Name of the file. */
-	void *hdr;              /* File header (for WAL files). */
-	struct vfsPage **pages; /* All pages in the file. */
-	int pages_len;          /* Number of pages in the file. */
-	unsigned int page_size; /* Page size of each page. */
-
-	int refcount;             /* N. of files referencing this content. */
+	char *filename;           /* Name of the file. */
+	void *hdr;                /* File header (for WAL files). */
+	struct vfsPage **pages;   /* All pages in the file. */
+	int pages_len;            /* Number of pages in the file. */
+	unsigned int page_size;   /* Page size of each page. */
+	unsigned refcount;        /* N. of files referencing this content. */
 	enum vfsContentType type; /* Content type (either main db or WAL). */
-
-	struct vfsShm *shm;     /* Shared memory (for db files). */
-	struct vfsContent *wal; /* WAL file content (for db files). */
+	struct vfsShm *shm;       /* Shared memory (for db files). */
+	struct vfsContent *wal;   /* WAL file content (for db files). */
 };
 
 /* Create the content structure for a new volatile file. */

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -481,27 +481,6 @@ TEST(VfsOpen, oomFilename, setUp, tearDown, 0, NULL)
 	return MUNIT_OK;
 }
 
-/* Out of memory when creating the WAL file header. */
-TEST(VfsOpen, oomWal, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
-	int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_WAL;
-	int rc;
-
-	(void)params;
-
-	test_heap_fault_config(2, 1);
-	test_heap_fault_enable();
-
-	rc = f->vfs.xOpen(&f->vfs, "test.db-wal", file, flags, &flags);
-	munit_assert_int(rc, ==, SQLITE_NOMEM);
-
-	free(file);
-
-	return MUNIT_OK;
-}
-
 /* Open a temporary file. */
 TEST(VfsOpen, tmp, setUp, tearDown, 0, NULL)
 {

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -338,37 +338,6 @@ TEST(VfsOpen, noent, setUp, tearDown, 0, NULL)
 	return MUNIT_OK;
 }
 
-/* There's an hard-coded limit for the number of files that can be opened. */
-TEST(VfsOpen, entfile, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
-
-	int flags;
-	int rc;
-	int i;
-	char name[20];
-
-	(void)params;
-
-	flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
-
-	for (i = 0; i < 64; i++) {
-		sprintf(name, "test-%d.db", i);
-		rc = f->vfs.xOpen(&f->vfs, name, file, flags, &flags);
-		munit_assert_int(rc, ==, 0);
-	}
-
-	rc = f->vfs.xOpen(&f->vfs, "test-64.db", file, flags, &flags);
-
-	munit_assert_int(rc, ==, SQLITE_CANTOPEN);
-	munit_assert_int(ENFILE, ==, f->vfs.xGetLastError(&f->vfs, 0, 0));
-
-	free(file);
-
-	return MUNIT_OK;
-}
-
 /* Trying to open a WAL file before its main database file results in an
  * error. */
 TEST(VfsOpen, walBeforeDb, setUp, tearDown, 0, NULL)
@@ -484,7 +453,7 @@ TEST(VfsOpen, oom, setUp, tearDown, 0, NULL)
 	test_heap_fault_enable();
 
 	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
-	munit_assert_int(rc, ==, SQLITE_NOMEM);
+	munit_assert_int(rc, ==, SQLITE_CANTOPEN);
 
 	free(file);
 
@@ -1716,7 +1685,7 @@ TEST(VfsSleep, success, setUp, tearDown, 0, NULL)
 
 SUITE(VfsInit);
 
-static char *test_create_oom_delay[] = {"0", "1", NULL};
+static char *test_create_oom_delay[] = {"0", NULL};
 static char *test_create_oom_repeat[] = {"1", NULL};
 
 static MunitParameterEnum test_create_oom_params[] = {

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -552,12 +552,12 @@ TEST(VfsDelete, success, setUp, tearDown, 0, NULL)
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
 
-	int flags;
+	int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
 	int rc;
 
 	(void)params;
 
-	rc = f->vfs.xOpen(&f->vfs, "test.db", file, SQLITE_OPEN_CREATE, &flags);
+	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 	munit_assert_int(rc, ==, 0);
 
 	rc = file->pMethods->xClose(file);
@@ -582,12 +582,12 @@ TEST(VfsDelete, busy, setUp, tearDown, 0, NULL)
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
 
-	int flags;
+	int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
 	int rc;
 
 	(void)params;
 
-	rc = f->vfs.xOpen(&f->vfs, "test.db", file, SQLITE_OPEN_CREATE, &flags);
+	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 	munit_assert_int(rc, ==, 0);
 
 	rc = f->vfs.xDelete(&f->vfs, "test.db", 0);
@@ -632,13 +632,13 @@ TEST(VfsAccess, success, setUp, tearDown, 0, NULL)
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
 
-	int flags;
+	int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
 	int rc;
 	int exists;
 
 	(void)params;
 
-	rc = f->vfs.xOpen(&f->vfs, "test.db", file, SQLITE_OPEN_CREATE, &flags);
+	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 
 	munit_assert_int(rc, ==, 0);
 
@@ -713,12 +713,12 @@ TEST(VfsClose, thenDelete, setUp, tearDown, 0, NULL)
 	struct fixture *f = data;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
 
-	int flags;
+	int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
 	int rc;
 
 	(void)params;
 
-	rc = f->vfs.xOpen(&f->vfs, "test.db", file, SQLITE_OPEN_CREATE, &flags);
+	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 	munit_assert_int(rc, ==, 0);
 
 	rc = file->pMethods->xClose(file);

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1363,7 +1363,7 @@ TEST(VfsTruncate, misaligned, setUp, tearDown, 0, NULL)
 
 SUITE(VfsShmMap);
 
-static char *test_shm_map_oom_delay[] = {"0", "1", "2", NULL};
+static char *test_shm_map_oom_delay[] = {"0", "1", NULL};
 static char *test_shm_map_oom_repeat[] = {"1", NULL};
 
 static MunitParameterEnum test_shm_map_oom_params[] = {

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -962,7 +962,7 @@ TEST(VfsWrite, oomPageArray, setUp, tearDown, 0, NULL)
 	char buf[512];
 	int rc;
 
-	test_heap_fault_config(2, 1);
+	test_heap_fault_config(1, 1);
 	test_heap_fault_enable();
 
 	(void)params;
@@ -1001,47 +1001,6 @@ TEST(VfsWrite, oomPageBuf, setUp, tearDown, 0, NULL)
 
 	free(buf_header_main);
 	free(file);
-
-	return MUNIT_OK;
-}
-
-/* Out of memory when trying to create the header buffer of a new WAL page. */
-TEST(VfsWrite, oomPageHdr, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	sqlite3_file *file1 = __file_create_main_db(&f->vfs);
-	sqlite3_file *file2 = __file_create_wal(&f->vfs);
-	void *buf_header_main = __buf_header_main_db();
-	void *buf_header_wal = __buf_header_wal();
-	void *buf_header_wal_frame = __buf_header_wal_frame();
-	char buf[512];
-	int rc;
-
-	(void)params;
-
-	memset(buf, 0, 512);
-
-	test_heap_fault_config(6, 1);
-	test_heap_fault_enable();
-
-	/* First write the main database header, which sets the page size. */
-	rc = file1->pMethods->xWrite(file1, buf_header_main, 100, 0);
-	munit_assert_int(rc, ==, 0);
-
-	/* Write the WAL header */
-	rc = file2->pMethods->xWrite(file2, buf_header_wal, 32, 0);
-	munit_assert_int(rc, ==, 0);
-
-	/* Write the header of the first frame, which triggers creating the
-	 * first page. */
-	rc = file2->pMethods->xWrite(file2, buf_header_wal_frame, 24, 32);
-	munit_assert_int(rc, ==, SQLITE_NOMEM);
-
-	free(buf_header_main);
-	free(buf_header_wal);
-	free(buf_header_wal_frame);
-	free(file1);
-	free(file2);
 
 	return MUNIT_OK;
 }

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -353,7 +353,7 @@ TEST(VfsOpen, walBeforeDb, setUp, tearDown, 0, NULL)
 	flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_WAL;
 	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 
-	munit_assert_int(rc, ==, SQLITE_CORRUPT);
+	munit_assert_int(rc, ==, SQLITE_CANTOPEN);
 
 	free(file);
 


### PR DESCRIPTION
This is a purely refactoring branch that doesn't change behavior.

The goal is to achieve better separation between database and WAL logic in the custom VFS implementation that dqlite plugs into SQLite. Reading and writing operations are already different and this PR makes that difference more explicit, even in terms of data layout (see how `struct vfsContent` has been decomposed).

Further down the road this separation will become even more profound, since the custom VFS will interact more closely with the dqlite state machine in order to reduce the number failure-related edge cases we need to handle when Raft transactions fail to get committed.