### PR TITLE
gateway: Finalize stmt when `raft_barrier` fails

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -564,7 +564,9 @@ static int handle_query_sql(struct handle *req, struct cursor *cursor)
 	if (rv != 0) {
                 tracef("barrier failed %d", rv);
 		g->req = NULL;
+		sqlite3_finalize(g->stmt);
 		g->stmt = NULL;
+		g->stmt_finalize = false;
 		return rv;
 	}
 	return 0;


### PR DESCRIPTION
`g->stmt` is prepared here https://github.com/canonical/dqlite/blob/d5694bb937c98591911e84407ec77d64e96e04a0/src/gateway.c#L546, but never finalized when `leader__barrier` fails. This could lead to resource leaks and possibly triggering the assert in https://github.com/canonical/dqlite/blob/d5694bb937c98591911e84407ec77d64e96e04a0/src/leader.c#L143.

Possibly resolves https://github.com/canonical/dqlite/issues/327

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>