### PR TITLE
gateway: Finalize stmt when query_barrier_cb reports failure

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -230,6 +230,16 @@ int clientSendQuery(struct client *c, unsigned stmt_id)
 	return 0;
 }
 
+int clientSendQuerySql(struct client *c, const char *sql)
+{
+	tracef("client send query sql fd %d sql %s", c->fd, sql);
+	struct request_query_sql request;
+	request.db_id = c->db_id;
+	request.sql = sql;
+	REQUEST(query_sql, QUERY_SQL);
+	return 0;
+}
+
 int clientRecvRows(struct client *c, struct rows *rows)
 {
 	tracef("client recv rows fd %d", c->fd);

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -382,7 +382,7 @@ done:
 
 static void query_barrier_cb(struct barrier *barrier, int status)
 {
-        tracef("query barrier cb");
+	tracef("query barrier cb status:%d", status);
 	struct gateway *g = barrier->data;
 	struct handle *handle = g->req;
 	sqlite3_stmt *stmt = g->stmt;
@@ -394,6 +394,10 @@ static void query_barrier_cb(struct barrier *barrier, int status)
 	g->req = NULL;
 
 	if (status != 0) {
+		if (g->stmt_finalize) {
+			sqlite3_finalize(stmt);
+			g->stmt_finalize = false;
+		}
 		failure(handle, status, "barrier error");
 		return;
 	}

--- a/test/unit/test_conn.c
+++ b/test/unit/test_conn.c
@@ -150,6 +150,17 @@ static void connCloseCb(struct conn *conn)
 		munit_assert_int(rv2, ==, 0);               \
 	}
 
+/* Perform a non-prepared query. */
+#define QUERY_SQL(SQL, ROWS)                                   \
+	{                                                      \
+		int rv2;                                       \
+		rv2 = clientSendQuerySql(&f->client, SQL);     \
+		munit_assert_int(rv2, ==, 0);                  \
+		test_uv_run(&f->loop, 2);                      \
+		rv2 = clientRecvRows(&f->client, ROWS);        \
+		munit_assert_int(rv2, ==, 0);                  \
+	}
+
 /******************************************************************************
  *
  * Handle the handshake


### PR DESCRIPTION
`g->stmt` could be leaked resulting in the `assert` being hit in `leader__close` https://github.com/canonical/dqlite/blob/7f9a00ad9ad88b4bc8d361d74cee8fede795ce80/src/leader.c#L143

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>