### PR TITLE
Fix flaky tests

### DIFF
--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -43,19 +43,6 @@
 
 /******************************************************************************
  *
- * Common parameters.
- *
- ******************************************************************************/
-
-/* Run the test using only TCP. */
-char *socket_family[] = {"tcp", NULL};
-static MunitParameterEnum endpointParams[] = {
-    {TEST_ENDPOINT_FAMILY, socket_family},
-    {NULL, NULL},
-};
-
-/******************************************************************************
- *
  * Helper macros.
  *
  ******************************************************************************/
@@ -159,7 +146,7 @@ static void tearDown(void *data)
 	free(f);
 }
 
-TEST(membership, join, setUp, tearDown, 0, endpointParams)
+TEST(membership, join, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
 	unsigned id = 2;
@@ -167,7 +154,7 @@ TEST(membership, join, setUp, tearDown, 0, endpointParams)
 	unsigned stmt_id;
 	unsigned last_insert_id;
 	unsigned rows_affected;
-	(void)params;
+
 	HANDSHAKE;
 	ADD(id, address);
 	ASSIGN(id, 1 /* voter */);

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -25,11 +25,12 @@ void test_server_setup(struct test_server *s,
 		       const unsigned id,
 		       const MunitParameter params[])
 {
+	(void)params;
+
 	s->id = id;
 	sprintf(s->address, "@%u", id);
 
 	s->dir = test_dir_setup();
-	test_endpoint_setup(&s->endpoint, params);
 
 	memset(s->others, 0, sizeof s->others);
 }
@@ -38,7 +39,6 @@ void test_server_tear_down(struct test_server *s)
 {
 	int rv;
 
-	test_endpoint_tear_down(&s->endpoint);
 	clientClose(&s->client);
 	close(s->client.fd);
 	rv = dqlite_node_stop(s->dqlite);

--- a/test/lib/server.h
+++ b/test/lib/server.h
@@ -18,7 +18,6 @@ struct test_server
 	unsigned id;                   /* Server ID. */
 	char address[8];               /* Server address. */
 	char *dir;                     /* Data directory. */
-	struct test_endpoint endpoint; /* For network connections. */
 	dqlite_node *dqlite;           /* Dqlite instance. */
 	struct client client;          /* Connected client. */
 	struct test_server *others[5]; /* Other servers, by ID-1. */

--- a/test/unit/test_conn.c
+++ b/test/unit/test_conn.c
@@ -149,7 +149,7 @@ static void connCloseCb(struct conn *conn)
 		int rv2;                                    \
 		rv2 = clientSendQuery(&f->client, STMT_ID); \
 		munit_assert_int(rv2, ==, 0);               \
-		test_uv_run(&f->loop, 1);                   \
+		test_uv_run(&f->loop, 2);                   \
 		rv2 = clientRecvRows(&f->client, ROWS);     \
 		munit_assert_int(rv2, ==, 0);               \
 	}
@@ -310,7 +310,7 @@ TEST_CASE(exec, success, NULL)
 	unsigned rows_affected;
 	(void)params;
 	PREPARE("CREATE TABLE test (n INT)", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 7);
+	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 8);
 	munit_assert_int(last_insert_id, ==, 0);
 	munit_assert_int(rows_affected, ==, 0);
 	return MUNIT_OK;
@@ -323,13 +323,13 @@ TEST_CASE(exec, result, NULL)
 	unsigned rows_affected;
 	(void)params;
 	PREPARE("BEGIN", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 1);
+	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 2);
 	PREPARE("CREATE TABLE test (n INT)", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 4);
+	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 5);
 	PREPARE("INSERT INTO test (n) VALUES(123)", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 1);
+	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 2);
 	PREPARE("COMMIT", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 4);
+	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 5);
 	munit_assert_int(last_insert_id, ==, 1);
 	munit_assert_int(rows_affected, ==, 1);
 	return MUNIT_OK;


### PR DESCRIPTION
This fixes running in tests in parallel, as reported by @mjeanson in [this comment](https://github.com/canonical/dqlite/pull/247#discussion_r464621189).