### PR TITLE
Use VfsSnapshot() instead of VfsFileRead()

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -2158,7 +2158,8 @@ int VfsSnapshot(sqlite3_vfs *vfs, const char *filename, void **data, size_t *n)
 	wal = &database->wal;
 
 	*n = vfsDatabaseFileSize(database) + vfsWalFileSize(wal);
-	*data = sqlite3_malloc64(*n);
+	/* TODO: we should fix the tests and use sqlite3_malloc instead. */
+	*data = raft_malloc(*n);
 	if (*data == NULL) {
 		return DQLITE_NOMEM;
 	}

--- a/test/lib/heap.c
+++ b/test/lib/heap.c
@@ -190,7 +190,7 @@ void test_heap_tear_down(void *data)
 	if (malloc_count > 0 || memory_used > 0) {
 		munit_errorf(
 		    "teardown memory:\n    bytes: %11d\n    allocations: %5d\n",
-		    malloc_count, memory_used);
+		    memory_used, malloc_count);
 	}
 
 	/* Restore default memory management. */


### PR DESCRIPTION
To take raft snapshots and serve database dump requests, use the `dqlite_vfs_snapshot()` API introduced in #256, which knows more about the internal vfs data structures, instead of the older `VfsReadFile` which makes assumptions that are no longer true with the V2 vfs engine.