### PR TITLE
vfs: Return 0 as size of the WAL file if there are no frames

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1119,10 +1119,13 @@ static int vfsFileSize(sqlite3_file *file, sqlite_int64 *size)
 		case VFS__WAL:
 			/* TODO? here we assume that FileSize() is never invoked
 			 * between a header write and a page write. */
-			*size = FORMAT__WAL_HDR_SIZE;
-			*size += (f->database->wal.n_frames *
-				  (FORMAT__WAL_FRAME_HDR_SIZE +
-				   f->database->page_size));
+			*size = 0;
+			if (f->database->wal.n_frames > 0) {
+				*size += FORMAT__WAL_HDR_SIZE;
+				*size += (f->database->wal.n_frames *
+					  (FORMAT__WAL_FRAME_HDR_SIZE +
+					   f->database->page_size));
+			}
 			break;
 	}
 

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1136,10 +1136,10 @@ TEST(VfsTruncate, wal, setUp, tearDown, 0, NULL)
 	rc = file1->pMethods->xWrite(file1, buf_header_main, 100, 0);
 	munit_assert_int(rc, ==, 0);
 
-	/* Initial size of the WAL file is equal to the header length. */
+	/* Initial size of the WAL file is zero. */
 	rc = file2->pMethods->xFileSize(file2, &size);
 	munit_assert_int(rc, ==, 0);
-	munit_assert_int(size, ==, 32);
+	munit_assert_int(size, ==, 0);
 
 	/* Write the WAL header. */
 	rc = file2->pMethods->xWrite(file2, buf_header_wal, 32, 0);
@@ -1172,10 +1172,10 @@ TEST(VfsTruncate, wal, setUp, tearDown, 0, NULL)
 	rc = file2->pMethods->xTruncate(file2, 0);
 	munit_assert_int(rc, ==, 0);
 
-	/* The size is equal to the header size. */
+	/* The size is zero. */
 	rc = file2->pMethods->xFileSize(file2, &size);
 	munit_assert_int(rc, ==, 0);
-	munit_assert_int(size, ==, 32);
+	munit_assert_int(size, ==, 0);
 
 	free(buf_header_wal_frame_2);
 	free(buf_header_wal_frame_1);


### PR DESCRIPTION
This had been changed to return the size of the WAL header, but it breaks
consumers.