### PR TITLE
Initial public APIs exposing dqlite's custom VFS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ libdqlite_la_SOURCES = \
   src/command.c \
   src/conn.c \
   src/db.c \
+  src/dqlite.c \
   src/error.c \
   src/format.c \
   src/fsm.c \
@@ -81,9 +82,10 @@ unit_test_LDFLAGS = $(AM_LDFLAGS)
 unit_test_LDADD = libtest.la
 
 integration_test_SOURCES = \
+  test/integration/test_client.c \
   test/integration/test_membership.c \
   test/integration/test_server.c \
-  test/integration/test_client.c \
+  test/integration/test_vfs.c \
   test/integration/main.c
 integration_test_CFLAGS = $(AM_CFLAGS)
 integration_test_LDFLAGS = $(AM_LDFLAGS) -no-install

--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -2,6 +2,7 @@
 #define DQLITE_H
 
 #include <stddef.h>
+#include <sqlite3.h>
 
 /**
  * Error codes.
@@ -193,5 +194,17 @@ const char *dqlite_node_errmsg(dqlite_node *n);
  * Generate a unique ID for the given address.
  */
 dqlite_node_id dqlite_generate_node_id(const char *address);
+
+/**
+ * Initialize the given SQLite VFS interface object with dqlite's custom
+ * implementation, which can be used for replication.
+ */
+int dqlite_vfs_init(sqlite3_vfs *vfs, const char *name);
+
+/**
+ * Release all memory used internally by a SQLite VFS object that was
+ * initialized using @qlite_vfs_init.
+ */
+void dqlite_vfs_close(sqlite3_vfs *vfs);
 
 #endif /* DQLITE_H */

--- a/src/dqlite.c
+++ b/src/dqlite.c
@@ -1,0 +1,11 @@
+#include "../include/dqlite.h"
+
+#include "vfs.h"
+
+int dqlite_vfs_init(sqlite3_vfs *vfs, const char *name) {
+	return VfsInitV2(vfs, name);
+}
+
+void dqlite_vfs_close(sqlite3_vfs *vfs) {
+	VfsClose(vfs);
+}

--- a/src/server.c
+++ b/src/server.c
@@ -27,7 +27,7 @@ int dqlite__init(struct dqlite_node *d,
 	if (rv != 0) {
 		goto err;
 	}
-	rv = VfsInit(&d->vfs, d->config.name);
+	rv = VfsInitV1(&d->vfs, d->config.name);
 	if (rv != 0) {
 		goto err_after_config_init;
 	}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1748,7 +1748,7 @@ static int vfsGetLastError(sqlite3_vfs *vfs, int x, char *y)
 	return rc;
 }
 
-int VfsInit(struct sqlite3_vfs *vfs, const char *name)
+int VfsInitV1(struct sqlite3_vfs *vfs, const char *name)
 {
 	vfs->iVersion = 2;
 	vfs->szOsFile = sizeof(struct vfsFile);

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -15,6 +15,10 @@
  * patching SQLite. */
 int VfsInitV1(struct sqlite3_vfs *vfs, const char *name);
 
+/* Initialize the given SQLite VFS interface with dqlite's custom
+ * implementation. */
+int VfsInitV2(struct sqlite3_vfs *vfs, const char *name);
+
 /* Release all memory associated with the given dqlite in-memory VFS
  * implementation.
  *

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -9,8 +9,11 @@
  * implementation.
  *
  * This function also automatically register the implementation in the global
- * SQLite registry, using the given @name. */
-int VfsInit(struct sqlite3_vfs *vfs, const char *name);
+ * SQLite registry, using the given @name.
+ *
+ * NOTE: This will make the VFS implement the legacy behavior which depends on
+ * patching SQLite. */
+int VfsInitV1(struct sqlite3_vfs *vfs, const char *name);
 
 /* Release all memory associated with the given dqlite in-memory VFS
  * implementation.

--- a/test/integration/test_vfs.c
+++ b/test/integration/test_vfs.c
@@ -1,0 +1,68 @@
+#include "../lib/heap.h"
+#include "../lib/runner.h"
+#include "../lib/sqlite.h"
+
+#include "../../include/dqlite.h"
+
+SUITE(vfs);
+
+struct fixture
+{
+	struct sqlite3_vfs vfs;
+};
+
+static void *setUp(const MunitParameter params[], void *user_data)
+{
+	struct fixture *f = munit_malloc(sizeof *f);
+	int rv;
+
+	SETUP_HEAP;
+	SETUP_SQLITE;
+
+	rv = dqlite_vfs_init(&f->vfs, "dqlite");
+	munit_assert_int(rv, ==, 0);
+
+	sqlite3_vfs_register(&f->vfs, 0);
+
+	return f;
+}
+
+static void tearDown(void *data)
+{
+	struct fixture *f = data;
+
+	sqlite3_vfs_unregister(&f->vfs);
+
+	dqlite_vfs_close(&f->vfs);
+
+	TEAR_DOWN_SQLITE;
+	TEAR_DOWN_HEAP;
+
+	free(f);
+}
+
+/* Open a new database connection. */
+#define OPEN(DB)                                                         \
+	do {                                                             \
+		int _flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE; \
+		int _rv;                                                 \
+		_rv = sqlite3_open_v2("test.db", &DB, _flags, "dqlite"); \
+		munit_assert_int(_rv, ==, SQLITE_OK);                    \
+	} while (0)
+
+/* Close a database connection. */
+#define CLOSE(DB)                                     \
+	do {                                          \
+		int _rv;                              \
+		_rv = sqlite3_close(DB);              \
+		munit_assert_int(_rv, ==, SQLITE_OK); \
+	} while (0)
+
+/* Open and close a new connection using the dqlite VFS. */
+TEST(vfs, open, setUp, tearDown, 0, NULL)
+{
+	sqlite3 *db;
+	OPEN(db);
+	CLOSE(db);
+	return MUNIT_OK;
+}

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -81,7 +81,7 @@ struct server
 		_rc = config__init(&_s->config, I + 1, address);               \
 		munit_assert_int(_rc, ==, 0);                                  \
                                                                                \
-		_rc = VfsInit(&_s->vfs, _s->config.name);                      \
+		_rc = VfsInitV1(&_s->vfs, _s->config.name);                    \
 		munit_assert_int(_rc, ==, 0);                                  \
                                                                                \
 		registry__init(&_s->registry, &_s->config);                    \

--- a/test/lib/vfs.h
+++ b/test/lib/vfs.h
@@ -8,11 +8,11 @@
 #include "../../src/vfs.h"
 
 #define FIXTURE_VFS struct sqlite3_vfs vfs;
-#define SETUP_VFS                                       \
-	{                                               \
-		int rv_;                                \
-		rv_ = VfsInit(&f->vfs, f->config.name); \
-		munit_assert_int(rv_, ==, 0);           \
+#define SETUP_VFS                                         \
+	{                                                 \
+		int rv_;                                  \
+		rv_ = VfsInitV1(&f->vfs, f->config.name); \
+		munit_assert_int(rv_, ==, 0);             \
 	}
 
 #define TEAR_DOWN_VFS VfsClose(&f->vfs);

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -31,7 +31,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
 	int rv;
 	SETUP_HEAP;
 	SETUP_SQLITE;
-	rv = VfsInit(&f->vfs, "dqlite");
+	rv = VfsInitV1(&f->vfs, "dqlite");
 	munit_assert_int(rv, ==, 0);
 	return f;
 }
@@ -1642,7 +1642,7 @@ TEST(VfsInit, oom, setUp, tearDown, 0, test_create_oom_params)
 
 	test_heap_fault_enable();
 
-	rv = VfsInit(&vfs, "dqlite");
+	rv = VfsInitV1(&vfs, "dqlite");
 	munit_assert_int(rv, ==, DQLITE_NOMEM);
 
 	return MUNIT_OK;


### PR DESCRIPTION
This is the initial scaffolding implementation of the new `dqlite_vfs_init()` and `dqlite_vfs_close()` public APIs, which will be used to expose the dqlite's custom version of the `sqlite3_vfs` interface. The implementation of the VFS object returned by `dqlite_vfs_init()` will differ a bit from the current one, so internally they are differentiated with the `V1` and `V2` tag.

There are no actual behavior changes for users, since the new implementation won't be really used until later on, when we'll move away from the dependency on the SQLite replication patch.

There's also a small refactoring which breaks `vfsFileShmMap()` into more granular sub-functions.