### PR TITLE
Don't pull the libco-dev package in the Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
     - lcov
     - libsqlite3-dev
     - libuv1-dev
-    - libco-dev
     - libraft-dev
 
   coverity_scan:

--- a/dqlite.pc.in
+++ b/dqlite.pc.in
@@ -7,5 +7,5 @@ Name: dqlite
 Description: Distributed SQLite engine
 Version:  @PACKAGE_VERSION@
 Libs: -L${libdir} -ldqlite
-Libs.private: @SQLITE_LIBS@ @UV_LIBS@ @CO_LIBS@ @RAFT_LIBS@
+Libs.private: @SQLITE_LIBS@ @UV_LIBS@ @RAFT_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Also fixes a leftover reference to `libco` in `dqlite.pc.in`.