### PR TITLE
Use new test macros in server unit tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,6 +83,7 @@ unit_test_LDADD = libtest.la
 integration_test_SOURCES = \
   test/integration/test_membership.c \
   test/integration/test_server.c \
+  test/integration/test_client.c \
   test/integration/main.c
 integration_test_CFLAGS = $(AM_CFLAGS)
 integration_test_LDFLAGS = $(AM_LDFLAGS) -no-install

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -1,11 +1,3 @@
-#include "../lib/munit.h"
+#include "../lib/runner.h"
 
-MunitSuite _main_suites[64];
-int _main_suites_n = 0;
-
-/* Test runner executable */
-int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc + 1)])
-{
-	MunitSuite suite = {(char *)"", NULL, _main_suites, 1, 0};
-	return munit_suite_main(&suite, (void *)"µnit", argc, argv);
-}
+RUNNER("integration")

--- a/test/integration/test_client.c
+++ b/test/integration/test_client.c
@@ -1,0 +1,151 @@
+#include "../lib/heap.h"
+#include "../lib/runner.h"
+#include "../lib/server.h"
+#include "../lib/sqlite.h"
+
+/******************************************************************************
+ *
+ * Fixture
+ *
+ ******************************************************************************/
+
+#define FIXTURE struct test_server server
+#define SETUP                                     \
+	test_heap_setup(params, user_data);       \
+	test_sqlite_setup(params);                \
+	test_server_setup(&f->server, 1, params); \
+	test_server_start(&f->server)
+#define TEAR_DOWN                          \
+	test_server_tear_down(&f->server); \
+	test_sqlite_tear_down();           \
+	test_heap_tear_down(data)
+
+/******************************************************************************
+ *
+ * Helper macros.
+ *
+ ******************************************************************************/
+
+/* Send the initial client handshake. */
+#define HANDSHAKE                                     \
+	{                                             \
+		int rv_;                              \
+		rv_ = clientSendHandshake(f->client); \
+		munit_assert_int(rv_, ==, 0);         \
+	}
+
+/* Open a test database. */
+#define OPEN                                             \
+	{                                                \
+		int rv_;                                 \
+		rv_ = clientSendOpen(f->client, "test"); \
+		munit_assert_int(rv_, ==, 0);            \
+		rv_ = clientRecvDb(f->client);           \
+		munit_assert_int(rv_, ==, 0);            \
+	}
+
+/* Prepare a statement. */
+#define PREPARE(SQL, STMT_ID)                             \
+	{                                                 \
+		int rv_;                                  \
+		rv_ = clientSendPrepare(f->client, SQL);  \
+		munit_assert_int(rv_, ==, 0);             \
+		rv_ = clientRecvStmt(f->client, STMT_ID); \
+		munit_assert_int(rv_, ==, 0);             \
+	}
+
+/* Execute a statement. */
+#define EXEC(STMT_ID, LAST_INSERT_ID, ROWS_AFFECTED)              \
+	{                                                         \
+		int rv_;                                          \
+		rv_ = clientSendExec(f->client, STMT_ID);         \
+		munit_assert_int(rv_, ==, 0);                     \
+		rv_ = clientRecvResult(f->client, LAST_INSERT_ID, \
+				       ROWS_AFFECTED);            \
+		munit_assert_int(rv_, ==, 0);                     \
+	}
+
+/* Perform a query. */
+#define QUERY(STMT_ID, ROWS)                               \
+	{                                                  \
+		int rv_;                                   \
+		rv_ = clientSendQuery(f->client, STMT_ID); \
+		munit_assert_int(rv_, ==, 0);              \
+		rv_ = clientRecvRows(f->client, ROWS);     \
+		munit_assert_int(rv_, ==, 0);              \
+	}
+
+/******************************************************************************
+ *
+ * Handle client requests
+ *
+ ******************************************************************************/
+
+SUITE(client);
+
+struct fixture
+{
+	FIXTURE;
+	struct client *client;
+};
+
+static void *setUp(const MunitParameter params[], void *user_data)
+{
+	struct fixture *f = munit_malloc(sizeof *f);
+	(void)user_data;
+	SETUP;
+	f->client = test_server_client(&f->server);
+	HANDSHAKE;
+	OPEN;
+	return f;
+}
+
+static void tearDown(void *data)
+{
+	struct fixture *f = data;
+	TEAR_DOWN;
+	free(f);
+}
+
+TEST(client, exec, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	(void)params;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	return MUNIT_OK;
+}
+
+TEST(client, query, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	unsigned i;
+	struct rows rows;
+	(void)params;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	PREPARE("BEGIN", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	PREPARE("INSERT INTO test (n) VALUES(123)", &stmt_id);
+	for (i = 0; i < 256; i++) {
+		EXEC(stmt_id, &last_insert_id, &rows_affected);
+	}
+
+	PREPARE("COMMIT", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	PREPARE("SELECT n FROM test", &stmt_id);
+	QUERY(stmt_id, &rows);
+
+	clientCloseRows(&rows);
+
+	return MUNIT_OK;
+}

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -7,8 +7,6 @@
 #include "../lib/server.h"
 #include "../lib/sqlite.h"
 
-TEST_MODULE(membership);
-
 /******************************************************************************
  *
  * Fixture
@@ -140,28 +138,30 @@ static MunitParameterEnum endpointParams[] = {
  *
  ******************************************************************************/
 
-struct join_fixture
+SUITE(membership)
+
+struct fixture
 {
 	FIXTURE;
 };
 
-TEST_SUITE(join);
-TEST_SETUP(join)
+static void *setUp(const MunitParameter params[], void *user_data)
 {
-	struct join_fixture *f = munit_malloc(sizeof *f);
+	struct fixture *f = munit_malloc(sizeof *f);
 	SETUP;
 	return f;
 }
-TEST_TEAR_DOWN(join)
+
+static void tearDown(void *data)
 {
-	struct join_fixture *f = data;
+	struct fixture *f = data;
 	TEAR_DOWN;
 	free(f);
 }
 
-TEST_CASE(join, success, endpointParams)
+TEST(membership, join, setUp, tearDown, 0, endpointParams)
 {
-	struct join_fixture *f = data;
+	struct fixture *f = data;
 	unsigned id = 2;
 	const char *address = "@2";
 	unsigned stmt_id;

--- a/test/integration/test_server.c
+++ b/test/integration/test_server.c
@@ -1,13 +1,7 @@
-#include "../lib/client.h"
-#include "../lib/fs.h"
 #include "../lib/heap.h"
 #include "../lib/runner.h"
 #include "../lib/server.h"
 #include "../lib/sqlite.h"
-
-#include "../../src/client.h"
-
-TEST_MODULE(server);
 
 /******************************************************************************
  *
@@ -28,162 +22,35 @@ TEST_MODULE(server);
 
 /******************************************************************************
  *
- * Helper macros.
+ * dqlite_node_start
  *
  ******************************************************************************/
 
-/* Send the initial client handshake. */
-#define HANDSHAKE                                     \
-	{                                             \
-		int rv_;                              \
-		rv_ = clientSendHandshake(f->client); \
-		munit_assert_int(rv_, ==, 0);         \
-	}
+SUITE(dqlite_node_start);
 
-/* Open a test database. */
-#define OPEN                                             \
-	{                                                \
-		int rv_;                                 \
-		rv_ = clientSendOpen(f->client, "test"); \
-		munit_assert_int(rv_, ==, 0);            \
-		rv_ = clientRecvDb(f->client);           \
-		munit_assert_int(rv_, ==, 0);            \
-	}
-
-/* Prepare a statement. */
-#define PREPARE(SQL, STMT_ID)                             \
-	{                                                 \
-		int rv_;                                  \
-		rv_ = clientSendPrepare(f->client, SQL);  \
-		munit_assert_int(rv_, ==, 0);             \
-		rv_ = clientRecvStmt(f->client, STMT_ID); \
-		munit_assert_int(rv_, ==, 0);             \
-	}
-
-/* Execute a statement. */
-#define EXEC(STMT_ID, LAST_INSERT_ID, ROWS_AFFECTED)              \
-	{                                                         \
-		int rv_;                                          \
-		rv_ = clientSendExec(f->client, STMT_ID);         \
-		munit_assert_int(rv_, ==, 0);                     \
-		rv_ = clientRecvResult(f->client, LAST_INSERT_ID, \
-				       ROWS_AFFECTED);            \
-		munit_assert_int(rv_, ==, 0);                     \
-	}
-
-/* Perform a query. */
-#define QUERY(STMT_ID, ROWS)                               \
-	{                                                  \
-		int rv_;                                   \
-		rv_ = clientSendQuery(f->client, STMT_ID); \
-		munit_assert_int(rv_, ==, 0);              \
-		rv_ = clientRecvRows(f->client, ROWS);     \
-		munit_assert_int(rv_, ==, 0);              \
-	}
-
-/******************************************************************************
- *
- * dqlite_run
- *
- ******************************************************************************/
-
-struct run_fixture
+struct fixture
 {
 	FIXTURE;
 };
 
-TEST_SUITE(run);
-TEST_SETUP(run)
+static void *setUp(const MunitParameter params[], void *user_data)
 {
-	struct run_fixture *f = munit_malloc(sizeof *f);
+	struct fixture *f = munit_malloc(sizeof *f);
 	SETUP;
 	return f;
 }
-TEST_TEAR_DOWN(run)
+
+static void tearDown(void *data)
 {
-	struct run_fixture *f = data;
+	struct fixture *f = data;
 	TEAR_DOWN;
 	free(f);
 }
 
-TEST_CASE(run, success, NULL)
+TEST(dqlite_node_start, success, setUp, tearDown, 0, NULL)
 {
 	struct run_fixture *f = data;
 	(void)params;
 	(void)f;
-	return MUNIT_OK;
-}
-
-/******************************************************************************
- *
- * Handle client requests
- *
- ******************************************************************************/
-
-struct client_fixture
-{
-	FIXTURE;
-	struct client *client;
-};
-
-TEST_SUITE(client);
-TEST_SETUP(client)
-{
-	struct client_fixture *f = munit_malloc(sizeof *f);
-	(void)user_data;
-	SETUP;
-	f->client = test_server_client(&f->server);
-	HANDSHAKE;
-	OPEN;
-	return f;
-}
-
-TEST_TEAR_DOWN(client)
-{
-	struct client_fixture *f = data;
-	TEAR_DOWN;
-	free(f);
-}
-
-TEST_CASE(client, exec, NULL)
-{
-	struct client_fixture *f = data;
-	unsigned stmt_id;
-	unsigned last_insert_id;
-	unsigned rows_affected;
-	(void)params;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-	return MUNIT_OK;
-}
-
-TEST_CASE(client, query, NULL)
-{
-	struct client_fixture *f = data;
-	unsigned stmt_id;
-	unsigned last_insert_id;
-	unsigned rows_affected;
-	unsigned i;
-	struct rows rows;
-	(void)params;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	PREPARE("BEGIN", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	PREPARE("INSERT INTO test (n) VALUES(123)", &stmt_id);
-	for (i = 0; i < 256; i++) {
-		EXEC(stmt_id, &last_insert_id, &rows_affected);
-	}
-
-	PREPARE("COMMIT", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	PREPARE("SELECT n FROM test", &stmt_id);
-	QUERY(stmt_id, &rows);
-
-	clientCloseRows(&rows);
-
 	return MUNIT_OK;
 }


### PR DESCRIPTION
This is just a cleanup branch that extends to `test_server.c` the use of slightly simpler an more flexible test macros that were introduced in earlier branches. It also moves tests that actually involve client interaction to a separate `test_client.c` file.