### PR TITLE
cluster tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ unit_test_LDADD = libtest.la
 
 integration_test_SOURCES = \
   test/integration/test_client.c \
+  test/integration/test_cluster.c \
   test/integration/test_membership.c \
   test/integration/test_node.c \
   test/integration/test_vfs.c \

--- a/test/integration/test_client.c
+++ b/test/integration/test_client.c
@@ -1,62 +1,8 @@
+#include "../lib/client.h"
 #include "../lib/heap.h"
 #include "../lib/runner.h"
 #include "../lib/server.h"
 #include "../lib/sqlite.h"
-
-/******************************************************************************
- *
- * Helper macros.
- *
- ******************************************************************************/
-
-/* Send the initial client handshake. */
-#define HANDSHAKE                                     \
-	{                                             \
-		int rv_;                              \
-		rv_ = clientSendHandshake(f->client); \
-		munit_assert_int(rv_, ==, 0);         \
-	}
-
-/* Open a test database. */
-#define OPEN                                             \
-	{                                                \
-		int rv_;                                 \
-		rv_ = clientSendOpen(f->client, "test"); \
-		munit_assert_int(rv_, ==, 0);            \
-		rv_ = clientRecvDb(f->client);           \
-		munit_assert_int(rv_, ==, 0);            \
-	}
-
-/* Prepare a statement. */
-#define PREPARE(SQL, STMT_ID)                             \
-	{                                                 \
-		int rv_;                                  \
-		rv_ = clientSendPrepare(f->client, SQL);  \
-		munit_assert_int(rv_, ==, 0);             \
-		rv_ = clientRecvStmt(f->client, STMT_ID); \
-		munit_assert_int(rv_, ==, 0);             \
-	}
-
-/* Execute a statement. */
-#define EXEC(STMT_ID, LAST_INSERT_ID, ROWS_AFFECTED)              \
-	{                                                         \
-		int rv_;                                          \
-		rv_ = clientSendExec(f->client, STMT_ID);         \
-		munit_assert_int(rv_, ==, 0);                     \
-		rv_ = clientRecvResult(f->client, LAST_INSERT_ID, \
-				       ROWS_AFFECTED);            \
-		munit_assert_int(rv_, ==, 0);                     \
-	}
-
-/* Perform a query. */
-#define QUERY(STMT_ID, ROWS)                               \
-	{                                                  \
-		int rv_;                                   \
-		rv_ = clientSendQuery(f->client, STMT_ID); \
-		munit_assert_int(rv_, ==, 0);              \
-		rv_ = clientRecvRows(f->client, ROWS);     \
-		munit_assert_int(rv_, ==, 0);              \
-	}
 
 /******************************************************************************
  *

--- a/test/integration/test_cluster.c
+++ b/test/integration/test_cluster.c
@@ -1,0 +1,167 @@
+#include "../../src/client.h"
+#include "../../src/server.h"
+#include "../lib/client.h"
+#include "../lib/endpoint.h"
+#include "../lib/fs.h"
+#include "../lib/heap.h"
+#include "../lib/runner.h"
+#include "../lib/server.h"
+#include "../lib/sqlite.h"
+
+/******************************************************************************
+ *
+ * Fixture
+ *
+ ******************************************************************************/
+
+#define N_SERVERS 3
+#define FIXTURE                                \
+	struct test_server servers[N_SERVERS]; \
+	struct client *client
+
+#define SETUP                                                 \
+	unsigned i_;                                          \
+	test_heap_setup(params, user_data);                   \
+	test_sqlite_setup(params);                            \
+	for (i_ = 0; i_ < N_SERVERS; i_++) {                  \
+		struct test_server *server = &f->servers[i_]; \
+		test_server_setup(server, i_ + 1, params);    \
+	}                                                     \
+	test_server_network(f->servers, N_SERVERS);           \
+	for (i_ = 0; i_ < N_SERVERS; i_++) {                  \
+		struct test_server *server = &f->servers[i_]; \
+		test_server_start(server);                    \
+	}                                                     \
+	SELECT(1)
+
+#define TEAR_DOWN                                       \
+	unsigned i_;                                    \
+	for (i_ = 0; i_ < N_SERVERS; i_++) {            \
+		test_server_tear_down(&f->servers[i_]); \
+	}                                               \
+	test_sqlite_tear_down();                        \
+	test_heap_tear_down(data)
+
+/* Use the client connected to the server with the given ID. */
+#define SELECT(ID) f->client = test_server_client(&f->servers[ID - 1])
+
+/******************************************************************************
+ *
+ * cluster
+ *
+ ******************************************************************************/
+
+SUITE(cluster)
+
+struct fixture
+{
+	FIXTURE;
+};
+
+static void *setUp(const MunitParameter params[], void *user_data)
+{
+	struct fixture *f = munit_malloc(sizeof *f);
+	SETUP;
+	return f;
+}
+
+static void tearDown(void *data)
+{
+	struct fixture *f = data;
+	TEAR_DOWN;
+	free(f);
+}
+
+static char* num_records[] = {
+    "0", "1", "256",
+    /* WAL will just have been checkpointed after 993 writes. */
+    "993",
+    /* Non-empty WAL, checkpointed twice, 2 snapshots taken */
+    "2200", NULL
+};
+
+static MunitParameterEnum num_records_params[] = {
+    { "num_records", num_records },
+    { NULL, NULL },
+};
+
+/* Restart a node and check if all data is there */
+TEST(cluster, restart, setUp, tearDown, 0, num_records_params)
+{
+	struct fixture *f = data;
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	struct rows rows;
+	long n_records = strtol(munit_parameters_get(params, "num_records"), NULL, 0);
+	char sql[128];
+
+	HANDSHAKE;
+	OPEN;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	for (unsigned i = 0; i < n_records; ++i) {
+		sprintf(sql, "INSERT INTO test(n) VALUES(%d)", i + 1);
+		PREPARE(sql, &stmt_id);
+		EXEC(stmt_id, &last_insert_id, &rows_affected);
+	}
+
+	struct test_server *server = &f->servers[0];
+	test_server_stop(server);
+	test_server_start(server);
+
+	/* The table is visible after restart. */
+	HANDSHAKE;
+	OPEN;
+	PREPARE("SELECT COUNT(*) from test", &stmt_id);
+	QUERY(stmt_id, &rows);
+	munit_assert_long(rows.next->values->integer, ==, n_records);
+	clientCloseRows(&rows);
+	return MUNIT_OK;
+}
+
+/* Add data to a node, add a new node and make sure data is there. */
+TEST(cluster, dataOnNewNode, setUp, tearDown, 0, num_records_params)
+{
+	struct fixture *f = data;
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	struct rows rows;
+	long n_records = strtol(munit_parameters_get(params, "num_records"), NULL, 0);
+	char sql[128];
+	unsigned id = 2;
+	const char *address = "@2";
+
+	HANDSHAKE;
+	OPEN;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	for (unsigned i = 0; i < n_records; ++i) {
+		sprintf(sql, "INSERT INTO test(n) VALUES(%d)", i + 1);
+		PREPARE(sql, &stmt_id);
+		EXEC(stmt_id, &last_insert_id, &rows_affected);
+	}
+
+	/* Add a second voting server, this one will receive all data from the
+	 * original leader. */
+	ADD(id, address);
+	ASSIGN(id, 1 /* voter */);
+
+	/* Remove original server so second server becomes leader after election
+	 * timeout */
+	REMOVE(1);
+	sleep(1);
+
+	/* The full table is visible from the new node */
+	SELECT(2);
+	HANDSHAKE;
+	OPEN;
+	PREPARE("SELECT COUNT(*) from test", &stmt_id);
+	QUERY(stmt_id, &rows);
+	munit_assert_long(rows.next->values->integer, ==, n_records);
+	clientCloseRows(&rows);
+	return MUNIT_OK;
+}

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -1,5 +1,6 @@
 #include "../../src/client.h"
 #include "../../src/server.h"
+#include "../lib/client.h"
 #include "../lib/endpoint.h"
 #include "../lib/fs.h"
 #include "../lib/heap.h"
@@ -49,75 +50,6 @@
 
 /* Use the client connected to the server with the given ID. */
 #define SELECT(ID) f->client = test_server_client(&f->servers[ID - 1])
-
-/* Send the initial client handshake. */
-#define HANDSHAKE                                     \
-	{                                             \
-		int rv_;                              \
-		rv_ = clientSendHandshake(f->client); \
-		munit_assert_int(rv_, ==, 0);         \
-	}
-
-/* Send an add request. */
-#define ADD(ID, ADDRESS)                                     \
-	{                                                    \
-		int rv_;                                     \
-		rv_ = clientSendAdd(f->client, ID, ADDRESS); \
-		munit_assert_int(rv_, ==, 0);                \
-		rv_ = clientRecvEmpty(f->client);            \
-		munit_assert_int(rv_, ==, 0);                \
-	}
-
-/* Send an assign role request. */
-#define ASSIGN(ID, ROLE)                                     \
-	{                                                    \
-		int rv_;                                     \
-		rv_ = clientSendAssign(f->client, ID, ROLE); \
-		munit_assert_int(rv_, ==, 0);                \
-		rv_ = clientRecvEmpty(f->client);            \
-		munit_assert_int(rv_, ==, 0);                \
-	}
-
-/* Send a remove request. */
-#define REMOVE(ID)                                     \
-	{                                              \
-		int rv_;                               \
-		rv_ = clientSendRemove(f->client, ID); \
-		munit_assert_int(rv_, ==, 0);          \
-		rv_ = clientRecvEmpty(f->client);      \
-		munit_assert_int(rv_, ==, 0);          \
-	}
-
-/* Open a test database. */
-#define OPEN                                             \
-	{                                                \
-		int rv_;                                 \
-		rv_ = clientSendOpen(f->client, "test"); \
-		munit_assert_int(rv_, ==, 0);            \
-		rv_ = clientRecvDb(f->client);           \
-		munit_assert_int(rv_, ==, 0);            \
-	}
-
-/* Prepare a statement. */
-#define PREPARE(SQL, STMT_ID)                             \
-	{                                                 \
-		int rv_;                                  \
-		rv_ = clientSendPrepare(f->client, SQL);  \
-		munit_assert_int(rv_, ==, 0);             \
-		rv_ = clientRecvStmt(f->client, STMT_ID); \
-		munit_assert_int(rv_, ==, 0);             \
-	}
-
-/* Execute a statement. */
-#define EXEC(STMT_ID, LAST_INSERT_ID, ROWS_AFFECTED)              \
-	{                                                         \
-		int rv_;                                          \
-		rv_ = clientSendExec(f->client, STMT_ID);         \
-		munit_assert_int(rv_, ==, 0);                     \
-		rv_ = clientRecvResult(f->client, LAST_INSERT_ID, \
-				       ROWS_AFFECTED);            \
-		munit_assert_int(rv_, ==, 0);                     \
-	}
 
 /******************************************************************************
  *

--- a/test/lib/client.h
+++ b/test/lib/client.h
@@ -25,4 +25,107 @@
 	clientClose(&f->client); \
 	test_endpoint_tear_down(&f->endpoint)
 
+/******************************************************************************
+ *
+ * Helper macros.
+ *
+ ******************************************************************************/
+
+/* Send the initial client handshake. */
+#define HANDSHAKE                                     \
+	{                                             \
+		int rv_;                              \
+		rv_ = clientSendHandshake(f->client); \
+		munit_assert_int(rv_, ==, 0);         \
+	}
+
+/* Send an add request. */
+#define ADD(ID, ADDRESS)                                     \
+	{                                                    \
+		int rv_;                                     \
+		rv_ = clientSendAdd(f->client, ID, ADDRESS); \
+		munit_assert_int(rv_, ==, 0);                \
+		rv_ = clientRecvEmpty(f->client);            \
+		munit_assert_int(rv_, ==, 0);                \
+	}
+
+/* Send an assign role request. */
+#define ASSIGN(ID, ROLE)                                     \
+	{                                                    \
+		int rv_;                                     \
+		rv_ = clientSendAssign(f->client, ID, ROLE); \
+		munit_assert_int(rv_, ==, 0);                \
+		rv_ = clientRecvEmpty(f->client);            \
+		munit_assert_int(rv_, ==, 0);                \
+	}
+
+/* Send a remove request. */
+#define REMOVE(ID)                                     \
+	{                                              \
+		int rv_;                               \
+		rv_ = clientSendRemove(f->client, ID); \
+		munit_assert_int(rv_, ==, 0);          \
+		rv_ = clientRecvEmpty(f->client);      \
+		munit_assert_int(rv_, ==, 0);          \
+	}
+
+/* Open a test database. */
+#define OPEN                                             \
+	{                                                \
+		int rv_;                                 \
+		rv_ = clientSendOpen(f->client, "test"); \
+		munit_assert_int(rv_, ==, 0);            \
+		rv_ = clientRecvDb(f->client);           \
+		munit_assert_int(rv_, ==, 0);            \
+	}
+
+/* Open a test database with a specific name. */
+#define OPEN_NAME(NAME)                                  \
+	{                                                \
+		int rv_;                                 \
+		rv_ = clientSendOpen(f->client, NAME);   \
+		munit_assert_int(rv_, ==, 0);            \
+		rv_ = clientRecvDb(f->client);           \
+		munit_assert_int(rv_, ==, 0);            \
+	}
+
+/* Prepare a statement. */
+#define PREPARE(SQL, STMT_ID)                             \
+	{                                                 \
+		int rv_;                                  \
+		rv_ = clientSendPrepare(f->client, SQL);  \
+		munit_assert_int(rv_, ==, 0);             \
+		rv_ = clientRecvStmt(f->client, STMT_ID); \
+		munit_assert_int(rv_, ==, 0);             \
+	}
+
+#define PREPARE_FAIL(SQL, STMT_ID, RV, MSG)                  \
+	{                                                    \
+		int rv_;                                     \
+		rv_ = clientSendPrepare(f->client, SQL);     \
+		munit_assert_int(rv_, ==, 0);                \
+		rv_ = clientRecvFailure(f->client, RV, MSG); \
+		munit_assert_int(rv_, ==, 0);                \
+	}
+
+/* Execute a statement. */
+#define EXEC(STMT_ID, LAST_INSERT_ID, ROWS_AFFECTED)              \
+	{                                                         \
+		int rv_;                                          \
+		rv_ = clientSendExec(f->client, STMT_ID);         \
+		munit_assert_int(rv_, ==, 0);                     \
+		rv_ = clientRecvResult(f->client, LAST_INSERT_ID, \
+				       ROWS_AFFECTED);            \
+		munit_assert_int(rv_, ==, 0);                     \
+	}
+
+/* Perform a query. */
+#define QUERY(STMT_ID, ROWS)                               \
+	{                                                  \
+		int rv_;                                   \
+		rv_ = clientSendQuery(f->client, STMT_ID); \
+		munit_assert_int(rv_, ==, 0);              \
+		rv_ = clientRecvRows(f->client, ROWS);     \
+		munit_assert_int(rv_, ==, 0);              \
+	}
 #endif /* TEST_CLIENT_H */

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -35,7 +35,7 @@ void test_server_setup(struct test_server *s,
 	memset(s->others, 0, sizeof s->others);
 }
 
-void test_server_tear_down(struct test_server *s)
+void test_server_stop(struct test_server *s)
 {
 	int rv;
 
@@ -43,9 +43,12 @@ void test_server_tear_down(struct test_server *s)
 	close(s->client.fd);
 	rv = dqlite_node_stop(s->dqlite);
 	munit_assert_int(rv, ==, 0);
-
 	dqlite_node_destroy(s->dqlite);
+}
 
+void test_server_tear_down(struct test_server *s)
+{
+	test_server_stop(s);
 	test_dir_tear_down(s->dir);
 }
 
@@ -61,6 +64,9 @@ void test_server_start(struct test_server *s)
 	munit_assert_int(rv, ==, 0);
 
 	rv = dqlite_node_set_connect_func(s->dqlite, endpointConnect, s);
+	munit_assert_int(rv, ==, 0);
+
+	rv = dqlite_node_set_network_latency_ms(s->dqlite, 10);
 	munit_assert_int(rv, ==, 0);
 
 	rv = dqlite_node_start(s->dqlite);

--- a/test/lib/server.h
+++ b/test/lib/server.h
@@ -34,6 +34,9 @@ void test_server_tear_down(struct test_server *s);
 /* Start the test server. */
 void test_server_start(struct test_server *s);
 
+/* Stop the test server. */
+void test_server_stop(struct test_server *s);
+
 /* Connect all the given the servers to each other. */
 void test_server_network(struct test_server *servers, unsigned n_servers);
 

--- a/test/unit/test_conn.c
+++ b/test/unit/test_conn.c
@@ -85,7 +85,7 @@ static void connCloseCb(struct conn *conn)
  ******************************************************************************/
 
 /* Send the initial client handshake. */
-#define HANDSHAKE                                      \
+#define HANDSHAKE_CONN                                 \
 	{                                              \
 		int rv2;                               \
 		rv2 = clientSendHandshake(&f->client); \
@@ -94,7 +94,7 @@ static void connCloseCb(struct conn *conn)
 	}
 
 /* Open a test database. */
-#define OPEN                                              \
+#define OPEN_CONN                                         \
 	{                                                 \
 		int rv2;                                  \
 		rv2 = clientSendOpen(&f->client, "test"); \
@@ -105,7 +105,7 @@ static void connCloseCb(struct conn *conn)
 	}
 
 /* Prepare a statement. */
-#define PREPARE(SQL, STMT_ID)                              \
+#define PREPARE_CONN(SQL, STMT_ID)                         \
 	{                                                  \
 		int rv2;                                   \
 		rv2 = clientSendPrepare(&f->client, SQL);  \
@@ -116,7 +116,7 @@ static void connCloseCb(struct conn *conn)
 	}
 
 /* Execute a statement. */
-#define EXEC(STMT_ID, LAST_INSERT_ID, ROWS_AFFECTED, LOOP)         \
+#define EXEC_CONN(STMT_ID, LAST_INSERT_ID, ROWS_AFFECTED, LOOP)    \
 	{                                                          \
 		int rv2;                                           \
 		rv2 = clientSendExec(&f->client, STMT_ID);         \
@@ -128,7 +128,7 @@ static void connCloseCb(struct conn *conn)
 	}
 
 /* Execute a non-prepared statement. */
-#define EXEC_SQL(SQL, LAST_INSERT_ID, ROWS_AFFECTED, LOOP)         \
+#define EXEC_SQL_CONN(SQL, LAST_INSERT_ID, ROWS_AFFECTED, LOOP)    \
 	{                                                          \
 		int rv2;                                           \
 		rv2 = clientSendExecSQL(&f->client, SQL);          \
@@ -140,7 +140,7 @@ static void connCloseCb(struct conn *conn)
 	}
 
 /* Perform a query. */
-#define QUERY(STMT_ID, ROWS)                                \
+#define QUERY_CONN(STMT_ID, ROWS)                           \
 	{                                                   \
 		int rv2;                                    \
 		rv2 = clientSendQuery(&f->client, STMT_ID); \
@@ -151,7 +151,7 @@ static void connCloseCb(struct conn *conn)
 	}
 
 /* Perform a non-prepared query. */
-#define QUERY_SQL(SQL, ROWS)                                   \
+#define QUERY_SQL_CONN(SQL, ROWS)                              \
 	{                                                      \
 		int rv2;                                       \
 		rv2 = clientSendQuerySql(&f->client, SQL);     \
@@ -192,7 +192,7 @@ TEST_CASE(handshake, success, NULL)
 {
 	struct handshake_fixture *f = data;
 	(void)params;
-	HANDSHAKE;
+	HANDSHAKE_CONN;
 	return MUNIT_OK;
 }
 
@@ -213,7 +213,7 @@ TEST_SETUP(open)
 {
 	struct open_fixture *f = munit_malloc(sizeof *f);
 	SETUP;
-	HANDSHAKE;
+	HANDSHAKE_CONN;
 	return f;
 }
 
@@ -228,7 +228,7 @@ TEST_CASE(open, success, NULL)
 {
 	struct open_fixture *f = data;
 	(void)params;
-	OPEN;
+	OPEN_CONN;
 	return MUNIT_OK;
 }
 
@@ -249,8 +249,8 @@ TEST_SETUP(prepare)
 {
 	struct prepare_fixture *f = munit_malloc(sizeof *f);
 	SETUP;
-	HANDSHAKE;
-	OPEN;
+	HANDSHAKE_CONN;
+	OPEN_CONN;
 	return f;
 }
 
@@ -266,7 +266,7 @@ TEST_CASE(prepare, success, NULL)
 	struct prepare_fixture *f = data;
 	unsigned stmt_id;
 	(void)params;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	PREPARE_CONN("CREATE TABLE test (n INT)", &stmt_id);
 	munit_assert_int(stmt_id, ==, 0);
 	return MUNIT_OK;
 }
@@ -289,8 +289,8 @@ TEST_SETUP(exec)
 {
 	struct exec_fixture *f = munit_malloc(sizeof *f);
 	SETUP;
-	HANDSHAKE;
-	OPEN;
+	HANDSHAKE_CONN;
+	OPEN_CONN;
 	return f;
 }
 
@@ -307,8 +307,8 @@ TEST_CASE(exec, success, NULL)
 	unsigned last_insert_id;
 	unsigned rows_affected;
 	(void)params;
-	PREPARE("CREATE TABLE test (n INT)", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 8);
+	PREPARE_CONN("CREATE TABLE test (n INT)", &f->stmt_id);
+	EXEC_CONN(f->stmt_id, &last_insert_id, &rows_affected, 8);
 	munit_assert_int(last_insert_id, ==, 0);
 	munit_assert_int(rows_affected, ==, 0);
 	return MUNIT_OK;
@@ -320,14 +320,14 @@ TEST_CASE(exec, result, NULL)
 	unsigned last_insert_id;
 	unsigned rows_affected;
 	(void)params;
-	PREPARE("BEGIN", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 3);
-	PREPARE("CREATE TABLE test (n INT)", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 6);
-	PREPARE("INSERT INTO test (n) VALUES(123)", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 3);
-	PREPARE("COMMIT", &f->stmt_id);
-	EXEC(f->stmt_id, &last_insert_id, &rows_affected, 6);
+	PREPARE_CONN("BEGIN", &f->stmt_id);
+	EXEC_CONN(f->stmt_id, &last_insert_id, &rows_affected, 3);
+	PREPARE_CONN("CREATE TABLE test (n INT)", &f->stmt_id);
+	EXEC_CONN(f->stmt_id, &last_insert_id, &rows_affected, 6);
+	PREPARE_CONN("INSERT INTO test (n) VALUES(123)", &f->stmt_id);
+	EXEC_CONN(f->stmt_id, &last_insert_id, &rows_affected, 3);
+	PREPARE_CONN("COMMIT", &f->stmt_id);
+	EXEC_CONN(f->stmt_id, &last_insert_id, &rows_affected, 6);
 	munit_assert_int(last_insert_id, ==, 1);
 	munit_assert_int(rows_affected, ==, 1);
 	return MUNIT_OK;
@@ -341,7 +341,7 @@ TEST_CASE(exec, close_while_in_flight, NULL)
 	int rv;
 	(void)params;
 
-	EXEC_SQL("CREATE TABLE test (n)", &last_insert_id, &rows_affected, 7);
+	EXEC_SQL_CONN("CREATE TABLE test (n)", &last_insert_id, &rows_affected, 7);
 	rv = clientSendExecSQL(&f->client, "INSERT INTO test(n) VALUES(1)");
 	munit_assert_int(rv, ==, 0);
 
@@ -373,12 +373,12 @@ TEST_SETUP(query)
 	struct query_fixture *f = munit_malloc(sizeof *f);
 	unsigned stmt_id;
 	SETUP;
-	HANDSHAKE;
-	OPEN;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
-	EXEC(stmt_id, &f->last_insert_id, &f->rows_affected, 7);
-	PREPARE("INSERT INTO test(n) VALUES (123)", &f->insert_stmt_id);
-	EXEC(f->insert_stmt_id, &f->last_insert_id, &f->rows_affected, 4);
+	HANDSHAKE_CONN;
+	OPEN_CONN;
+	PREPARE_CONN("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC_CONN(stmt_id, &f->last_insert_id, &f->rows_affected, 7);
+	PREPARE_CONN("INSERT INTO test(n) VALUES (123)", &f->insert_stmt_id);
+	EXEC_CONN(f->insert_stmt_id, &f->last_insert_id, &f->rows_affected, 4);
 	return f;
 }
 
@@ -396,8 +396,8 @@ TEST_CASE(query, one, NULL)
 	struct query_fixture *f = data;
 	struct row *row;
 	(void)params;
-	PREPARE("SELECT n FROM test", &f->stmt_id);
-	QUERY(f->stmt_id, &f->rows);
+	PREPARE_CONN("SELECT n FROM test", &f->stmt_id);
+	QUERY_CONN(f->stmt_id, &f->rows);
 	munit_assert_int(f->rows.column_count, ==, 1);
 	munit_assert_string_equal(f->rows.column_names[0], "n");
 	row = f->rows.next;


### PR DESCRIPTION
- Move some duplicated utility macros
- Add a new test suite, `cluster` which will be used to test some end-to-end functionality. Currently have added tests to see if the database survives node restarts and if the database is transferred to new servers for different cases (with/without snapshots). 

This PR is meant to reduce the size of https://github.com/canonical/dqlite/pull/356 so it will be easier to review.