### PR TITLE
fix: do not free munit allocations with sqlite3_free

### DIFF
--- a/test/integration/test_vfs.c
+++ b/test/integration/test_vfs.c
@@ -178,8 +178,8 @@ static void tearDown(void *data)
 /* Release all memory used by a struct tx object. */
 #define DONE(TX)                               \
 	do {                                   \
-		sqlite3_free(TX.frames);       \
-		sqlite3_free(TX.page_numbers); \
+		free(TX.frames);       \
+		free(TX.page_numbers); \
 	} while (0)
 
 /* Open and close a new connection using the dqlite VFS. */


### PR DESCRIPTION
==199893==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x619000004178 in thread T0
    #0 0x7fd51bdab7cf in __interceptor_free (/lib/x86_64-linux-gnu/libasan.so.5+0x10d7cf)
    #1 0x56243f445145 in mem_fault_free test/lib/heap.c:57
    #2 0x7fd51bb8b70e in sqlite3_free sqlite3.c:28007
    #3 0x7fd51bb8b70e in sqlite3_free sqlite3.c:27999
    #4 0x56243f43a95e in test_vfs_pollAfterWriteTransaction test/integration/test_vfs.c:238
    #5 0x56243f44a1a9 in munit_test_runner_exec test/lib/munit.c:1195
    #6 0x56243f44b198 in munit_test_runner_run_test_with_params test/lib/munit.c:1357
    #7 0x56243f44d81c in munit_test_runner_run_test test/lib/munit.c:1585
    #8 0x56243f44e917 in munit_test_runner_run_suite test/lib/munit.c:1678
    #9 0x56243f44eaf1 in munit_test_runner_run_suite test/lib/munit.c:1687
    #10 0x56243f44ecb8 in munit_test_runner_run test/lib/munit.c:1697
    #11 0x56243f45253d in munit_suite_main_custom test/lib/munit.c:2027
    #12 0x56243f452bac in munit_suite_main test/lib/munit.c:2055
    #13 0x56243f444f0d in main test/integration/main.c:3
    #14 0x7fd51b88b0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #15 0x56243f4322fd in _start (/home/mjeanson/Git/lxc/dqlite/integration-test+0x142fd)

0x619000004178 is located 8 bytes to the left of 1024-byte region [0x619000004180,0x619000004580)
allocated by thread T0 here:
    #0 0x7fd51bdabdc6 in calloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10ddc6)
    #1 0x56243f4471d6 in munit_malloc_ex test/lib/munit.c:280
    #2 0x56243f43a39f in test_vfs_pollAfterWriteTransaction test/integration/test_vfs.c:230
    #3 0x56243f44a1a9 in munit_test_runner_exec test/lib/munit.c:1195
    #4 0x56243f44b198 in munit_test_runner_run_test_with_params test/lib/munit.c:1357
    #5 0x56243f44d81c in munit_test_runner_run_test test/lib/munit.c:1585
    #6 0x56243f44e917 in munit_test_runner_run_suite test/lib/munit.c:1678
    #7 0x56243f44eaf1 in munit_test_runner_run_suite test/lib/munit.c:1687
    #8 0x56243f44ecb8 in munit_test_runner_run test/lib/munit.c:1697
    #9 0x56243f45253d in munit_suite_main_custom test/lib/munit.c:2027
    #10 0x56243f452bac in munit_suite_main test/lib/munit.c:2055
    #11 0x56243f444f0d in main test/integration/main.c:3
    #12 0x7fd51b88b0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

SUMMARY: AddressSanitizer: bad-free (/lib/x86_64-linux-gnu/libasan.so.5+0x10d7cf) in __interceptor_free

Signed-off-by: Michael Jeanson <mjeanson@debian.org>