### PR TITLE
vfs: Drop unnecessary page_size cache from struct vfsDatabase

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -70,12 +70,6 @@ void formatWalGetPageSize(const uint8_t *header, unsigned *page_size)
 	*page_size = formatDecodePageSize(buf);
 }
 
-void formatWalGetChecksums(const uint8_t *header, uint32_t checksum[2])
-{
-	formatGet32(header + 24, &checksum[0]);
-	formatGet32(header + 28, &checksum[1]);
-}
-
 void formatWalGetSalt(const uint8_t *header, uint32_t salt[2])
 {
 	salt[0] = *(uint32_t *)(header + 16);

--- a/src/format.c
+++ b/src/format.c
@@ -87,12 +87,6 @@ void formatWalGetFrameDatabaseSize(const uint8_t *header, uint32_t *n) {
 	formatGet32(header + 4, n);
 }
 
-void formatWalGetFrameChecksums(const uint8_t *header, uint32_t checksum[2])
-{
-	formatGet32(header + 16, &checksum[0]);
-	formatGet32(header + 20, &checksum[1]);
-}
-
 void formatWalGetNativeChecksum(const uint8_t *header, bool *native)
 {
 	uint32_t magic;

--- a/src/format.c
+++ b/src/format.c
@@ -155,19 +155,6 @@ static void formatWalChecksumBytes(
 	out[1] = s2;
 }
 
-void formatWalInitHeader(uint8_t *header, unsigned page_size)
-{
-	uint32_t checksum[2] = {0, 0};
-	formatPut32(FORMAT__WAL_MAGIC, &header[0]);
-	formatPut32(FORMAT__WAL_MAX_VERSION, &header[4]);
-	formatPut32(page_size, &header[8]);
-	formatPut32(0, &header[12]);
-	sqlite3_randomness(8, &header[16]);
-	formatWalChecksumBytes(true, header, 24, checksum, checksum);
-	formatPut32(checksum[0], header + 24);
-	formatPut32(checksum[1], header + 28);
-}
-
 void formatWalRestartHeader(uint8_t *header) {
 	uint32_t checksum[2] = {0, 0};
 	uint32_t checkpoint;

--- a/src/format.h
+++ b/src/format.h
@@ -64,9 +64,6 @@ void formatDatabaseGetPageSize(const uint8_t *header, unsigned *page_size);
  * If the page size is invalid, 0 is returned. */
 void formatWalGetPageSize(const uint8_t *header, unsigned *page_size);
 
-/* Get checksums from the WAL header. */
-void formatWalGetChecksums(const uint8_t *header, uint32_t checksum[2]);
-
 /* Get the Salt-1 and Salt-2 fields stored in the WAL header. */
 void formatWalGetSalt(const uint8_t *header, uint32_t salt[2]);
 

--- a/src/format.h
+++ b/src/format.h
@@ -81,9 +81,6 @@ void formatWalGetFramePageNumber(const uint8_t *header, uint32_t *page_number);
 /* Extract from a WAL frame header the database size in pages. */
 void formatWalGetFrameDatabaseSize(const uint8_t *header, uint32_t *n);
 
-/* Extract the checksums from a WAL frame header. */
-void formatWalGetFrameChecksums(const uint8_t *header, uint32_t checksum[2]);
-
 /* Return true if native byte order should be used when calculating WAL
  * checksums, or false if bit-endian byte order should be used instead. */
 void formatWalGetNativeChecksum(const uint8_t *header, bool *native);

--- a/src/format.h
+++ b/src/format.h
@@ -85,9 +85,6 @@ void formatWalGetFrameDatabaseSize(const uint8_t *header, uint32_t *n);
  * checksums, or false if bit-endian byte order should be used instead. */
 void formatWalGetNativeChecksum(const uint8_t *header, bool *native);
 
-/* Initialize the header of a new WAL file. */
-void formatWalInitHeader(uint8_t *header, unsigned page_size);
-
 /* Restart the header of a WAL file after a checkpoint. */
 void formatWalRestartHeader(uint8_t *header);
 

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1241,20 +1241,13 @@ static void vfsWalRewriteIndexHeader(struct vfsWal *w)
 {
 	struct vfsShm *shm = &w->database->shm;
 	uint8_t *hdr = shm->regions[0];
-	unsigned i;
 	uint32_t frame_checksum[2] = {0, 0};
 	uint32_t n_pages = (uint32_t)w->database->n_pages;
 
-	for (i = 0; i < w->n_frames; i++) {
-		struct vfsFrame *frame = w->frames[i];
-		uint32_t page_number;
-		formatWalGetFramePageNumber(frame->header, &page_number);
-		if (page_number > n_pages) {
-			n_pages = page_number;
-		}
-		if (i == w->n_frames - 1) {
-			vfsFrameGetChecksum(frame, frame_checksum);
-		}
+	if (w->n_frames > 0) {
+		struct vfsFrame *last = w->frames[w->n_frames - 1];
+		vfsFrameGetChecksum(last, frame_checksum);
+		formatWalGetFrameDatabaseSize(last->header, &n_pages);
 	}
 
 	formatWalPutIndexHeader(hdr, w->n_frames, n_pages, frame_checksum);

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1690,6 +1690,8 @@ static int vfsOpen(sqlite3_vfs *vfs,
 			goto err;
 		}
 
+		assert(type == VFS__DATABASE);
+
 		/* Check the create flag. */
 		if (!create) {
 			v->error = ENOENT;

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -2046,7 +2046,7 @@ static int vfsWalAppend(struct vfsWal *w,
 			uint8_t *pages)
 {
 	struct vfsFrame **frames; /* New frames array. */
-	unsigned page_size = w->database->page_size;
+	uint32_t page_size;
 	uint32_t database_size = w->database->n_pages;
 	unsigned i;
 	unsigned j;
@@ -2056,6 +2056,9 @@ static int vfsWalAppend(struct vfsWal *w,
 
 	/* No pending transactions. */
 	assert(w->n_tx == 0);
+
+	vfsWalGetPageSize(w, &page_size);
+	assert(page_size > 0);
 
 	/* Get the salt from the WAL header. */
 	formatWalGetNativeChecksum(w->hdr, &native);

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -21,6 +21,18 @@
 /* Maximum pathname length supported by this VFS. */
 #define VFS__MAX_PATHNAME 512
 
+/* WAL magic value. Either this value, or the same value with the least
+ * significant bit also set (FORMAT__WAL_MAGIC | 0x00000001) is stored in 32-bit
+ * big-endian format in the first 4 bytes of a WAL file.
+ *
+ * If the LSB is set, then the checksums for each frame within the WAL file are
+ * calculated by treating all data as an array of 32-bit big-endian
+ * words. Otherwise, they are calculated by interpreting all data as 32-bit
+ * little-endian words. */
+#define VFS__WAL_MAGIC 0x377f0682
+
+#define VFS__WAL_MAX_VERSION 3007000
+
 /* Hold content for a shared memory mapping. */
 struct vfsShm
 {
@@ -90,6 +102,52 @@ static uint32_t vfsFlip32(uint32_t v)
 static uint32_t vfsGet32(const uint8_t buf[4])
 {
 	return vfsFlip32(*(const uint32_t *)buf);
+}
+
+/* Store a 32-bit number in big endian format */
+static void vfsPut32(uint32_t v, uint8_t *buf)
+{
+	uint32_t u = vfsFlip32(v);
+	memcpy(buf, &u, sizeof u);
+}
+
+/*
+ * Generate or extend an 8 byte checksum based on the data in array data[] and
+ * the initial values of in[0] and in[1] (or initial values of 0 and 0 if
+ * in==NULL).
+ *
+ * The checksum is written back into out[] before returning.
+ *
+ * n must be a positive multiple of 8. */
+static void vfsChecksum(
+    uint8_t *data, /* Content to be checksummed */
+    unsigned n,    /* Bytes of content in a[].  Must be a multiple of 8. */
+    const uint32_t in[2], /* Initial checksum value input */
+    uint32_t out[2]       /* OUT: Final checksum value output */
+)
+{
+	uint32_t s1, s2;
+	uint32_t *cur = (uint32_t *)data;
+	uint32_t *end = (uint32_t *)&data[n];
+
+	if (in) {
+		s1 = in[0];
+		s2 = in[1];
+	} else {
+		s1 = s2 = 0;
+	}
+
+	assert(n >= 8);
+	assert((n & 0x00000007) == 0);
+	assert(n <= 65536);
+
+	do {
+		s1 += *cur++ + s2;
+		s2 += *cur++ + s1;
+	} while (cur < end);
+
+	out[0] = s1;
+	out[1] = s2;
 }
 
 /* Create a new frame of a WAL file. */
@@ -913,6 +971,21 @@ static int vfsFileRead(sqlite3_file *file,
 	return rv;
 }
 
+static uint32_t vfsDatabaseGetPageSize(struct vfsDatabase *d)
+{
+	uint8_t *page;
+
+	assert(d->n_pages > 0);
+
+	page = d->pages[0];
+
+	/* The page size is stored in the 16th and 17th bytes of the first
+	 * database page (big-endian) */
+	uint8_t buf[4] = {0, 0, page[16], page[17]};
+
+	return vfsDecodePageSize(buf);
+}
+
 static int vfsDatabaseWrite(struct vfsDatabase *d,
 			    const void *buf,
 			    int amount,
@@ -1224,10 +1297,6 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fnctl)
 		if (strcasecmp(right, "wal") != 0) {
 			fnctl[0] = "only WAL mode is supported";
 			return SQLITE_IOERR;
-		}
-		if (f->database->wal.n_frames == 0) {
-			formatWalInitHeader(f->database->wal.hdr,
-					    f->database->page_size);
 		}
 	}
 
@@ -2124,6 +2193,21 @@ oom:
 	return DQLITE_NOMEM;
 }
 
+/* Write the header of a brand new WAL file image. */
+static void vfsWalStartHeader(struct vfsWal *w, uint32_t page_size)
+{
+	assert(page_size > 0);
+	uint32_t checksum[2] = {0, 0};
+	vfsPut32(VFS__WAL_MAGIC, &w->hdr[0]);
+	vfsPut32(VFS__WAL_MAX_VERSION, &w->hdr[4]);
+	vfsPut32(page_size, &w->hdr[8]);
+	vfsPut32(0, &w->hdr[12]);
+	sqlite3_randomness(8, &w->hdr[16]);
+	vfsChecksum(w->hdr, 24, checksum, checksum);
+	vfsPut32(checksum[0], w->hdr + 24);
+	vfsPut32(checksum[1], w->hdr + 28);
+}
+
 int VfsApply(sqlite3_vfs *vfs,
 	     const char *filename,
 	     unsigned n,
@@ -2143,6 +2227,13 @@ int VfsApply(sqlite3_vfs *vfs,
 
 	wal = &database->wal;
 	shm = &database->shm;
+
+	/* If there's no page size set in the WAL header, it must mean that WAL
+	 * file was never written. In that case we need to initialize the WAL
+	 * header. */
+	if (vfsWalGetPageSize(wal) == 0) {
+		vfsWalStartHeader(wal, vfsDatabaseGetPageSize(database));
+	}
 
 	rv = vfsWalAppend(wal, database->n_pages, n, page_numbers, frames);
 	if (rv != 0) {

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1242,7 +1242,6 @@ static void vfsWalRewriteIndexHeader(struct vfsWal *w)
 	struct vfsShm *shm = &w->database->shm;
 	uint8_t *hdr = shm->regions[0];
 	unsigned i;
-	uint32_t max_frame = 0;
 	uint32_t frame_checksum[2] = {0, 0};
 	uint32_t n_pages = (uint32_t)w->database->n_pages;
 
@@ -1253,13 +1252,12 @@ static void vfsWalRewriteIndexHeader(struct vfsWal *w)
 		if (page_number > n_pages) {
 			n_pages = page_number;
 		}
-		max_frame++;
 		if (i == w->n_frames - 1) {
 			vfsFrameGetChecksum(frame, frame_checksum);
 		}
 	}
 
-	formatWalPutIndexHeader(hdr, max_frame, n_pages, frame_checksum);
+	formatWalPutIndexHeader(hdr, w->n_frames, n_pages, frame_checksum);
 }
 
 /* The SQLITE_FCNTL_COMMIT_PHASETWO file control op code is trigged by the

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -2191,6 +2191,7 @@ static void vfsDatabaseSnapshot(struct vfsDatabase *d, uint8_t **cursor)
 
 static void vfsWalSnapshot(struct vfsWal *w, uint8_t **cursor)
 {
+	uint32_t page_size;
 	unsigned i;
 
 	if (w->n_frames == 0) {
@@ -2200,12 +2201,15 @@ static void vfsWalSnapshot(struct vfsWal *w, uint8_t **cursor)
 	memcpy(*cursor, w->hdr, FORMAT__WAL_HDR_SIZE);
 	*cursor += FORMAT__WAL_HDR_SIZE;
 
+	vfsWalGetPageSize(w, &page_size);
+	assert(page_size > 0);
+
 	for (i = 0; i < w->n_frames; i++) {
 		struct vfsFrame *frame = w->frames[i];
 		memcpy(*cursor, frame->header, FORMAT__WAL_FRAME_HDR_SIZE);
 		*cursor += FORMAT__WAL_FRAME_HDR_SIZE;
-		memcpy(*cursor, frame->page, w->database->page_size);
-		*cursor += w->database->page_size;
+		memcpy(*cursor, frame->page, page_size);
+		*cursor += page_size;
 	}
 }
 

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1135,9 +1135,10 @@ static size_t vfsWalFileSize(struct vfsWal *w)
 {
 	size_t size = 0;
 	if (w->n_frames > 0) {
+		uint32_t page_size;
+		vfsWalGetPageSize(w, &page_size);
 		size += FORMAT__WAL_HDR_SIZE;
-		size += w->n_frames *
-			(FORMAT__WAL_FRAME_HDR_SIZE + w->database->page_size);
+		size += w->n_frames * (FORMAT__WAL_FRAME_HDR_SIZE + page_size);
 	}
 	return size;
 }

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1229,6 +1229,12 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fnctl)
 	return SQLITE_NOTFOUND;
 }
 
+/* Return the checksum stored in the header of the given frame. */
+static void vfsFrameGetChecksum(struct vfsFrame *f, uint32_t checksum[2]) {
+	vfsGet32(&f->header[16], &checksum[0]);
+	vfsGet32(&f->header[20], &checksum[1]);
+}
+
 /* Overwrite the WAL index header to reflect the current committed content of
  * the WAL. */
 static void vfsWalRewriteIndexHeader(struct vfsWal *w)
@@ -1249,8 +1255,7 @@ static void vfsWalRewriteIndexHeader(struct vfsWal *w)
 		}
 		max_frame++;
 		if (i == w->n_frames - 1) {
-			formatWalGetFrameChecksums(frame->header,
-						   frame_checksum);
+			vfsFrameGetChecksum(frame, frame_checksum);
 		}
 	}
 
@@ -2045,7 +2050,7 @@ static int vfsWalAppend(struct vfsWal *w,
 		vfsWalGetChecksum(w, checksum);
 	} else {
 		struct vfsFrame *frame = w->frames[w->n_frames - 1];
-		formatWalGetFrameChecksums(frame->header, checksum);
+		vfsFrameGetChecksum(frame, checksum);
 		formatWalGetFrameDatabaseSize(frame->header, &database_size);
 	}
 

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -808,7 +808,8 @@ static int vfsWalRead(struct vfsWal *w,
 		memcpy(buf, frame->page, (size_t)amount);
 	} else {
 		memcpy(buf, frame->header, FORMAT__WAL_FRAME_HDR_SIZE);
-		memcpy(buf + FORMAT__WAL_FRAME_HDR_SIZE, frame->page, page_size);
+		memcpy(buf + FORMAT__WAL_FRAME_HDR_SIZE, frame->page,
+		       page_size);
 	}
 
 	return SQLITE_OK;
@@ -1983,7 +1984,7 @@ int VfsPoll(sqlite3_vfs *vfs,
 static int vfsWalAppend(struct vfsWal *w,
 			unsigned n,
 			unsigned long *page_numbers,
-			void *data)
+			uint8_t *pages)
 {
 	struct vfsFrame **frames; /* New frames array. */
 	unsigned page_size = w->database->page_size;
@@ -2023,7 +2024,7 @@ static int vfsWalAppend(struct vfsWal *w,
 		struct vfsFrame *frame = vfsFrameCreate(page_size);
 		uint32_t page_number = (uint32_t)page_numbers[i];
 		uint32_t commit = 0;
-		void *page = data + i * page_size;
+		uint8_t *page = &pages[i * page_size];
 
 		if (frame == NULL) {
 			goto oom_after_frames_alloc;

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -966,30 +966,6 @@ TEST(VfsWrite, oomPageBuf, setUp, tearDown, 0, NULL)
 	return MUNIT_OK;
 }
 
-/* Trying to write the second page without writing the first results in an
- * error. */
-TEST(VfsWrite, beyondFirst, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	sqlite3_file *file = __file_create_main_db(&f->vfs);
-	void *buf_page_1 = __buf_page_1();
-	char buf[512];
-	int rc;
-
-	(void)params;
-
-	memset(buf, 0, 512);
-
-	/* Write the second page, without writing the first. */
-	rc = file->pMethods->xWrite(file, buf_page_1, 512, 512);
-	munit_assert_int(rc, ==, SQLITE_IOERR_WRITE);
-
-	free(buf_page_1);
-	free(file);
-
-	return MUNIT_OK;
-}
-
 /* Trying to write two pages beyond the last one results in an error. */
 TEST(VfsWrite, beyondLast, setUp, tearDown, 0, NULL)
 {
@@ -1483,38 +1459,6 @@ TEST(VfsShmLock, release, setUp, tearDown, 0, NULL)
  ******************************************************************************/
 
 SUITE(VfsFileControl)
-
-/* Trying to set the page size to a value different than the current one
- * produces an error. */
-TEST(VfsFileControl, pageSize, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	sqlite3_file *file = __file_create_main_db(&f->vfs);
-	char *fnctl[] = {
-	    "",
-	    "page_size",
-	    "512",
-	    "",
-	};
-	int rc;
-
-	(void)params;
-	(void)data;
-
-	/* Setting the page size a first time returns NOTFOUND, which is what
-	 * SQLite effectively expects. */
-	rc = file->pMethods->xFileControl(file, SQLITE_FCNTL_PRAGMA, fnctl);
-	munit_assert_int(rc, ==, SQLITE_NOTFOUND);
-
-	/* Trying to change the page size results in an error. */
-	fnctl[2] = "1024";
-	rc = file->pMethods->xFileControl(file, SQLITE_FCNTL_PRAGMA, fnctl);
-	munit_assert_int(rc, ==, SQLITE_IOERR);
-
-	free(file);
-
-	return MUNIT_OK;
-}
 
 /* Trying to set the journal mode to anything other than "wal" produces an
  * error. */

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -563,32 +563,6 @@ TEST(VfsDelete, success, setUp, tearDown, 0, NULL)
 	return MUNIT_OK;
 }
 
-/* Attempt to delete a file with open file descriptors. */
-TEST(VfsDelete, busy, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	sqlite3_file *file = munit_malloc(f->vfs.szOsFile);
-
-	int flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
-	int rc;
-
-	(void)params;
-
-	rc = f->vfs.xOpen(&f->vfs, "test.db", file, flags, &flags);
-	munit_assert_int(rc, ==, 0);
-
-	rc = f->vfs.xDelete(&f->vfs, "test.db", 0);
-	munit_assert_int(rc, ==, SQLITE_IOERR_DELETE);
-	munit_assert_int(EBUSY, ==, f->vfs.xGetLastError(&f->vfs, 0, 0));
-
-	rc = file->pMethods->xClose(file);
-	munit_assert_int(rc, ==, 0);
-
-	free(file);
-
-	return MUNIT_OK;
-}
-
 /* Trying to delete a non-existing file results in an error. */
 TEST(VfsDelete, enoent, setUp, tearDown, 0, NULL)
 {


### PR DESCRIPTION
This branch contains a number of cleanups including some code and data structure simplifications, most importantly dropping the `vfsDatabase->page_size` cache and using directly the value stored in the header of the first database page. This avoids the possibility of the two values getting out of sync.