### PR TITLE
Revert "server: Lower default HeartBeat timeout."

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -63,7 +63,7 @@ int dqlite__init(struct dqlite_node *d,
 	}
 	/* TODO: expose these values through some API */
 	raft_set_election_timeout(&d->raft, 3000);
-	raft_set_heartbeat_timeout(&d->raft, 300);
+	raft_set_heartbeat_timeout(&d->raft, 500);
 	raft_set_snapshot_threshold(&d->raft, 1024);
 	raft_set_snapshot_trailing(&d->raft, 8192);
 	raft_set_pre_vote(&d->raft, true);


### PR DESCRIPTION
This reverts commit 7594d6d2acf7d11bb9752193842aad72890951d5.

Somehow makes the LXD cluster tests more flaky. To be investigated further.