### PR TITLE
server: Loosen snapshot_trailing restriction

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -366,7 +366,7 @@ int dqlite_node_set_snapshot_params(dqlite_node *n, unsigned snapshot_threshold,
         return DQLITE_MISUSE;
     }
 
-    if (snapshot_trailing < 1024) {
+    if (snapshot_trailing < 4) {
         return DQLITE_MISUSE;
     }
 

--- a/test/integration/test_node.c
+++ b/test/integration/test_node.c
@@ -161,7 +161,7 @@ TEST(node, snapshotParamsTrailingTooSmall, setUp, tearDown, 0, NULL)
         struct fixture *f = data;
         int rv;
 
-        rv = dqlite_node_set_snapshot_params(f->node, 512, 512);
+        rv = dqlite_node_set_snapshot_params(f->node, 2, 2);
         munit_assert_int(rv, !=, 0);
 
         startStopNode(f);


### PR DESCRIPTION
Allows to test snapshots more in jepsen tests.