### PR TITLE
Fixed the segfault in case raft uses direct IO backend

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -608,15 +608,16 @@ static int handle_add(struct handle *req, struct cursor *cursor)
 	}
 	r->gateway = g;
 	r->req.data = r;
+	g->req = req;
 
 	rv = raft_add(g->raft, &r->req, request.id, request.address,
 		      raftChangeCb);
 	if (rv != 0) {
+        g->req = NULL;
 		sqlite3_free(r);
 		failure(req, translateRaftErrCode(rv), raft_strerror(rv));
 		return 0;
 	}
-	g->req = req;
 
 	return 0;
 }
@@ -664,15 +665,16 @@ static int handle_assign(struct handle *req, struct cursor *cursor)
 	}
 	r->gateway = g;
 	r->req.data = r;
+	g->req = req;
 
 	rv = raft_assign(g->raft, &r->req, request.id,
 			 translateDqliteRole((int)role), raftChangeCb);
 	if (rv != 0) {
+        g->req = NULL;
 		sqlite3_free(r);
 		failure(req, translateRaftErrCode(rv), raft_strerror(rv));
 		return 0;
 	}
-	g->req = req;
 
 	return 0;
 }
@@ -693,14 +695,15 @@ static int handle_remove(struct handle *req, struct cursor *cursor)
 	}
 	r->gateway = g;
 	r->req.data = r;
+	g->req = req;
 
 	rv = raft_remove(g->raft, &r->req, request.id, raftChangeCb);
 	if (rv != 0) {
+        g->req = NULL;
 		sqlite3_free(r);
 		failure(req, translateRaftErrCode(rv), raft_strerror(rv));
 		return 0;
 	}
-	g->req = req;
 
 	return 0;
 }
@@ -934,14 +937,15 @@ static int handle_transfer(struct handle *req, struct cursor *cursor)
 		return DQLITE_NOMEM;
 	}
 	r->data = g;
+	g->req = req;
 
 	rv = raft_transfer(g->raft, r, request.id, raftTransferCb);
 	if (rv != 0) {
+        g->req = NULL;
 		sqlite3_free(r);
 		failure(req, translateRaftErrCode(rv), raft_strerror(rv));
 		return 0;
 	}
-	g->req = req;
 
 	return 0;
 }


### PR DESCRIPTION
In case RAFT uses non-async IO backend - dqlite will be unable to execute `g->req` - it will be `NULL` and cause segfault in `raftChangeCb`:`SUCCESS` callback execution.

Not sure why those lines are actually set after `raft_` func call - so moved forward and that finally allowed to work macos->macos and macos->linux nodes communication.

The other patches in series:
* canonical/go-dqlite#132
* canonical/dqlite#285
* https://github.com/canonical/dqlite/pull/290
* https://github.com/canonical/raft/pull/173