### PR TITLE
Revert "Makefile: Define NDEBUG when not debugging"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,7 +92,7 @@ integration_test_LDADD = libtest.la libdqlite.la
 if DEBUG_ENABLED
   AM_CFLAGS += -g
 else
-  AM_CFLAGS += -O2 -DNDEBUG
+  AM_CFLAGS += -O2
 endif
 if SANITIZE_ENABLED
   AM_CFLAGS += -fsanitize=address


### PR DESCRIPTION
Compiling out the asserts causes a lot of warnings about unused variables and code analysis issues, will reintroduce once I sort those out.

This reverts commit d08bf164a0545580f3e44e40e0b4462280da3a34.