### PR TITLE
Initial implementation of VFS replication APIs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,7 +87,7 @@ integration_test_SOURCES = \
   test/integration/test_server.c \
   test/integration/test_vfs.c \
   test/integration/main.c
-integration_test_CFLAGS = $(AM_CFLAGS)
+integration_test_CFLAGS = $(AM_CFLAGS) -Wno-conversion
 integration_test_LDFLAGS = $(AM_LDFLAGS) -no-install
 integration_test_LDADD = libtest.la libdqlite.la
 

--- a/src/dqlite.c
+++ b/src/dqlite.c
@@ -2,10 +2,20 @@
 
 #include "vfs.h"
 
-int dqlite_vfs_init(sqlite3_vfs *vfs, const char *name) {
+int dqlite_vfs_init(sqlite3_vfs *vfs, const char *name)
+{
 	return VfsInitV2(vfs, name);
 }
 
-void dqlite_vfs_close(sqlite3_vfs *vfs) {
+void dqlite_vfs_close(sqlite3_vfs *vfs)
+{
 	VfsClose(vfs);
+}
+
+int dqlite_vfs_poll(sqlite3_vfs *vfs,
+		    const char *filename,
+		    dqlite_vfs_frame **frames,
+		    unsigned *n)
+{
+	return VfsPoll(vfs, filename, frames, n);
 }

--- a/src/dqlite.c
+++ b/src/dqlite.c
@@ -19,3 +19,13 @@ int dqlite_vfs_poll(sqlite3_vfs *vfs,
 {
 	return VfsPoll(vfs, filename, frames, n);
 }
+
+int dqlite_vfs_commit(sqlite3_vfs *vfs,
+		      const char *filename,
+		      unsigned n,
+		      unsigned *page_numbers,
+		      void *frames)
+{
+	return VfsCommit(vfs, filename, n, page_numbers, frames);
+}
+

--- a/src/format.c
+++ b/src/format.c
@@ -52,25 +52,25 @@ void formatDatabaseGetPageSize(const uint8_t *header, unsigned *page_size)
 	*page_size = formatDecodePageSize(buf);
 }
 
-void format__get_mx_frame(const uint8_t *buf, uint32_t *mx_frame)
+void formatWalGetMxFrame(const uint8_t *header, uint32_t *mx_frame)
 {
-	assert(buf != NULL);
+	assert(header != NULL);
 	assert(mx_frame != NULL);
 
 	/* The mxFrame number is 16th byte of the WAL index header. See also
 	 * https://sqlite.org/walformat.html. */
-	*mx_frame = ((uint32_t *)buf)[4];
+	*mx_frame = ((uint32_t *)header)[4];
 }
 
-void format__get_read_marks(const uint8_t *buf,
+void formatWalGetReadMarks(const uint8_t *header,
 			    uint32_t read_marks[FORMAT__WAL_NREADER])
 {
 	uint32_t *idx;
 
-	assert(buf != NULL);
+	assert(header != NULL);
 	assert(read_marks != NULL);
 
-	idx = (uint32_t *)buf;
+	idx = (uint32_t *)header;
 
 	/* The read-mark array starts at the 100th byte of the WAL index
 	 * header. See also https://sqlite.org/walformat.html. */

--- a/src/format.c
+++ b/src/format.c
@@ -63,7 +63,7 @@ void formatWalGetMxFrame(const uint8_t *header, uint32_t *mx_frame)
 }
 
 void formatWalGetReadMarks(const uint8_t *header,
-			    uint32_t read_marks[FORMAT__WAL_NREADER])
+			   uint32_t read_marks[FORMAT__WAL_NREADER])
 {
 	uint32_t *idx;
 
@@ -75,4 +75,15 @@ void formatWalGetReadMarks(const uint8_t *header,
 	/* The read-mark array starts at the 100th byte of the WAL index
 	 * header. See also https://sqlite.org/walformat.html. */
 	memcpy(read_marks, &idx[25], (sizeof *idx) * FORMAT__WAL_NREADER);
+}
+
+void formatWalGetFramePageNumber(const uint8_t *header, unsigned *page_number)
+{
+	/* The page number is stored in the first 4 bytes of the header
+	 * (big-endian) */
+	*page_number = 0;
+	*page_number += (unsigned)(header[0] << 24);
+	*page_number += (unsigned)(header[1] << 16);
+	*page_number += (unsigned)(header[2] << 8);
+	*page_number += (unsigned)(header[3]);
 }

--- a/src/format.c
+++ b/src/format.c
@@ -8,18 +8,34 @@
 
 #include "format.h"
 
+/* WAL magic value. Either this value, or the same value with the least
+ * significant bit also set (FORMAT__WAL_MAGIC | 0x00000001) is stored in 32-bit
+ * big-endian format in the first 4 bytes of a WAL file.
+ *
+ * If the LSB is set, then the checksums for each frame within the WAL file are
+ * calculated by treating all data as an array of 32-bit big-endian
+ * words. Otherwise, they are calculated by interpreting all data as 32-bit
+ * little-endian words. */
+#define FORMAT__WAL_MAGIC 0x377f0682
+
+static void formatGet32(const uint8_t buf[4], uint32_t *v)
+{
+	*v = 0;
+	*v += (uint32_t)(buf[0] << 24);
+	*v += (uint32_t)(buf[1] << 16);
+	*v += (uint32_t)(buf[2] << 8);
+	*v += (uint32_t)(buf[3]);
+}
+
 /* Decode the page size ("Must be a power of two between 512 and 32768
  * inclusive, or the value 1 representing a page size of 65536").
  *
  * Return 0 if the page size is out of bound. */
 static unsigned formatDecodePageSize(uint8_t buf[4])
 {
-	uint64_t page_size = 0;
+	uint32_t page_size;
 
-	page_size += (uint64_t)(buf[0] << 24);
-	page_size += (uint64_t)(buf[1] << 16);
-	page_size += (uint64_t)(buf[2] << 8);
-	page_size += (uint64_t)(buf[3]);
+	formatGet32(buf, &page_size);
 
 	if (page_size == 1) {
 		page_size = FORMAT__PAGE_SIZE_MAX;
@@ -34,6 +50,15 @@ static unsigned formatDecodePageSize(uint8_t buf[4])
 	return (unsigned)page_size;
 }
 
+void formatDatabaseGetPageSize(const uint8_t *header, unsigned *page_size)
+{
+	/* The page size is stored in the 16th and 17th bytes
+	 * (big-endian) */
+	uint8_t buf[4] = {0, 0, header[16], header[17]};
+
+	*page_size = formatDecodePageSize(buf);
+}
+
 void formatWalGetPageSize(const uint8_t *header, unsigned *page_size)
 {
 	/* The page size is stored in the 4 bytes starting at 8
@@ -43,13 +68,24 @@ void formatWalGetPageSize(const uint8_t *header, unsigned *page_size)
 	*page_size = formatDecodePageSize(buf);
 }
 
-void formatDatabaseGetPageSize(const uint8_t *header, unsigned *page_size)
+void formatWalGetChecksums(const uint8_t *header,
+			   unsigned *checksum1,
+			   unsigned *checksum2)
 {
-	/* The page size is stored in the 16th and 17th bytes
-	 * (big-endian) */
-	uint8_t buf[4] = {0, 0, header[16], header[17]};
+	uint32_t v;
+	formatGet32(header + 24, &v);
+	*checksum1 = (unsigned)v;
+	formatGet32(header + 28, &v);
+	*checksum2 = (unsigned)v;
+}
 
-	*page_size = formatDecodePageSize(buf);
+void formatWalGetSalt(const uint8_t *header, unsigned *salt1, unsigned *salt2)
+{
+	uint32_t v;
+	v = *(uint32_t *)(header + 16);
+	*salt1 = v;
+	v = *(uint32_t *)(header + 20);
+	*salt2 = v;
 }
 
 void formatWalGetMxFrame(const uint8_t *header, uint32_t *mx_frame)
@@ -81,9 +117,141 @@ void formatWalGetFramePageNumber(const uint8_t *header, unsigned *page_number)
 {
 	/* The page number is stored in the first 4 bytes of the header
 	 * (big-endian) */
-	*page_number = 0;
-	*page_number += (unsigned)(header[0] << 24);
-	*page_number += (unsigned)(header[1] << 16);
-	*page_number += (unsigned)(header[2] << 8);
-	*page_number += (unsigned)(header[3]);
+	uint32_t v;
+	formatGet32(header, &v);
+	*page_number = v;
+}
+
+void formatWalGetFrameChecksums(const uint8_t *header,
+				unsigned *checksum1,
+				unsigned *checksum2)
+{
+	uint32_t v;
+	formatGet32(header + 16, &v);
+	*checksum1 = (unsigned)v;
+	formatGet32(header + 20, &v);
+	*checksum2 = (unsigned)v;
+}
+
+void formatWalGetNativeChecksum(const uint8_t *header, bool *native)
+{
+	uint32_t magic;
+	formatGet32(header, &magic);
+	assert((magic & 0xFFFFFFFE) == FORMAT__WAL_MAGIC);
+	*native = !(bool)(magic & 0x00000001);
+}
+
+/* Encode a 32-bit number to big endian format */
+static void formatPut32(uint32_t v, uint8_t *buf)
+{
+	buf[0] = (uint8_t)(v >> 24);
+	buf[1] = (uint8_t)(v >> 16);
+	buf[2] = (uint8_t)(v >> 8);
+	buf[3] = (uint8_t)v;
+}
+
+/*
+ * Generate or extend an 8 byte checksum based on the data in array data[] and
+ * the initial values of in[0] and in[1] (or initial values of 0 and 0 if
+ * in==NULL).
+ *
+ * The checksum is written back into out[] before returning.
+ *
+ * n must be a positive multiple of 8. */
+static void formatWalChecksumBytes(
+    bool native,        /* True for native byte-order, false for non-native */
+    uint8_t *data,      /* Content to be checksummed */
+    unsigned n,         /* Bytes of content in a[].  Must be a multiple of 8. */
+    const uint32_t *in, /* Initial checksum value input */
+    uint32_t *out       /* OUT: Final checksum value output */
+)
+{
+	uint32_t s1, s2;
+	uint32_t *cur = (uint32_t *)data;
+	uint32_t *end = (uint32_t *)&data[n];
+
+	if (in) {
+		s1 = in[0];
+		s2 = in[1];
+	} else {
+		s1 = s2 = 0;
+	}
+
+	assert(n >= 8);
+	assert((n & 0x00000007) == 0);
+	assert(n <= 65536);
+
+	if (native) {
+		do {
+			s1 += *cur++ + s2;
+			s2 += *cur++ + s1;
+		} while (cur < end);
+	} else {
+		do {
+			uint32_t d;
+			formatPut32(cur[0], (uint8_t *)&d);
+			s1 += d + s2;
+			formatPut32(cur[1], (uint8_t *)&d);
+			s2 += d + s1;
+			cur += 2;
+		} while (cur < end);
+	}
+
+	out[0] = s1;
+	out[1] = s2;
+}
+
+void formatWalPutFrameHeader(bool native,
+			     unsigned page_number,
+			     unsigned database_size,
+			     unsigned salt1,
+			     unsigned salt2,
+			     unsigned *checksum1,
+			     unsigned *checksum2,
+			     uint8_t *header,
+			     uint8_t *page,
+			     unsigned page_size)
+{
+	uint32_t checksum[2] = {*checksum1, *checksum2};
+	uint32_t salt;
+	formatPut32(page_number, header);
+	formatPut32(database_size, header + 4);
+
+	formatWalChecksumBytes(native, header, 8, checksum, checksum);
+	formatWalChecksumBytes(native, page, page_size, checksum, checksum);
+
+	salt = salt1;
+	memcpy(header + 8, &salt, sizeof salt);
+	salt = salt2;
+	memcpy(header + 12, &salt, sizeof salt);
+
+	formatPut32(checksum[0], header + 16);
+	formatPut32(checksum[1], header + 20);
+
+	*checksum1 = checksum[0];
+	*checksum2 = checksum[1];
+}
+
+void formatWalIndexHeaderRevert(uint8_t *header,
+				unsigned max_frame,
+				unsigned n_pages,
+				unsigned frame_checksum1,
+				unsigned frame_checksum2)
+{
+	uint32_t checksum[2] = {0, 0};
+	bool native = !header[13];
+
+	*(uint32_t *)(header + 16) = max_frame;
+	*(uint32_t *)(header + 20) = n_pages;
+	*(uint32_t *)(header + 24) = frame_checksum1;
+	*(uint32_t *)(header + 28) = frame_checksum2;
+
+	formatWalChecksumBytes(native, header, 40, checksum, checksum);
+
+	*(uint32_t *)(header + 40) = checksum[0];
+	*(uint32_t *)(header + 44) = checksum[1];
+
+	/* Update the second copy of the first part of the WAL index header. */
+	memcpy(header + FORMAT__WAL_IDX_HDR_SIZE, header,
+	       FORMAT__WAL_IDX_HDR_SIZE);
 }

--- a/src/format.h
+++ b/src/format.h
@@ -27,6 +27,10 @@
  * WAL_READ_LOCK definition in the wal.c file of the SQLite source code. */
 #define FORMAT__WAL_READ_LOCK(I) (3 + (I))
 
+/* Size of each memory region in the WAL index. Same as WALINDEX_PGSZ defined in
+ * wal.c of SQLite. */
+#define FORMAT__WAL_IDX_PAGE_SIZE 32768
+
 /* Given the page size, calculate the size of a full WAL frame (frame header
  * plus page data). */
 #define formatWalCalcFrameSize(PAGE_SIZE) \

--- a/src/format.h
+++ b/src/format.h
@@ -39,16 +39,15 @@
 #define formatWalCalcFrameSize(PAGE_SIZE) \
 	(FORMAT__WAL_FRAME_HDR_SIZE + PAGE_SIZE)
 
-/* Given the page size and the WAL file size, calculate the number of pages
- * currently in the WAL. */
-#define formatWalCalcPages(PAGE_SIZE, SIZE) \
+/* Given the page size and the WAL file size, calculate the number of frames it
+ * has. */
+#define formatWalCalcFramesNumber(PAGE_SIZE, SIZE) \
 	((SIZE - FORMAT__WAL_HDR_SIZE) / formatWalCalcFrameSize(PAGE_SIZE))
 
 /* Given the page size, calculate the WAL page number of the frame starting at
  * the given offset. */
-#define formatWalCalcPgno(PAGE_SIZE, OFFSET) \
-	formatWalCalcPages(PAGE_SIZE,        \
-			   OFFSET + formatWalCalcFrameSize(PAGE_SIZE))
+#define formatWalCalcFrameIndex(PAGE_SIZE, OFFSET) \
+	(formatWalCalcFramesNumber(PAGE_SIZE, OFFSET) + 1)
 
 /* Extract the page size from the content of the WAL header.
  *

--- a/src/format.h
+++ b/src/format.h
@@ -72,4 +72,7 @@ void formatWalGetMxFrame(const uint8_t *header, uint32_t *mx_frame);
 void formatWalGetReadMarks(const uint8_t *header,
 			   uint32_t read_marks[FORMAT__WAL_NREADER]);
 
+/* Extract the page number from a WAL frame header. */
+void formatWalGetFramePageNumber(const uint8_t *header, unsigned *page_number);
+
 #endif /* FORMAT_H */

--- a/src/format.h
+++ b/src/format.h
@@ -1,68 +1,47 @@
-/**
- * Utilities around SQLite file formats.
+/* Utilities around SQLite file formats.
  *
- * See https://sqlite.org/fileformat.html.
- */
+ * See https://sqlite.org/fileformat.html. */
 
 #ifndef FORMAT_H_
 #define FORMAT_H_
 
 #include <stdint.h>
-#include <stdlib.h>
 
-/**
- * Minumum and maximum page size.
- */
+/* Minumum and maximum page size. */
 #define FORMAT__PAGE_SIZE_MIN 512
 #define FORMAT__PAGE_SIZE_MAX 65536
 
-/**
- * Database header size.
- */
+/* Database header size. */
 #define FORMAT__DB_HDR_SIZE 100
 
-/**
- * Write ahead log header size.
- */
+/* Write ahead log header size. */
 #define FORMAT__WAL_HDR_SIZE 32
 
-/**
- * Write ahead log frame header size.
- */
+/* Write ahead log frame header size. */
 #define FORMAT__WAL_FRAME_HDR_SIZE 24
 
-/**
- * Number of reader marks in the wal index header.
- */
+/* Number of reader marks in the wal index header. */
 #define FORMAT__WAL_NREADER 5
 
-/**
- * Lock index given the offset I in the aReadMark array. See the equivalent
- * WAL_READ_LOCK definition in the wal.c file of the SQLite source code.
- */
+/* Lock index given the offset I in the aReadMark array. See the equivalent
+ * WAL_READ_LOCK definition in the wal.c file of the SQLite source code. */
 #define FORMAT__WAL_READ_LOCK(I) (3 + (I))
 
-/**
- * Given the page size, calculate the size of a full WAL frame (frame header
- * plus page data).
- */
-#define format__wal_calc_frame_size(PAGE_SIZE) \
+/* Given the page size, calculate the size of a full WAL frame (frame header
+ * plus page data). */
+#define formatWalCalcFrameSize(PAGE_SIZE) \
 	(FORMAT__WAL_FRAME_HDR_SIZE + PAGE_SIZE)
 
-/**
- * Given the page size and the WAL file size, calculate the number of pages
- * currently in the WAL.
- */
-#define format__wal_calc_pages(PAGE_SIZE, SIZE) \
-	((SIZE - FORMAT__WAL_HDR_SIZE) / format__wal_calc_frame_size(PAGE_SIZE))
+/* Given the page size and the WAL file size, calculate the number of pages
+ * currently in the WAL. */
+#define formatWalCalcPages(PAGE_SIZE, SIZE) \
+	((SIZE - FORMAT__WAL_HDR_SIZE) / formatWalCalcFrameSize(PAGE_SIZE))
 
-/**
- * Given the page size, calculate the WAL page number of the frame starting at
- * the given offset.
- */
-#define format__wal_calc_pgno(PAGE_SIZE, OFFSET) \
-	format__wal_calc_pages(                  \
-	    PAGE_SIZE, OFFSET + format__wal_calc_frame_size(PAGE_SIZE))
+/* Given the page size, calculate the WAL page number of the frame starting at
+ * the given offset. */
+#define formatWalCalcPgno(PAGE_SIZE, OFFSET) \
+	formatWalCalcPages(PAGE_SIZE,        \
+			   OFFSET + formatWalCalcFrameSize(PAGE_SIZE))
 
 /* Extract the page size from the content of the WAL header.
  *
@@ -78,17 +57,13 @@ void formatWalGetPageSize(const uint8_t *header, unsigned *page_size);
  * If the page size is invalid, 0 is returned. */
 void formatDatabaseGetPageSize(const uint8_t *header, unsigned *page_size);
 
-/**
- * Extract the mxFrame field from the WAL index header stored in the given
- * buffer
- */
-void format__get_mx_frame(const uint8_t *buf, uint32_t *mx_frame);
+/* Extract the mxFrame field from the WAL index header stored in the given
+ * buffer */
+void formatWalGetMxFrame(const uint8_t *header, uint32_t *mx_frame);
 
-/**
- * Extract the read marks array from the WAL index header stored in the given
- * buffer.
- */
-void format__get_read_marks(const uint8_t *buf,
-			    uint32_t read_marks[FORMAT__WAL_NREADER]);
+/* Extract the read marks array from the WAL index header stored in the given
+ * buffer. */
+void formatWalGetReadMarks(const uint8_t *header,
+			   uint32_t read_marks[FORMAT__WAL_NREADER]);
 
 #endif /* FORMAT_H */

--- a/src/format.h
+++ b/src/format.h
@@ -1,5 +1,5 @@
 /**
-  * Utilities around SQLite file formats.
+ * Utilities around SQLite file formats.
  *
  * See https://sqlite.org/fileformat.html.
  */
@@ -9,13 +9,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-
-/**
- * Possible file types.
- */
-#define FORMAT__DB 0
-#define FORMAT__WAL 1
-#define FORMAT__OTHER 2
 
 /**
  * Minumum and maximum page size.
@@ -71,19 +64,19 @@
 	format__wal_calc_pages(                  \
 	    PAGE_SIZE, OFFSET + format__wal_calc_frame_size(PAGE_SIZE))
 
-/**
- * Extract the page size from the content of the first database page or from the
- * WAL header.
+/* Extract the page size from the content of the WAL header.
  *
- * If type is FORMAT__DB the given buffer must hold at least
- * FORMAT__DB_HDR_SIZE bytes.
+ * The given buffer must hold at least FORMAT__WAL_HDR_SIZE.
  *
- * If type is FORMAT__WAL the given buffer must hold at least
- * FORMAT__WAL_HDR_SIZE.
- */
-int format__get_page_size(int type,
-			  const uint8_t *buf,
-			  unsigned int *page_size);
+ * If the page size is invalid, 0 is returned. */
+void formatWalGetPageSize(const uint8_t *header, unsigned *page_size);
+
+/* Extract the page size from the content of the database header.
+ *
+ * The given buffer must hold at least FORMAT__DB_HDR_SIZE bytes.
+ *
+ * If the page size is invalid, 0 is returned. */
+void formatDatabaseGetPageSize(const uint8_t *header, unsigned *page_size);
 
 /**
  * Extract the mxFrame field from the WAL index header stored in the given

--- a/src/format.h
+++ b/src/format.h
@@ -27,6 +27,9 @@
  * WAL_READ_LOCK definition in the wal.c file of the SQLite source code. */
 #define FORMAT__WAL_READ_LOCK(I) (3 + (I))
 
+/* Size of the first part of the WAL index header. */
+#define FORMAT__WAL_IDX_HDR_SIZE 48
+
 /* Size of each memory region in the WAL index. Same as WALINDEX_PGSZ defined in
  * wal.c of SQLite. */
 #define FORMAT__WAL_IDX_PAGE_SIZE 32768

--- a/src/leader.c
+++ b/src/leader.c
@@ -63,10 +63,10 @@ static int maybeCheckpoint(void *ctx,
 	assert(rv == SQLITE_OK); /* Should never fail */
 
 	/* Get the current value of mxFrame. */
-	format__get_mx_frame((const uint8_t *)region, &mx_frame);
+	formatWalGetMxFrame((const uint8_t *)region, &mx_frame);
 
 	/* Get the content of the read marks. */
-	format__get_read_marks((const uint8_t *)region, read_marks);
+	formatWalGetReadMarks((const uint8_t *)region, read_marks);
 
 	/* Check each mark and associated lock. This logic is similar to the one
 	 * in the walCheckpoint function of wal.c, in the SQLite code. */

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <stdlib.h>
 
 #include <raft.h>
 
@@ -762,7 +763,7 @@ static int vfsWalRead(struct vfsWal *w,
 	if (amount == FORMAT__WAL_FRAME_HDR_SIZE) {
 		assert(((offset - FORMAT__WAL_HDR_SIZE) %
 			(page_size + FORMAT__WAL_FRAME_HDR_SIZE)) == 0);
-		pgno = format__wal_calc_pgno(page_size, (unsigned)offset);
+		pgno = formatWalCalcPgno(page_size, (unsigned)offset);
 	} else if (amount == sizeof(uint32_t) * 2) {
 		if (offset == FORMAT__WAL_FRAME_HDR_SIZE) {
 			/* Read the checksum from the WAL
@@ -779,10 +780,10 @@ static int vfsWalRead(struct vfsWal *w,
 		assert(((offset - FORMAT__WAL_HDR_SIZE -
 			 FORMAT__WAL_FRAME_HDR_SIZE) %
 			(page_size + FORMAT__WAL_FRAME_HDR_SIZE)) == 0);
-		pgno = format__wal_calc_pgno(page_size, (unsigned)offset);
+		pgno = formatWalCalcPgno(page_size, (unsigned)offset);
 	} else {
 		assert(amount == (FORMAT__WAL_FRAME_HDR_SIZE + (int)page_size));
-		pgno = format__wal_calc_pgno(page_size, (unsigned)offset);
+		pgno = formatWalCalcPgno(page_size, (unsigned)offset);
 	}
 
 	if (pgno == 0) {
@@ -969,7 +970,7 @@ static int vfsWalWrite(struct vfsWal *w,
 		assert(((offset - FORMAT__WAL_HDR_SIZE) %
 			(page_size + FORMAT__WAL_FRAME_HDR_SIZE)) == 0);
 
-		pgno = format__wal_calc_pgno(page_size, (unsigned)offset);
+		pgno = formatWalCalcPgno(page_size, (unsigned)offset);
 
 		vfsWalFrameGet(w, (int)pgno, &frame);
 		if (frame == NULL) {
@@ -983,7 +984,7 @@ static int vfsWalWrite(struct vfsWal *w,
 			 FORMAT__WAL_FRAME_HDR_SIZE) %
 			(page_size + FORMAT__WAL_FRAME_HDR_SIZE)) == 0);
 
-		pgno = format__wal_calc_pgno(page_size, (unsigned)offset);
+		pgno = formatWalCalcPgno(page_size, (unsigned)offset);
 
 		/* The header for the this frame must already
 		 * have been written, so the page is there. */

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1258,6 +1258,7 @@ static int vfsShmMap(struct vfsShm *s,
 	} else {
 		if (extend) {
 			/* We should grow the map one region at a time. */
+			assert(region_size == FORMAT__WAL_IDX_PAGE_SIZE);
 			assert(region_index == s->n_regions);
 			region = sqlite3_malloc64(region_size);
 			if (region == NULL) {

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -57,8 +57,10 @@ struct vfsWal
 {
 	struct vfsDatabase *database;      /* Associated database */
 	uint8_t hdr[FORMAT__WAL_HDR_SIZE]; /* Header. */
-	struct vfsFrame **frames;          /* All frames. */
-	unsigned n_frames;                 /* Number of frames. */
+	struct vfsFrame **frames;          /* All frames committed. */
+	unsigned n_frames;                 /* Number of committed frames. */
+	struct vfsFrame **tx;              /* Frames added by a transaction. */
+	unsigned n_tx;                     /* Number of added frames. */
 };
 
 enum vfsContentType {
@@ -175,6 +177,8 @@ static void vfsWalInit(struct vfsWal *w)
 	memset(w->hdr, 0, FORMAT__WAL_HDR_SIZE);
 	w->frames = NULL;
 	w->n_frames = 0;
+	w->tx = NULL;
+	w->n_tx = 0;
 }
 
 /* Create the content structure for a new volatile file. */

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -36,6 +36,8 @@ struct vfsShm
 	unsigned exclusive[SQLITE_SHM_NLOCK]; /* Count of exclusive locks */
 };
 
+struct vfsWal;
+
 /* Database-specific content */
 struct vfsDatabase
 {
@@ -43,6 +45,7 @@ struct vfsDatabase
 	void **pages;       /* All database. */
 	unsigned n_pages;   /* Number of pages. */
 	struct vfsShm shm;  /* Shared memory. */
+	struct vfsWal *wal; /* Associated WAL. */
 	int version;
 };
 
@@ -171,6 +174,7 @@ static void vfsDatabaseInit(struct vfsDatabase *d, int version)
 	d->n_pages = 0;
 	vfsShmInit(&d->shm);
 	d->version = version;
+	d->wal = NULL;
 }
 
 /* Initialize a new WAL object. */
@@ -1716,6 +1720,7 @@ static int vfsOpen(sqlite3_vfs *vfs,
 				goto err_after_content_create;
 			}
 			content->wal.database = database;
+			database->wal = &content->wal;
 		}
 
 		v->contents[n - 1] = content;

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -33,6 +33,13 @@ int VfsPoll(sqlite3_vfs *vfs,
 	    dqlite_vfs_frame **frames,
 	    unsigned *n);
 
+/* Append the given frames to the WAL. */
+int VfsCommit(sqlite3_vfs *vfs,
+	      const char *filename,
+	      unsigned n,
+	      unsigned *page_numbers,
+	      void *frames);
+
 /* Read the content of a file, using the VFS implementation registered under the
  * given name. Used to take database snapshots using the dqlite in-memory
  * VFS. */

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -26,6 +26,13 @@ int VfsInitV2(struct sqlite3_vfs *vfs, const char *name);
  * SQLite global registry. */
 void VfsClose(struct sqlite3_vfs *vfs);
 
+/* Check if the last sqlite3_step() call triggered a write transaction, and
+ * return its content if so. */
+int VfsPoll(sqlite3_vfs *vfs,
+	    const char *database,
+	    dqlite_vfs_frame **frames,
+	    unsigned *n);
+
 /* Read the content of a file, using the VFS implementation registered under the
  * given name. Used to take database snapshots using the dqlite in-memory
  * VFS. */

--- a/test/integration/test_vfs.c
+++ b/test/integration/test_vfs.c
@@ -41,6 +41,11 @@ static void tearDown(void *data)
 	free(f);
 }
 
+/* Helper to execute a SQL statement on the given DB. */
+#define EXEC(DB, SQL)                                  \
+	_rv = sqlite3_exec(DB, SQL, NULL, NULL, NULL); \
+	munit_assert_int(_rv, ==, SQLITE_OK);
+
 /* Open a new database connection. */
 #define OPEN(DB)                                                         \
 	do {                                                             \
@@ -48,6 +53,9 @@ static void tearDown(void *data)
 		int _rv;                                                 \
 		_rv = sqlite3_open_v2("test.db", &DB, _flags, "dqlite"); \
 		munit_assert_int(_rv, ==, SQLITE_OK);                    \
+		EXEC(DB, "PRAGMA page_size=512");                        \
+		EXEC(DB, "PRAGMA synchronous=OFF");                      \
+		EXEC(DB, "PRAGMA journal_mode=WAL");                     \
 	} while (0)
 
 /* Close a database connection. */

--- a/test/integration/test_vfs.c
+++ b/test/integration/test_vfs.c
@@ -53,6 +53,8 @@ static void tearDown(void *data)
 		int _rv;                                                 \
 		_rv = sqlite3_open_v2("test.db", &DB, _flags, "dqlite"); \
 		munit_assert_int(_rv, ==, SQLITE_OK);                    \
+		_rv = sqlite3_extended_result_codes(DB, 1);              \
+		munit_assert_int(_rv, ==, SQLITE_OK);                    \
 		EXEC(DB, "PRAGMA page_size=512");                        \
 		EXEC(DB, "PRAGMA synchronous=OFF");                      \
 		EXEC(DB, "PRAGMA journal_mode=WAL");                     \
@@ -66,11 +68,67 @@ static void tearDown(void *data)
 		munit_assert_int(_rv, ==, SQLITE_OK); \
 	} while (0)
 
+/* Prepare a statement. */
+#define PREPARE(DB, STMT, SQL)                                      \
+	do {                                                        \
+		int _rv;                                            \
+		_rv = sqlite3_prepare_v2(DB, SQL, -1, &STMT, NULL); \
+		if (_rv != SQLITE_OK) {                             \
+			munit_errorf("prepare '%s': %s (%d)", SQL,  \
+				     sqlite3_errmsg(DB), _rv);      \
+			munit_assert_int(_rv, ==, SQLITE_OK);       \
+		}                                                   \
+	} while (0)
+
+/* Finalize a statement. */
+#define FINALIZE(STMT)                                \
+	do {                                          \
+		int _rv;                              \
+		_rv = sqlite3_finalize(STMT);         \
+		munit_assert_int(_rv, ==, SQLITE_OK); \
+	} while (0)
+
+/* Step through a statement and assert that the given value is returned. */
+#define STEP(STMT, RV)                                                        \
+	do {                                                                  \
+		int _rv;                                                      \
+		_rv = sqlite3_step(STMT);                                     \
+		if (_rv != RV) {                                              \
+			munit_errorf("step: %s (%d)",                         \
+				     sqlite3_errmsg(sqlite3_db_handle(STMT)), \
+				     _rv);                                    \
+		}                                                             \
+	} while (0)
+
 /* Open and close a new connection using the dqlite VFS. */
 TEST(vfs, open, setUp, tearDown, 0, NULL)
 {
 	sqlite3 *db;
 	OPEN(db);
 	CLOSE(db);
+	return MUNIT_OK;
+}
+
+/* Write transactions are not committed synchronously, so they are not visible
+ * from other connections yet when sqlite3_step() returns. */
+TEST(vfs, unreplicatedCommitIsNotVisible, setUp, tearDown, 0, NULL)
+{
+	sqlite3 *db1;
+	sqlite3 *db2;
+	sqlite3_stmt *stmt1;
+	sqlite3_stmt *stmt2;
+	int rv;
+	OPEN(db1);
+	PREPARE(db1, stmt1, "CREATE TABLE test(n INT)");
+	STEP(stmt1, SQLITE_DONE);
+	FINALIZE(stmt1);
+
+	OPEN(db2);
+	rv = sqlite3_prepare_v2(db2, "SELECT * FROM test", -1, &stmt2, NULL);
+	munit_assert_int(rv, ==, SQLITE_ERROR);
+
+	CLOSE(db1);
+	CLOSE(db2);
+
 	return MUNIT_OK;
 }

--- a/test/unit/test_format.c
+++ b/test/unit/test_format.c
@@ -6,128 +6,177 @@
 
 #include "../../src/format.h"
 
-TEST_MODULE(format);
+/******************************************************************************
+ *
+ * formatWalGetPageSize
+ *
+ ******************************************************************************/
 
-TEST_SUITE(get_page_size);
+SUITE(formatWalGetPageSize);
 
-/* Parse the page size stored in a database file header. */
-TEST_CASE(get_page_size, db, NULL)
+TEST(formatWalGetPageSize, valid, NULL, NULL, 0, NULL)
 {
-	uint8_t      buf[FORMAT__DB_HDR_SIZE];
-	unsigned int page_size;
-	int          rc;
+	uint8_t header[FORMAT__WAL_HDR_SIZE];
+	unsigned page_size;
 
-	(void)params;
-	(void)data;
+	header[8] = 0;
+	header[9] = 0;
+	header[10] = 16;
+	header[11] = 0;
 
-	buf[16] = 16;
-	buf[17] = 0;
-
-	rc = format__get_page_size(FORMAT__DB, buf, &page_size);
-	munit_assert_int(rc, ==, SQLITE_OK);
-
-	munit_assert_int(page_size, ==, 4096);
-
-	return MUNIT_OK;
-}
-
-/* Parse the page size stored in a WAL file header. */
-TEST_CASE(get_page_size, wal, NULL)
-{
-	uint8_t      buf[FORMAT__WAL_HDR_SIZE];
-	unsigned int page_size;
-	int          rc;
-
-	(void)params;
-	(void)data;
-
-	buf[8]  = 0;
-	buf[9]  = 0;
-	buf[10] = 16;
-	buf[11] = 0;
-
-	rc = format__get_page_size(FORMAT__WAL, buf, &page_size);
-	munit_assert_int(rc, ==, SQLITE_OK);
-
+	formatWalGetPageSize(header, &page_size);
 	munit_assert_int(page_size, ==, 4096);
 
 	return MUNIT_OK;
 }
 
 /* If the stored value is 1, the resulting page size is the maximum one. */
-TEST_CASE(get_page_size, max, NULL)
+TEST(formatWalGetPageSize, max, NULL, NULL, 0, NULL)
 {
-	uint8_t      buf[FORMAT__DB_HDR_SIZE];
-	unsigned int page_size;
-	int          rc;
+	uint8_t header[FORMAT__WAL_HDR_SIZE];
+	unsigned page_size;
 
-	(void)params;
-	(void)data;
+	header[8] = 0;
+	header[9] = 0;
+	header[10] = 0;
+	header[11] = 1;
 
-	buf[16] = 0;
-	buf[17] = 1;
-
-	rc = format__get_page_size(FORMAT__DB, buf, &page_size);
-	munit_assert_int(rc, ==, SQLITE_OK);
-
+	formatWalGetPageSize(header, &page_size);
 	munit_assert_int(page_size, ==, 65536);
 
 	return MUNIT_OK;
 }
 
-/* If the stored value is smaller than the minimum size, an error is returned. */
-TEST_CASE(get_page_size, too_small, NULL)
+/* The stored value is smaller than the minimum size. */
+TEST(formatWalGetPageSize, tooSmall, NULL, NULL, 0, NULL)
 {
-	uint8_t      buf[FORMAT__DB_HDR_SIZE];
-	unsigned int page_size;
-	int          rc;
+	uint8_t header[FORMAT__WAL_HDR_SIZE];
+	unsigned page_size;
 
-	(void)params;
-	(void)data;
+	header[8] = 0;
+	header[9] = 0;
+	header[10] = 0;
+	header[11] = 128;
 
-	buf[16] = 0;
-	buf[17] = 128;
-
-	rc = format__get_page_size(FORMAT__DB, buf, &page_size);
-	munit_assert_int(rc, ==, SQLITE_CORRUPT);
+	formatWalGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 0);
 
 	return MUNIT_OK;
 }
 
-/* If the stored is value larger than the maximum size, an error is returned. */
-TEST_CASE(get_page_size, too_large, NULL)
+/* The stored value is larger than the maximum size. */
+TEST(formatWalGetPageSize, tooLarge, NULL, NULL, 0, NULL)
 {
-	uint8_t      buf[FORMAT__DB_HDR_SIZE];
-	unsigned int page_size;
-	int          rc;
+	uint8_t header[FORMAT__WAL_HDR_SIZE];
+	unsigned page_size;
 
-	(void)params;
-	(void)data;
+	header[8] = 0;
+	header[9] = 0;
+	header[10] = 0xff;
+	header[11] = 0xff;
 
-	buf[16] = 0xff;
-	buf[17] = 0xff;
-
-	rc = format__get_page_size(FORMAT__DB, buf, &page_size);
-	munit_assert_int(rc, ==, SQLITE_CORRUPT);
+	formatWalGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 0);
 
 	return MUNIT_OK;
 }
 
-/* If the stored value is not a power of 2, an error is returned. */
-TEST_CASE(get_page_size, not_power_of_2, NULL)
+/* The stored value is not a power of 2. */
+TEST(formatWalGetPageSize, notPowerOf2, NULL, NULL, 0, NULL)
 {
-	uint8_t      buf[FORMAT__DB_HDR_SIZE];
-	unsigned int page_size;
-	int          rc;
+	uint8_t header[FORMAT__WAL_HDR_SIZE];
+	unsigned page_size;
 
-	(void)params;
-	(void)data;
+	header[8] = 0;
+	header[9] = 0;
+	header[10] = 6;
+	header[11] = 12;
 
-	buf[16] = 6;
-	buf[17] = 12;
+	formatWalGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 0);
 
-	rc = format__get_page_size(FORMAT__DB, buf, &page_size);
-	munit_assert_int(rc, ==, SQLITE_CORRUPT);
+	return MUNIT_OK;
+}
+
+/******************************************************************************
+ *
+ * formatDatabaseGetPageSize
+ *
+ ******************************************************************************/
+
+SUITE(formatDatabaseGetPageSize);
+
+/* Parse the page size stored in a database file header. */
+TEST(formatDatabaseGetPageSize, valid, NULL, NULL, 0, NULL)
+{
+	uint8_t header[FORMAT__DB_HDR_SIZE];
+	unsigned page_size;
+
+	header[16] = 16;
+	header[17] = 0;
+
+	formatDatabaseGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 4096);
+
+	return MUNIT_OK;
+}
+
+/* If the stored value is 1, the resulting page size is the maximum one. */
+TEST(formatDatabaseGetPageSize, max, NULL, NULL, 0, NULL)
+{
+	uint8_t header[FORMAT__DB_HDR_SIZE];
+	unsigned page_size;
+
+	header[16] = 0;
+	header[17] = 1;
+
+	formatDatabaseGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 65536);
+
+	return MUNIT_OK;
+}
+
+/* The stored value is smaller than the minimum size. */
+TEST(formatDatabaseGetPageSize, tooSmall, NULL, NULL, 0, NULL)
+{
+	uint8_t header[FORMAT__DB_HDR_SIZE];
+	unsigned page_size;
+
+	header[16] = 0;
+	header[17] = 128;
+
+	formatDatabaseGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 0);
+
+	return MUNIT_OK;
+}
+
+/* The stored value is larger than the maximum size. */
+TEST(formatDatabaseGetPageSize, tooLarge, NULL, NULL, 0, NULL)
+{
+	uint8_t header[FORMAT__DB_HDR_SIZE];
+	unsigned page_size;
+
+	header[16] = 0xff;
+	header[17] = 0xff;
+
+	formatDatabaseGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 0);
+
+	return MUNIT_OK;
+}
+
+/* The stored value is not a power of 2. */
+TEST(formatDatabaseGetPageSize, notPowerOf2, NULL, NULL, 0, NULL)
+{
+	uint8_t header[FORMAT__DB_HDR_SIZE];
+	unsigned page_size;
+
+	header[16] = 6;
+	header[17] = 12;
+
+	formatDatabaseGetPageSize(header, &page_size);
+	munit_assert_int(page_size, ==, 0);
 
 	return MUNIT_OK;
 }

--- a/test/unit/test_replication.c
+++ b/test/unit/test_replication.c
@@ -106,22 +106,22 @@ TEST_MODULE(replication);
  ******************************************************************************/
 
 /* Assert the number of pages in the WAL file on the I'th node. */
-#define ASSERT_WAL_PAGES(I, N)                                           \
-	{                                                                \
-		struct leader *leader_ = &f->leaders[I];                 \
-		sqlite3_file *file_;                                     \
-		sqlite_int64 size_;                                      \
-		int pages_;                                              \
-		int rv_;                                                 \
-		rv_ = sqlite3_file_control(leader_->conn, "main",        \
-					   SQLITE_FCNTL_JOURNAL_POINTER, \
-					   &file_);                      \
-		munit_assert_int(rv_, ==, 0);                            \
-		rv_ = file_->pMethods->xFileSize(file_, &size_);         \
-		munit_assert_int(rv_, ==, 0);                            \
-		pages_ = format__wal_calc_pages(                         \
-		    leader_->db->config->page_size, size_);              \
-		munit_assert_int(pages_, ==, N);                         \
+#define ASSERT_WAL_PAGES(I, N)                                                 \
+	{                                                                      \
+		struct leader *leader_ = &f->leaders[I];                       \
+		sqlite3_file *file_;                                           \
+		sqlite_int64 size_;                                            \
+		int pages_;                                                    \
+		int rv_;                                                       \
+		rv_ = sqlite3_file_control(leader_->conn, "main",              \
+					   SQLITE_FCNTL_JOURNAL_POINTER,       \
+					   &file_);                            \
+		munit_assert_int(rv_, ==, 0);                                  \
+		rv_ = file_->pMethods->xFileSize(file_, &size_);               \
+		munit_assert_int(rv_, ==, 0);                                  \
+		pages_ =                                                       \
+		    formatWalCalcPages(leader_->db->config->page_size, size_); \
+		munit_assert_int(pages_, ==, N);                               \
 	}
 
 /******************************************************************************
@@ -290,7 +290,8 @@ TEST_CASE(exec, checkpoint_read_lock, NULL)
 	rv = sqlite3_exec(leader2.conn, "BEGIN", NULL, NULL, &errmsg);
 	munit_assert_int(rv, ==, 0);
 
-	rv = sqlite3_exec(leader2.conn, "SELECT * FROM test", NULL, NULL, &errmsg);
+	rv = sqlite3_exec(leader2.conn, "SELECT * FROM test", NULL, NULL,
+			  &errmsg);
 	munit_assert_int(rv, ==, 0);
 
 	EXEC_SQL(0, "INSERT INTO test(n) VALUES(1)");

--- a/test/unit/test_replication.c
+++ b/test/unit/test_replication.c
@@ -106,22 +106,22 @@ TEST_MODULE(replication);
  ******************************************************************************/
 
 /* Assert the number of pages in the WAL file on the I'th node. */
-#define ASSERT_WAL_PAGES(I, N)                                                 \
-	{                                                                      \
-		struct leader *leader_ = &f->leaders[I];                       \
-		sqlite3_file *file_;                                           \
-		sqlite_int64 size_;                                            \
-		int pages_;                                                    \
-		int rv_;                                                       \
-		rv_ = sqlite3_file_control(leader_->conn, "main",              \
-					   SQLITE_FCNTL_JOURNAL_POINTER,       \
-					   &file_);                            \
-		munit_assert_int(rv_, ==, 0);                                  \
-		rv_ = file_->pMethods->xFileSize(file_, &size_);               \
-		munit_assert_int(rv_, ==, 0);                                  \
-		pages_ =                                                       \
-		    formatWalCalcPages(leader_->db->config->page_size, size_); \
-		munit_assert_int(pages_, ==, N);                               \
+#define ASSERT_WAL_PAGES(I, N)                                           \
+	{                                                                \
+		struct leader *leader_ = &f->leaders[I];                 \
+		sqlite3_file *file_;                                     \
+		sqlite_int64 size_;                                      \
+		int pages_;                                              \
+		int rv_;                                                 \
+		rv_ = sqlite3_file_control(leader_->conn, "main",        \
+					   SQLITE_FCNTL_JOURNAL_POINTER, \
+					   &file_);                      \
+		munit_assert_int(rv_, ==, 0);                            \
+		rv_ = file_->pMethods->xFileSize(file_, &size_);         \
+		munit_assert_int(rv_, ==, 0);                            \
+		pages_ = formatWalCalcFramesNumber(                      \
+		    leader_->db->config->page_size, size_);              \
+		munit_assert_int(pages_, ==, N);                         \
 	}
 
 /******************************************************************************

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1848,7 +1848,7 @@ TEST(VfsIntegration, checkpoint, setUp, tearDown, 0, NULL)
 
 	/* The WAL file has now 13 pages */
 	rv = file2->pMethods->xFileSize(file2, &size);
-	munit_assert_int(formatWalCalcPages(512, size), ==, 13);
+	munit_assert_int(formatWalCalcFramesNumber(512, size), ==, 13);
 
 	mx_frame = __wal_idx_mx_frame(db1);
 	munit_assert_int(mx_frame, ==, 13);

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1323,7 +1323,7 @@ TEST(VfsShmMap, oom, setUp, tearDown, 0, test_shm_map_oom_params)
 
 	test_heap_fault_enable();
 
-	rc = file->pMethods->xShmMap(file, 0, 512, 1, &region);
+	rc = file->pMethods->xShmMap(file, 0, 32768, 1, &region);
 	munit_assert_int(rc, ==, SQLITE_NOMEM);
 
 	free(file);
@@ -1355,7 +1355,7 @@ TEST(VfsShmLock, sharedBusy, setUp, tearDown, 0, NULL)
 	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 	munit_assert_int(rc, ==, 0);
 
-	rc = file->pMethods->xShmMap(file, 0, 512, 1, &region);
+	rc = file->pMethods->xShmMap(file, 0, 32768, 1, &region);
 	munit_assert_int(rc, ==, 0);
 
 	/* Take an exclusive lock on a range. */
@@ -1389,7 +1389,7 @@ TEST(VfsShmLock, exclBusy, setUp, tearDown, 0, NULL)
 	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 	munit_assert_int(rc, ==, 0);
 
-	rc = file->pMethods->xShmMap(file, 0, 512, 1, &region);
+	rc = file->pMethods->xShmMap(file, 0, 32768, 1, &region);
 	munit_assert_int(rc, ==, 0);
 
 	/* Take a shared lock on index 3. */
@@ -1438,7 +1438,7 @@ TEST(VfsShmLock, releaseUnix, setUp, tearDown, 0, NULL)
 	rc = vfs->xOpen(vfs, path, file, flags, &flags);
 	munit_assert_int(rc, ==, 0);
 
-	rc = file->pMethods->xShmMap(file, 0, 4096, 1, &region);
+	rc = file->pMethods->xShmMap(file, 0, 32768, 1, &region);
 	munit_assert_int(rc, ==, 0);
 
 	flags = SQLITE_SHM_UNLOCK | SQLITE_SHM_EXCLUSIVE;
@@ -1479,7 +1479,7 @@ TEST(VfsShmLock, release, setUp, tearDown, 0, NULL)
 	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
 	munit_assert_int(rc, ==, 0);
 
-	rc = file->pMethods->xShmMap(file, 0, 512, 1, &region);
+	rc = file->pMethods->xShmMap(file, 0, 32768, 1, &region);
 	munit_assert_int(rc, ==, 0);
 
 	flags = SQLITE_SHM_UNLOCK | SQLITE_SHM_SHARED;

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -195,7 +195,7 @@ static uint32_t __wal_idx_mx_frame(sqlite3 *db)
 	rc = file->pMethods->xShmMap(file, 0, 0, 0, &region);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
-	format__get_mx_frame((const uint8_t *)region, &mx_frame);
+	formatWalGetMxFrame((const uint8_t *)region, &mx_frame);
 
 	return mx_frame;
 }
@@ -217,7 +217,7 @@ static uint32_t *__wal_idx_read_marks(sqlite3 *db)
 	rc = file->pMethods->xShmMap(file, 0, 0, 0, &region);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
-	format__get_read_marks((const uint8_t *)region, marks);
+	formatWalGetReadMarks((const uint8_t *)region, marks);
 
 	return marks;
 }
@@ -1848,7 +1848,7 @@ TEST(VfsIntegration, checkpoint, setUp, tearDown, 0, NULL)
 
 	/* The WAL file has now 13 pages */
 	rv = file2->pMethods->xFileSize(file2, &size);
-	munit_assert_int(format__wal_calc_pages(512, size), ==, 13);
+	munit_assert_int(formatWalCalcPages(512, size), ==, 13);
 
 	mx_frame = __wal_idx_mx_frame(db1);
 	munit_assert_int(mx_frame, ==, 13);


### PR DESCRIPTION
This branch adds the initial implementation of the `dqlite_vfs_poll()` and `dqlite_vfs_commit()` APIs that can be used to replicate the write-ahead log without needing to patch SQLite and introduce custom hooks.

Existing behavior for current users is unchanged, since these new APIs apply only to the "V2" version of the custom dqlite VFS, which is not used by default. Actual use of this functionality will happen later down the road when we start switching the core engine to it.