### PR TITLE
Add dqlite_vfs_abort() to cancel pending transaction

### DIFF
--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -241,4 +241,12 @@ int dqlite_vfs_commit(sqlite3_vfs *vfs,
 		      unsigned long *page_numbers,
 		      void *frames);
 
+/**
+ * Abort a pending write transaction that was returned by dqlite_vfs_poll().
+ *
+ * This should be called if the transaction could not be safely replicated. In
+ * particular it will release the write lock acquired by dqlite_vfs_poll().
+ */
+int dqlite_vfs_abort(sqlite3_vfs *vfs, const char *filename);
+
 #endif /* DQLITE_H */

--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -210,8 +210,8 @@ void dqlite_vfs_close(sqlite3_vfs *vfs);
  */
 struct dqlite_vfs_frame
 {
-	unsigned page_number; /* Database page number. */
-	void *data;           /* Content of the database page. */
+	unsigned long page_number; /* Database page number. */
+	void *data;                /* Content of the database page. */
 };
 typedef struct dqlite_vfs_frame dqlite_vfs_frame;
 
@@ -238,7 +238,7 @@ int dqlite_vfs_poll(sqlite3_vfs *vfs,
 int dqlite_vfs_commit(sqlite3_vfs *vfs,
 		      const char *filename,
 		      unsigned n,
-		      unsigned *page_numbers,
+		      unsigned long *page_numbers,
 		      void *frames);
 
 #endif /* DQLITE_H */

--- a/src/dqlite.c
+++ b/src/dqlite.c
@@ -28,3 +28,7 @@ int dqlite_vfs_commit(sqlite3_vfs *vfs,
 {
 	return VfsCommit(vfs, filename, n, page_numbers, frames);
 }
+
+int dqlite_vfs_abort(sqlite3_vfs *vfs, const char *filename) {
+	return VfsAbort(vfs, filename);
+}

--- a/src/dqlite.c
+++ b/src/dqlite.c
@@ -23,9 +23,8 @@ int dqlite_vfs_poll(sqlite3_vfs *vfs,
 int dqlite_vfs_commit(sqlite3_vfs *vfs,
 		      const char *filename,
 		      unsigned n,
-		      unsigned *page_numbers,
+		      unsigned long *page_numbers,
 		      void *frames)
 {
 	return VfsCommit(vfs, filename, n, page_numbers, frames);
 }
-

--- a/src/format.c
+++ b/src/format.c
@@ -18,6 +18,8 @@
  * little-endian words. */
 #define FORMAT__WAL_MAGIC 0x377f0682
 
+#define FORMAT__WAL_MAX_VERSION 3007000
+
 static void formatGet32(const uint8_t buf[4], uint32_t *v)
 {
 	*v = 0;
@@ -184,6 +186,19 @@ static void formatWalChecksumBytes(
 
 	out[0] = s1;
 	out[1] = s2;
+}
+
+void formatWalInitHeader(uint8_t *header, unsigned page_size)
+{
+	uint32_t checksum[2] = {0, 0};
+	formatPut32(FORMAT__WAL_MAGIC, &header[0]);
+	formatPut32(FORMAT__WAL_MAX_VERSION, &header[4]);
+	formatPut32(page_size, &header[8]);
+	formatPut32(0, &header[12]);
+	sqlite3_randomness(8, &header[16]);
+	formatWalChecksumBytes(true, header, 24, checksum, checksum);
+	formatPut32(checksum[0], header + 24);
+	formatPut32(checksum[1], header + 28);
 }
 
 void formatWalPutFrameHeader(bool native,

--- a/src/format.c
+++ b/src/format.c
@@ -105,13 +105,11 @@ void formatWalGetReadMarks(const uint8_t *header,
 	memcpy(read_marks, &idx[25], (sizeof *idx) * FORMAT__WAL_NREADER);
 }
 
-void formatWalGetFramePageNumber(const uint8_t *header, unsigned *page_number)
+void formatWalGetFramePageNumber(const uint8_t *header, uint32_t *page_number)
 {
 	/* The page number is stored in the first 4 bytes of the header
 	 * (big-endian) */
-	uint32_t v;
-	formatGet32(header, &v);
-	*page_number = v;
+	formatGet32(header, page_number);
 }
 
 void formatWalGetFrameChecksums(const uint8_t *header, uint32_t checksum[2])
@@ -189,19 +187,19 @@ static void formatWalChecksumBytes(
 }
 
 void formatWalPutFrameHeader(bool native,
-			     unsigned page_number,
-			     unsigned database_size,
+			     uint32_t page_number,
+			     uint32_t database_size,
 			     uint32_t salt[2],
 			     uint32_t checksum[2],
 			     uint8_t *header,
-			     uint8_t *page,
-			     unsigned page_size)
+			     uint8_t *data,
+			     unsigned n_data)
 {
 	formatPut32(page_number, header);
 	formatPut32(database_size, header + 4);
 
 	formatWalChecksumBytes(native, header, 8, checksum, checksum);
-	formatWalChecksumBytes(native, page, page_size, checksum, checksum);
+	formatWalChecksumBytes(native, data, n_data, checksum, checksum);
 
 	memcpy(header + 8, &salt[0], sizeof salt[0]);
 	memcpy(header + 12, &salt[1], sizeof salt[1]);
@@ -211,8 +209,8 @@ void formatWalPutFrameHeader(bool native,
 }
 
 void formatWalPutIndexHeader(uint8_t *header,
-			     unsigned max_frame,
-			     unsigned n_pages,
+			     uint32_t max_frame,
+			     uint32_t n_pages,
 			     unsigned frame_checksum[2])
 {
 	uint32_t checksum[2] = {0, 0};

--- a/src/format.h
+++ b/src/format.h
@@ -95,6 +95,9 @@ void formatWalGetFrameChecksums(const uint8_t *header, uint32_t checksum[2]);
  * checksums, or false if bit-endian byte order should be used instead. */
 void formatWalGetNativeChecksum(const uint8_t *header, bool *native);
 
+/* Initialize the header of a new WAL file. */
+void formatWalInitHeader(uint8_t *header, unsigned page_size);
+
 /* Encode a frame header and return the calculated checksums. */
 void formatWalPutFrameHeader(bool native,
 			     uint32_t page_number,

--- a/src/format.h
+++ b/src/format.h
@@ -81,12 +81,12 @@ void formatWalGetReadMarks(const uint8_t *header,
 
 /* Overwrite the WAL index header. */
 void formatWalPutIndexHeader(uint8_t *header,
-			     unsigned max_frame,
-			     unsigned n_pages,
+			     uint32_t max_frame,
+			     uint32_t n_pages,
 			     uint32_t frame_checksum[2]);
 
 /* Extract the page number from a WAL frame header. */
-void formatWalGetFramePageNumber(const uint8_t *header, unsigned *page_number);
+void formatWalGetFramePageNumber(const uint8_t *header, uint32_t *page_number);
 
 /* Extract the checksums from a WAL frame header. */
 void formatWalGetFrameChecksums(const uint8_t *header, uint32_t checksum[2]);
@@ -97,8 +97,8 @@ void formatWalGetNativeChecksum(const uint8_t *header, bool *native);
 
 /* Encode a frame header and return the calculated checksums. */
 void formatWalPutFrameHeader(bool native,
-			     unsigned page_number,
-			     unsigned database_size,
+			     uint32_t page_number,
+			     uint32_t database_size,
 			     uint32_t salt[2],
 			     uint32_t checksum[2],
 			     uint8_t *header,

--- a/src/format.h
+++ b/src/format.h
@@ -65,14 +65,10 @@ void formatDatabaseGetPageSize(const uint8_t *header, unsigned *page_size);
 void formatWalGetPageSize(const uint8_t *header, unsigned *page_size);
 
 /* Get checksums from the WAL header. */
-void formatWalGetChecksums(const uint8_t *header,
-			   unsigned *checksum1,
-			   unsigned *checksum2);
+void formatWalGetChecksums(const uint8_t *header, uint32_t checksum[2]);
 
 /* Get the Salt-1 and Salt-2 fields stored in the WAL header. */
-void formatWalGetSalt(const uint8_t *header, unsigned *salt1, unsigned *salt2);
-
-void formatWalGetFramePageNumber(const uint8_t *header, unsigned *page_number);
+void formatWalGetSalt(const uint8_t *header, uint32_t salt[2]);
 
 /* Extract the mxFrame field from the WAL index header stored in the given
  * buffer */
@@ -83,20 +79,17 @@ void formatWalGetMxFrame(const uint8_t *header, uint32_t *mx_frame);
 void formatWalGetReadMarks(const uint8_t *header,
 			   uint32_t read_marks[FORMAT__WAL_NREADER]);
 
-/* Revert the WAL index header as it was before a write transaction. */
-void formatWalIndexHeaderRevert(uint8_t *header,
-				unsigned max_frame,
-				unsigned n_pages,
-				unsigned frame_checksum1,
-				unsigned frame_checksum2);
+/* Overwrite the WAL index header. */
+void formatWalPutIndexHeader(uint8_t *header,
+			     unsigned max_frame,
+			     unsigned n_pages,
+			     uint32_t frame_checksum[2]);
 
 /* Extract the page number from a WAL frame header. */
 void formatWalGetFramePageNumber(const uint8_t *header, unsigned *page_number);
 
 /* Extract the checksums from a WAL frame header. */
-void formatWalGetFrameChecksums(const uint8_t *header,
-				unsigned *checksum1,
-				unsigned *checksum2);
+void formatWalGetFrameChecksums(const uint8_t *header, uint32_t checksum[2]);
 
 /* Return true if native byte order should be used when calculating WAL
  * checksums, or false if bit-endian byte order should be used instead. */
@@ -106,10 +99,8 @@ void formatWalGetNativeChecksum(const uint8_t *header, bool *native);
 void formatWalPutFrameHeader(bool native,
 			     unsigned page_number,
 			     unsigned database_size,
-			     unsigned salt1,
-			     unsigned salt2,
-			     unsigned *checksum1,
-			     unsigned *checksum2,
+			     uint32_t salt[2],
+			     uint32_t checksum[2],
 			     uint8_t *header,
 			     uint8_t *data,
 			     unsigned n_data);

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -2035,6 +2035,22 @@ int VfsCommit(sqlite3_vfs *vfs,
 	return 0;
 }
 
+int VfsAbort(sqlite3_vfs *vfs, const char *filename) {
+	struct vfs *v;
+	struct vfsDatabase *database;
+	int rv;
+
+	v = (struct vfs *)(vfs->pAppData);
+	database = vfsDatabaseLookup(v, filename);
+
+	rv = vfsShmUnlock(&database->shm, 0, 1, SQLITE_SHM_EXCLUSIVE);
+	if (rv != 0) {
+		return rv;
+	}
+
+	return 0;
+}
+
 /* Check if the given filename is a WAL filename. */
 static bool vfsIsWalFilename(const char *filename)
 {

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -63,7 +63,7 @@ struct vfsWal
 	int version;
 };
 
-enum vfsContentType {
+enum vfsFileType {
 	VFS__DATABASE, /* Main database file */
 	VFS__JOURNAL,  /* Default SQLite journal file */
 	VFS__WAL       /* Write-Ahead Log */
@@ -72,9 +72,9 @@ enum vfsContentType {
 /* Hold content for a single file in the custom dqlite VFS. */
 struct vfsContent
 {
-	char *filename;           /* Name of the file. */
-	enum vfsContentType type; /* Content type (either main db or WAL). */
-	unsigned refcount;        /* N. of files referencing this content. */
+	char *filename;        /* Name of the file. */
+	enum vfsFileType type; /* Content type (either main db or WAL). */
+	unsigned refcount;     /* N. of files referencing this content. */
 	union {
 		struct vfsDatabase database; /* VFS__DATABASE */
 		struct vfsWal wal;           /* VFS__WAL */
@@ -1563,7 +1563,7 @@ static int vfsOpen(sqlite3_vfs *vfs,
 	struct vfs *v;
 	struct vfsFile *f;
 	struct vfsContent *content;
-	enum vfsContentType type;
+	enum vfsFileType type;
 	bool exists;
 	int exclusive = flags & SQLITE_OPEN_EXCLUSIVE;
 	int create = flags & SQLITE_OPEN_CREATE;

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1118,12 +1118,10 @@ static int vfsFileSize(sqlite3_file *file, sqlite_int64 *size)
 		case VFS__WAL:
 			/* TODO? here we assume that FileSize() is never invoked
 			 * between a header write and a page write. */
-			*size = (f->database->wal.n_frames *
+			*size = FORMAT__WAL_HDR_SIZE;
+			*size += (f->database->wal.n_frames *
 				 (FORMAT__WAL_FRAME_HDR_SIZE +
 				  f->database->page_size));
-			if (*size > 0) {
-				*size += FORMAT__WAL_HDR_SIZE;
-			}
 			break;
 	}
 
@@ -1205,6 +1203,7 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fnctl)
 			fnctl[0] = "only WAL mode is supported";
 			return SQLITE_IOERR;
 		}
+		formatWalInitHeader(f->database->wal.hdr, f->database->page_size);
 	}
 
 	/* We're returning NOTFOUND here to tell SQLite that we wish it to go on

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -36,6 +36,7 @@ struct vfsWal;
 /* Database-specific content */
 struct vfsDatabase
 {
+	char *name;         /* Database name. */
 	unsigned page_size; /* Page size of each page. */
 	void **pages;       /* All database. */
 	unsigned n_pages;   /* Number of pages. */
@@ -760,8 +761,8 @@ static int vfsFileClose(sqlite3_file *file)
 	f->content->refcount--;
 
 	/* If we got zero references, reset the shared memory mapping. */
-	if (f->content->refcount == 0 && f->content->type == VFS__DATABASE) {
-		vfsShmReset(&f->content->database.shm);
+	if (f->content->refcount == 0 && f->type == VFS__DATABASE) {
+		vfsShmReset(&f->database->shm);
 	}
 
 	if (f->flags & SQLITE_OPEN_DELETEONCLOSE) {

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -40,6 +40,8 @@ int VfsCommit(sqlite3_vfs *vfs,
 	      unsigned long *page_numbers,
 	      void *frames);
 
+int VfsAbort(sqlite3_vfs *vfs, const char *filename);
+
 /* Read the content of a file, using the VFS implementation registered under the
  * given name. Used to take database snapshots using the dqlite in-memory
  * VFS. */

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -37,7 +37,7 @@ int VfsPoll(sqlite3_vfs *vfs,
 int VfsCommit(sqlite3_vfs *vfs,
 	      const char *filename,
 	      unsigned n,
-	      unsigned *page_numbers,
+	      unsigned long *page_numbers,
 	      void *frames);
 
 /* Read the content of a file, using the VFS implementation registered under the

--- a/test/integration/test_vfs.c
+++ b/test/integration/test_vfs.c
@@ -14,7 +14,7 @@ SUITE(vfs);
 struct tx
 {
 	unsigned n;
-	unsigned *page_numbers;
+	unsigned long *page_numbers;
 	void *frames;
 };
 

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -398,7 +398,7 @@ TEST(VfsOpen, noPageSize, setUp, tearDown, 0, NULL)
 	struct fixture *f = data;
 	sqlite3 *db;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
-	int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
+	int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
 	sqlite3_int64 size;
 	int rc;
 	(void)params;
@@ -415,14 +415,16 @@ TEST(VfsOpen, noPageSize, setUp, tearDown, 0, NULL)
 	rc = sqlite3_exec(db, "CREATE TABLE foo (n INT)", NULL, NULL, NULL);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
-	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
+	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags | SQLITE_OPEN_MAIN_DB,
+			  &flags);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
 	rc = file->pMethods->xFileSize(file, &size);
 	munit_assert_int(rc, ==, 0);
 	munit_assert_int(size, ==, 4096);
 
-	rc = f->vfs.xOpen(&f->vfs, "test.db-wal", file, flags, &flags);
+	rc = f->vfs.xOpen(&f->vfs, "test.db-wal", file, flags | SQLITE_OPEN_WAL,
+			  &flags);
 	munit_assert_int(rc, ==, SQLITE_OK);
 
 	rc = file->pMethods->xFileSize(file, &size);

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1203,6 +1203,7 @@ TEST(VfsTruncate, wal, setUp, tearDown, 0, NULL)
 TEST(VfsTruncate, unexpected, setUp, tearDown, 0, NULL)
 {
 	struct fixture *f = data;
+	sqlite3_file *main = __file_create_main_db(&f->vfs);
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
 	int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_JOURNAL;
 	char buf[32];
@@ -1223,6 +1224,7 @@ TEST(VfsTruncate, unexpected, setUp, tearDown, 0, NULL)
 	munit_assert_int(rc, ==, SQLITE_IOERR_TRUNCATE);
 
 	free(file);
+	free(main);
 
 	return MUNIT_OK;
 }

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1136,19 +1136,10 @@ TEST(VfsTruncate, wal, setUp, tearDown, 0, NULL)
 	rc = file1->pMethods->xWrite(file1, buf_header_main, 100, 0);
 	munit_assert_int(rc, ==, 0);
 
-	/* Initial size of the WAL file is 0. */
+	/* Initial size of the WAL file is equal to the header length. */
 	rc = file2->pMethods->xFileSize(file2, &size);
 	munit_assert_int(rc, ==, 0);
-	munit_assert_int(size, ==, 0);
-
-	/* Truncating an empty WAL file is a no-op. */
-	rc = file2->pMethods->xTruncate(file2, 0);
-	munit_assert_int(rc, ==, 0);
-
-	/* The size is still 0. */
-	rc = file2->pMethods->xFileSize(file2, &size);
-	munit_assert_int(rc, ==, 0);
-	munit_assert_int(size, ==, 0);
+	munit_assert_int(size, ==, 32);
 
 	/* Write the WAL header. */
 	rc = file2->pMethods->xWrite(file2, buf_header_wal, 32, 0);
@@ -1181,10 +1172,10 @@ TEST(VfsTruncate, wal, setUp, tearDown, 0, NULL)
 	rc = file2->pMethods->xTruncate(file2, 0);
 	munit_assert_int(rc, ==, 0);
 
-	/* The size is 0. */
+	/* The size is equal to the header size. */
 	rc = file2->pMethods->xFileSize(file2, &size);
 	munit_assert_int(rc, ==, 0);
-	munit_assert_int(size, ==, 0);
+	munit_assert_int(size, ==, 32);
 
 	free(buf_header_wal_frame_2);
 	free(buf_header_wal_frame_1);

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -398,7 +398,7 @@ TEST(VfsOpen, noPageSize, setUp, tearDown, 0, NULL)
 	struct fixture *f = data;
 	sqlite3 *db;
 	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
-	int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+	int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
 	sqlite3_int64 size;
 	int rc;
 	(void)params;


### PR DESCRIPTION
The new `dqlite_vfs_abort()` API can be used to cancel pending write transactions that could not be safely replicated.

Also, the WAL header gets now generated immediately when a `PRAGMA journal=WAL` statement is issued, allowing a "follower" VFS to accept replication changes via `dqlite_vfs_commit()` even when the database is empty.

In addition to that, the `struct vfsContent` indirection between `sqlite3_file` and `struct vfsDatabase` has been removed, simplifying a bit the data layout.