### PR TITLE
Tracing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,9 @@ jobs:
         compiler:
           - gcc
           - clang
+        tracing:
+          - LIBDQLITE_TRACE=1
+          - NOLIBDQLITE_TRACE=1
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -36,7 +39,9 @@ jobs:
     - name: Test
       env:
         CC: ${{ matrix.compiler }}
-      run: make CFLAGS=-O0 -j2 check || (cat ./test-suite.log && false)
+      run: |
+           export ${{ matrix.tracing }}
+           make CFLAGS=-O0 -j2 check || (cat ./test-suite.log && false)
 
     - name: Coverage
       env:

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,7 @@ libdqlite_la_SOURCES = \
   src/response.c \
   src/server.c \
   src/stmt.c \
+  src/tracing.c \
   src/transport.c \
   src/translate.c \
   src/tuple.c \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ sudo apt-get update
 sudo apt-get install libdqlite-dev
 ```
 
+Usage Notes
+-----------
+
+Detailed tracing will be enabled when the environment variable `LIBDQLITE_TRACE` is set before startup.
+
 Build
 -----
 

--- a/src/client.c
+++ b/src/client.c
@@ -9,19 +9,23 @@
 #include "protocol.h"
 #include "request.h"
 #include "response.h"
+#include "tracing.h"
 #include "tuple.h"
 
 int clientInit(struct client *c, int fd)
 {
+	tracef("init client fd %d", fd);
 	int rv;
 	c->fd = fd;
 
 	rv = buffer__init(&c->read);
 	if (rv != 0) {
+		tracef("init client read buffer init failed");
 		goto err;
 	}
 	rv = buffer__init(&c->write);
 	if (rv != 0) {
+		tracef("init client write buffer init failed");
 		goto err_after_read_buffer_init;
 	}
 
@@ -35,6 +39,7 @@ err:
 
 void clientClose(struct client *c)
 {
+	tracef("client close fd %d", c->fd);
 	buffer__close(&c->write);
 	buffer__close(&c->read);
 }
@@ -44,11 +49,13 @@ int clientSendHandshake(struct client *c)
 	uint64_t protocol;
 	ssize_t rv;
 
+	tracef("client send handshake fd %d", c->fd);
 	/* TODO: update to version 1 */
 	protocol = byte__flip64(DQLITE_PROTOCOL_VERSION_LEGACY);
 
 	rv = write(c->fd, &protocol, sizeof protocol);
 	if (rv < 0) {
+		tracef("client send handshake failed");
 		return DQLITE_ERROR;
 	}
 
@@ -79,43 +86,48 @@ int clientSendHandshake(struct client *c)
 		request_##LOWER##__encode(&request, &cursor);       \
 		rv = write(c->fd, buffer__cursor(&c->write, 0), n); \
 		if (rv != (int)n) {                                 \
+			tracef("request write failed rv %ld", rv);  \
 			return DQLITE_ERROR;                        \
 		}                                                   \
 	}
 
 /* Read a response without decoding it. */
-#define READ(LOWER, UPPER)                                      \
-	{                                                       \
-		struct message _message;                        \
-		struct cursor _cursor;                          \
-		size_t _n;                                      \
-		void *_p;                                       \
-		ssize_t _rv;                                    \
-		_n = message__sizeof(&_message);                \
-		buffer__reset(&c->read);                        \
-		_p = buffer__advance(&c->read, _n);             \
-		assert(_p != NULL);                             \
-		_rv = read(c->fd, _p, _n);                      \
-		if (_rv != (int)_n) {                           \
-			return DQLITE_ERROR;                    \
-		}                                               \
-		_cursor.p = _p;                                 \
-		_cursor.cap = _n;                               \
-		_rv = message__decode(&_cursor, &_message);     \
-		assert(_rv == 0);                               \
-		if (_message.type != DQLITE_RESPONSE_##UPPER) { \
-			return DQLITE_ERROR;                    \
-		}                                               \
-		buffer__reset(&c->read);                        \
-		_n = _message.words * 8;                        \
-		_p = buffer__advance(&c->read, _n);             \
-		if (_p == NULL) {                               \
-			return DQLITE_ERROR;                    \
-		}                                               \
-		_rv = read(c->fd, _p, _n);                      \
-		if (_rv != (int)_n) {                           \
-			return DQLITE_ERROR;                    \
-		}                                               \
+#define READ(LOWER, UPPER)                                          \
+	{                                                           \
+		struct message _message;                            \
+		struct cursor _cursor;                              \
+		size_t _n;                                          \
+		void *_p;                                           \
+		ssize_t _rv;                                        \
+		_n = message__sizeof(&_message);                    \
+		buffer__reset(&c->read);                            \
+		_p = buffer__advance(&c->read, _n);                 \
+		assert(_p != NULL);                                 \
+		_rv = read(c->fd, _p, _n);                          \
+		if (_rv != (int)_n) {                               \
+			tracef("read failed rv %ld)", _rv);         \
+			return DQLITE_ERROR;                        \
+		}                                                   \
+		_cursor.p = _p;                                     \
+		_cursor.cap = _n;                                   \
+		_rv = message__decode(&_cursor, &_message);         \
+		assert(_rv == 0);                                   \
+		if (_message.type != DQLITE_RESPONSE_##UPPER) {     \
+			tracef("read decode failed rv %ld)", _rv);  \
+			return DQLITE_ERROR;                        \
+		}                                                   \
+		buffer__reset(&c->read);                            \
+		_n = _message.words * 8;                            \
+		_p = buffer__advance(&c->read, _n);                 \
+		if (_p == NULL) {                                   \
+			tracef("read buf adv failed rv %ld)", _rv); \
+			return DQLITE_ERROR;                        \
+		}                                                   \
+		_rv = read(c->fd, _p, _n);                          \
+		if (_rv != (int)_n) {                               \
+			tracef("read failed rv %ld)", _rv);         \
+			return DQLITE_ERROR;                        \
+		}                                                   \
 	}
 
 /* Decode a response. */
@@ -127,6 +139,7 @@ int clientSendHandshake(struct client *c)
 		cursor.cap = buffer__offset(&c->read);               \
 		rv = response_##LOWER##__decode(&cursor, &response); \
 		if (rv != 0) {                                       \
+			tracef("decode failed rv %d)", rv);          \
 			return DQLITE_ERROR;                         \
 		}                                                    \
 	}
@@ -138,6 +151,7 @@ int clientSendHandshake(struct client *c)
 
 int clientSendOpen(struct client *c, const char *name)
 {
+	tracef("client send open fd %d name %s", c->fd, name);
 	struct request_open request;
 	request.filename = name;
 	request.flags = 0;    /* TODO: this is unused, should we drop it? */
@@ -148,6 +162,7 @@ int clientSendOpen(struct client *c, const char *name)
 
 int clientRecvDb(struct client *c)
 {
+	tracef("client recvdb fd %d", c->fd);
 	struct response_db response;
 	RESPONSE(db, DB);
 	c->db_id = response.id;
@@ -156,6 +171,7 @@ int clientRecvDb(struct client *c)
 
 int clientSendPrepare(struct client *c, const char *sql)
 {
+	tracef("client send prepare fd %d", c->fd);
 	struct request_prepare request;
 	request.db_id = c->db_id;
 	request.sql = sql;
@@ -168,11 +184,13 @@ int clientRecvStmt(struct client *c, unsigned *stmt_id)
 	struct response_stmt response;
 	RESPONSE(stmt, STMT);
 	*stmt_id = response.id;
+	tracef("client recv stmt fd %d stmt_id %u", c->fd, *stmt_id);
 	return 0;
 }
 
 int clientSendExec(struct client *c, unsigned stmt_id)
 {
+	tracef("client send exec fd %d id %u", c->fd, stmt_id);
 	struct request_exec request;
 	request.db_id = c->db_id;
 	request.stmt_id = stmt_id;
@@ -182,6 +200,7 @@ int clientSendExec(struct client *c, unsigned stmt_id)
 
 int clientSendExecSQL(struct client *c, const char *sql)
 {
+	tracef("client send exec sql fd %d", c->fd);
 	struct request_exec_sql request;
 	request.db_id = c->db_id;
 	request.sql = sql;
@@ -197,11 +216,13 @@ int clientRecvResult(struct client *c,
 	RESPONSE(result, RESULT);
 	*last_insert_id = (unsigned)response.last_insert_id;
 	*rows_affected = (unsigned)response.rows_affected;
+	tracef("client recv result fd %d last_insert_id %u rows_affected %u", c->fd, *last_insert_id, *rows_affected);
 	return 0;
 }
 
 int clientSendQuery(struct client *c, unsigned stmt_id)
 {
+	tracef("client send query fd %d stmt_id %u", c->fd, stmt_id);
 	struct request_query request;
 	request.db_id = c->db_id;
 	request.stmt_id = stmt_id;
@@ -211,6 +232,7 @@ int clientSendQuery(struct client *c, unsigned stmt_id)
 
 int clientRecvRows(struct client *c, struct rows *rows)
 {
+	tracef("client recv rows fd %d", c->fd);
 	struct cursor cursor;
 	struct tuple_decoder decoder;
 	uint64_t column_count;
@@ -222,6 +244,7 @@ int clientRecvRows(struct client *c, struct rows *rows)
 	cursor.cap = buffer__offset(&c->read);
 	rv = uint64__decode(&cursor, &column_count);
 	if (rv != 0) {
+		tracef("client recv rows fd %d decode failed %d", c->fd, rv);
 		return DQLITE_ERROR;
 	}
 	rows->column_count = (unsigned)column_count;
@@ -251,22 +274,26 @@ int clientRecvRows(struct client *c, struct rows *rows)
 		}
 		row = sqlite3_malloc(sizeof *row);
 		if (row == NULL) {
+			tracef("malloc");
 			return DQLITE_NOMEM;
 		}
 		row->values =
 		    sqlite3_malloc((int)(column_count * sizeof *row->values));
 		if (row->values == NULL) {
+			tracef("malloc");
 			return DQLITE_NOMEM;
 		}
 		row->next = NULL;
 		rv = tuple_decoder__init(&decoder, (unsigned)column_count,
 					 &cursor);
 		if (rv != 0) {
+			tracef("decode init error %d", rv);
 			return DQLITE_ERROR;
 		}
 		for (i = 0; i < rows->column_count; i++) {
 			rv = tuple_decoder__next(&decoder, &row->values[i]);
 			if (rv != 0) {
+				tracef("decode error %d", rv);
 				return DQLITE_ERROR;
 			}
 		}
@@ -295,6 +322,7 @@ void clientCloseRows(struct rows *rows)
 
 int clientSendAdd(struct client *c, unsigned id, const char *address)
 {
+	tracef("client send add fd %d id %u address %s", c->fd, id, address);
 	struct request_add request;
 	request.id = id;
 	request.address = address;
@@ -304,6 +332,7 @@ int clientSendAdd(struct client *c, unsigned id, const char *address)
 
 int clientSendAssign(struct client *c, unsigned id, int role)
 {
+	tracef("client send assign fd %d id %u role %d", c->fd, id, role);
 	struct request_assign request;
 	(void)role;
 	/* TODO: actually send an assign request, not a legacy promote one. */
@@ -314,6 +343,7 @@ int clientSendAssign(struct client *c, unsigned id, int role)
 
 int clientSendRemove(struct client *c, unsigned id)
 {
+	tracef("client send remove fd %d id %u", c->fd, id);
 	struct request_remove request;
 	request.id = id;
 	REQUEST(remove, REMOVE);
@@ -322,6 +352,7 @@ int clientSendRemove(struct client *c, unsigned id)
 
 int clientRecvEmpty(struct client *c)
 {
+	tracef("client recv empty fd %d", c->fd);
 	struct response_empty response;
 	RESPONSE(empty, EMPTY);
 	return 0;

--- a/src/db.c
+++ b/src/db.c
@@ -5,6 +5,7 @@
 #include "./lib/assert.h"
 
 #include "db.h"
+#include "tracing.h"
 
 /* Open a SQLite connection and set it to follower mode. */
 static int open_follower_conn(const char *filename,
@@ -14,6 +15,7 @@ static int open_follower_conn(const char *filename,
 
 void db__init(struct db *db, struct config *config, const char *filename)
 {
+        tracef("db init %s", filename);
 	db->config = config;
 	db->filename = sqlite3_malloc((int)(strlen(filename) + 1));
 	assert(db->filename != NULL); /* TODO: return an error instead */

--- a/src/server.c
+++ b/src/server.c
@@ -699,17 +699,21 @@ int dqlite_node_start(dqlite_node *t)
 	int rv;
 
 	dqliteTracingMaybeEnable(true);
+	tracef("dqlite node start");
 	rv = maybeBootstrap(t, t->config.id, t->config.address);
 	if (rv != 0) {
+		tracef("bootstrap failed %d", rv);
 		goto err;
 	}
 
 	rv = pthread_create(&t->thread, 0, &taskStart, t);
 	if (rv != 0) {
+		tracef("pthread create failed %d", rv);
 		goto err;
 	}
 
 	if (!taskReady(t)) {
+		tracef("!taskReady");
 		rv = DQLITE_ERROR;
 		goto err;
 	}
@@ -722,6 +726,7 @@ err:
 
 int dqlite_node_stop(dqlite_node *d)
 {
+	tracef("dqlite node stop");
 	void *result;
 	int rv;
 
@@ -750,6 +755,7 @@ int dqlite_node_recover(dqlite_node *n,
 			struct dqlite_node_info infos[],
 			int n_info)
 {
+    tracef("dqlite node recover");
     int i;
     int ret;
 
@@ -803,6 +809,7 @@ int dqlite_node_recover_ext(dqlite_node *n,
 			struct dqlite_node_info_ext infos[],
 			int n_info)
 {
+    	tracef("dqlite node recover ext");
 	struct raft_configuration configuration;
 	int i;
 	int rv;
@@ -838,6 +845,7 @@ out:
 
 dqlite_node_id dqlite_generate_node_id(const char *address)
 {
+	tracef("generate node id");
 	struct timespec ts;
 	int rv;
 	unsigned long long n;

--- a/src/server.c
+++ b/src/server.c
@@ -10,6 +10,7 @@
 #include "lib/assert.h"
 #include "logger.h"
 #include "protocol.h"
+#include "tracing.h"
 #include "translate.h"
 #include "transport.h"
 #include "utils.h"
@@ -697,6 +698,7 @@ int dqlite_node_start(dqlite_node *t)
 {
 	int rv;
 
+	dqliteTracingMaybeEnable(true);
 	rv = maybeBootstrap(t, t->config.id, t->config.address);
 	if (rv != 0) {
 		goto err;

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -1,0 +1,14 @@
+#include "tracing.h"
+
+#include <stdlib.h>
+
+#define LIBDQLITE_TRACE "LIBDQLITE_TRACE"
+
+bool _dqliteTracingEnabled = false;
+
+void dqliteTracingMaybeEnable(bool enable)
+{
+        if (getenv(LIBDQLITE_TRACE) != NULL) {
+                _dqliteTracingEnabled = enable;
+        }
+}

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -1,0 +1,23 @@
+/* Tracing functionality for dqlite */
+
+#ifndef DQLITE_TRACING_H_
+#define DQLITE_TRACING_H_
+
+#include <stdbool.h>
+
+/* This global variable is only written once at startup and is only read
+ * from there on. Users should not manipulate the value of this variable. */
+extern bool _dqliteTracingEnabled;
+
+#define tracef(...) do {                                                   \
+    if (_dqliteTracingEnabled) {                                           \
+	static char _msg[1024];                                            \
+	snprintf(_msg, sizeof(_msg), __VA_ARGS__);                         \
+	fprintf(stderr, "LIBDQLITE %s:%d %s\n", __func__, __LINE__, _msg); \
+    }                                                                      \
+} while(0)                                                                 \
+
+/* Enable tracing if the appropriate env variable is set, or disable tracing. */
+void dqliteTracingMaybeEnable(bool enabled);
+
+#endif /* DQLITE_TRACING_H_ */

--- a/src/transport.c
+++ b/src/transport.c
@@ -9,6 +9,7 @@
 #include "client.h"
 #include "message.h"
 #include "request.h"
+#include "tracing.h"
 #include "transport.h"
 
 struct impl
@@ -40,6 +41,7 @@ static int impl_init(struct raft_uv_transport *transport,
 		     raft_id id,
 		     const char *address)
 {
+        tracef("impl init");
 	struct impl *i = transport->impl;
 	i->id = id;
 	i->address = address;
@@ -49,6 +51,7 @@ static int impl_init(struct raft_uv_transport *transport,
 static int impl_listen(struct raft_uv_transport *transport,
 		       raft_uv_accept_cb cb)
 {
+        tracef("impl listen");
 	struct impl *i = transport->impl;
 	i->accept_cb = cb;
 	return 0;
@@ -56,6 +59,7 @@ static int impl_listen(struct raft_uv_transport *transport,
 
 static void connect_work_cb(uv_work_t *work)
 {
+        tracef("connect work cb");
 	struct connect *r = work->data;
 	struct impl *i = r->impl;
 	struct message message;
@@ -72,6 +76,7 @@ static void connect_work_cb(uv_work_t *work)
 	 * function. */
 	rv = i->connect.f(i->connect.arg, r->address, &r->fd);
 	if (rv != 0) {
+                tracef("connect failed to %llu@%s", r->id, r->address);
 		rv = RAFT_NOCONNECTION;
 		goto err;
 	}
@@ -80,6 +85,7 @@ static void connect_work_cb(uv_work_t *work)
 	protocol = byte__flip64(DQLITE_PROTOCOL_VERSION);
 	rv = (int)write(r->fd, &protocol, sizeof protocol);
 	if (rv != sizeof protocol) {
+                tracef("write failed");
 		rv = RAFT_NOCONNECTION;
 		goto err_after_connect;
 	}
@@ -99,6 +105,7 @@ static void connect_work_cb(uv_work_t *work)
 
 	buf = sqlite3_malloc64(n);
 	if (buf == NULL) {
+                tracef("malloc failed");
 		rv = RAFT_NOCONNECTION;
 		goto err_after_connect;
 	}
@@ -111,6 +118,7 @@ static void connect_work_cb(uv_work_t *work)
 	sqlite3_free(buf);
 
 	if (rv != (int)n) {
+                tracef("write failed");
 		rv = RAFT_NOCONNECTION;
 		goto err_after_connect;
 	}
@@ -127,6 +135,7 @@ err:
 
 static void connect_after_work_cb(uv_work_t *work, int status)
 {
+        tracef("connect after work cb status %d", status);
 	struct connect *r = work->data;
 	struct impl *i = r->impl;
 	struct uv_stream_s *stream = NULL;
@@ -140,6 +149,7 @@ static void connect_after_work_cb(uv_work_t *work, int status)
 
 	rv = transport__stream(i->loop, r->fd, &stream);
 	if (rv != 0) {
+                tracef("transport stream failed %d", rv);
 		r->status = RAFT_NOCONNECTION;
 		close(r->fd);
 		goto out;
@@ -155,12 +165,14 @@ static int impl_connect(struct raft_uv_transport *transport,
 			const char *address,
 			raft_uv_connect_cb cb)
 {
+        tracef("impl connect id:%llu address:%s", id, address);
 	struct impl *i = transport->impl;
 	struct connect *r;
 	int rv;
 
 	r = sqlite3_malloc(sizeof *r);
 	if (r == NULL) {
+                tracef("malloc failed");
 		rv = DQLITE_NOMEM;
 		goto err;
 	}
@@ -176,6 +188,7 @@ static int impl_connect(struct raft_uv_transport *transport,
 	rv = uv_queue_work(i->loop, &r->work, connect_work_cb,
 			   connect_after_work_cb);
 	if (rv != 0) {
+                tracef("queue work failed");
 		rv = RAFT_NOCONNECTION;
 		goto err_after_connect_alloc;
 	}
@@ -191,6 +204,7 @@ err:
 static void impl_close(struct raft_uv_transport *transport,
 		       raft_uv_transport_close_cb cb)
 {
+        tracef("impl close");
 	cb(transport);
 }
 
@@ -245,6 +259,7 @@ static int default_connect(void *arg, const char *address, int *fd)
 
 int raftProxyInit(struct raft_uv_transport *transport, struct uv_loop_s *loop)
 {
+        tracef("raft proxy init");
 	struct impl *i = sqlite3_malloc(sizeof *i);
 	if (i == NULL) {
 		return DQLITE_NOMEM;
@@ -263,6 +278,7 @@ int raftProxyInit(struct raft_uv_transport *transport, struct uv_loop_s *loop)
 
 void raftProxyClose(struct raft_uv_transport *transport)
 {
+        tracef("raft proxy close");
 	struct impl *i = transport->impl;
 	sqlite3_free(i);
 }
@@ -272,9 +288,11 @@ void raftProxyAccept(struct raft_uv_transport *transport,
 		     const char *address,
 		     struct uv_stream_s *stream)
 {
+        tracef("raft proxy accept");
 	struct impl *i = transport->impl;
 	/* If the accept callback is NULL it means we were stopped. */
 	if (i->accept_cb == NULL) {
+                tracef("raft proxy accept closed");
 		uv_close((struct uv_handle_s *)stream, (uv_close_cb)raft_free);
 	} else {
 		i->accept_cb(transport, id, address, stream);


### PR DESCRIPTION
Tracing to stderr can be enabled by setting the `LIBDQLITE_TRACE` environment variable before startup.