### PR TITLE
dqlite: Bump version to 1.8.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([libdqlite], [1.7.0], [https://github.com/canonical/dqlite])
+AC_INIT([libdqlite], [1.8.0], [https://github.com/canonical/dqlite])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([ac])
 

--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -5,6 +5,16 @@
 #include <stddef.h>
 
 /**
+ * Version.
+ */
+#define DQLITE_VERSION_MAJOR    1
+#define DQLITE_VERSION_MINOR    8
+#define DQLITE_VERSION_RELEASE  0
+#define DQLITE_VERSION_NUMBER (DQLITE_VERSION_MAJOR *100*100 + DQLITE_VERSION_MINOR *100 + DQLITE_VERSION_RELEASE)
+
+int dqlite_version_number (void);
+
+/**
  * Error codes.
  */
 #define DQLITE_ERROR 1  /* Generic error */

--- a/src/dqlite.c
+++ b/src/dqlite.c
@@ -2,6 +2,11 @@
 
 #include "vfs.h"
 
+int dqlite_version_number (void)
+{
+        return DQLITE_VERSION_NUMBER;
+}
+
 int dqlite_vfs_init(sqlite3_vfs *vfs, const char *name)
 {
 	return VfsInit(vfs, name);


### PR DESCRIPTION
Additionally define DQLITE_VERSION_XXXXX macros to allow
feature detection.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>