### PR TITLE
Revert "Close leader connection"

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -365,15 +365,6 @@ int clientSendRemove(struct client *c, unsigned id)
 	return 0;
 }
 
-int clientSendTransfer(struct client *c, unsigned id)
-{
-	tracef("client send transfer fd %d id %u", c->fd, id);
-	struct request_transfer request;
-	request.id = id;
-	REQUEST(transfer, TRANSFER);
-	return 0;
-}
-
 int clientRecvEmpty(struct client *c)
 {
 	tracef("client recv empty fd %d", c->fd);

--- a/src/client.h
+++ b/src/client.h
@@ -79,9 +79,6 @@ int clientSendAssign(struct client *c, unsigned id, int role);
 /* Send a request to remove a server from the cluster. */
 int clientSendRemove(struct client *c, unsigned id);
 
-/* Send a request to transfer leadership to node with id `id`. */
-int clientSendTransfer(struct client *c, unsigned id);
-
 /* Receive an empty response. */
 int clientRecvEmpty(struct client *c);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -333,19 +333,3 @@ void conn__stop(struct conn *c)
 	gateway__close(&c->gateway);
 	transport__close(&c->transport, closeCb);
 }
-
-/**
- * Close any connection that has an opened SQLite leader connection after
- * leadership has been lost.
- */
-void conn__leadership_lost(struct conn *c)
-{
-	tracef("conn leadership lost");
-	struct gateway *g;
-	g = &c->gateway;
-	if (g == NULL || g->leader == NULL) {
-		return;
-	}
-
-	conn__stop(c);
-}

--- a/src/conn.h
+++ b/src/conn.h
@@ -58,9 +58,4 @@ int conn__start(struct conn *c,
  */
 void conn__stop(struct conn *c);
 
-/**
- * Called in case Raft leadership is lost.
- */
-void conn__leadership_lost(struct conn *c);
-
 #endif /* DQLITE_CONN_H_ */

--- a/src/server.c
+++ b/src/server.c
@@ -572,21 +572,27 @@ static void monitor_cb(uv_prepare_t *monitor)
 {
 	struct dqlite_node *d = monitor->data;
 	int state = raft_state(&d->raft);
+	/*
 	queue *head;
 	struct conn *conn;
+	*/
 
 	if (state == RAFT_UNAVAILABLE) {
 		return;
 	}
 
+	/* TODO: we should shutdown clients that are performing SQL requests,
+	 * but not the ones which are doing management-requests, such as
+	 * transfer leadership.  */
+	/*
 	if (d->raft_state == RAFT_LEADER && state != RAFT_LEADER) {
-		tracef("leadership lost");
 		QUEUE__FOREACH(head, &d->conns)
 		{
 			conn = QUEUE__DATA(head, struct conn, queue);
-			conn__leadership_lost(conn);
+			conn__stop(conn);
 		}
 	}
+	*/
 
 	d->raft_state = state;
 }

--- a/test/integration/test_fsm.c
+++ b/test/integration/test_fsm.c
@@ -188,7 +188,8 @@ TEST(fsm, snapshotHeapFaultTwoDB, setUp, tearDown, 0, NULL)
 	EXEC(stmt_id, &last_insert_id, &rows_affected);
 
 	/* Close and reopen the client and open a second database */
-	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+	rv = test_server_client_reconnect(&f->servers[0]);
+	munit_assert_int(rv, ==, 0);
 
 	HANDSHAKE;
 	OPEN_NAME("test2");
@@ -252,7 +253,8 @@ TEST(fsm, snapshotNewDbAddedBeforeFinalize, setUp, tearDown, 0, NULL)
 
 	/* Close and reopen the client and open a second database,
 	 * and ensure finalize succeeds. */
-	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+	rv = test_server_client_reconnect(&f->servers[0]);
+	munit_assert_int(rv, ==, 0);
 
 	HANDSHAKE;
 	OPEN_NAME("test2");
@@ -389,7 +391,8 @@ TEST(fsm, snapshotRestore, setUp, tearDown, 0, num_writes_params)
 	munit_assert_int(rv, ==, 0);
 
 	/* Table is there on fresh connection. */
-	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+	rv = test_server_client_reconnect(&f->servers[0]);
+	munit_assert_int(rv, ==, 0);
 	HANDSHAKE;
 	OPEN;
 	PREPARE("SELECT COUNT(*) from test", &stmt_id);
@@ -466,7 +469,8 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, NULL)
 	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
 	EXEC(stmt_id, &last_insert_id, &rows_affected);
 
-	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+	rv = test_server_client_reconnect(&f->servers[0]);
+	munit_assert_int(rv, ==, 0);
 	HANDSHAKE;
 	OPEN_NAME("test2");
 	PREPARE("CREATE TABLE test2a (n INT)", &stmt_id);
@@ -494,7 +498,8 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, NULL)
 	munit_assert_int(rv, ==, 0);
 
 	/* Reopen connection */
-	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+	rv = test_server_client_reconnect(&f->servers[0]);
+	munit_assert_int(rv, ==, 0);
 	HANDSHAKE;
 	OPEN_NAME("test2");
 
@@ -509,7 +514,8 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, NULL)
 	munit_assert_string_equal(msg, "no such table: test2b");
 
 	/* Table is there on first DB */
-	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+	rv = test_server_client_reconnect(&f->servers[0]);
+	munit_assert_int(rv, ==, 0);
 	HANDSHAKE;
 	OPEN_NAME("test");
 	PREPARE("SELECT * from test", &stmt_id);

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -17,8 +17,7 @@
 #define N_SERVERS 3
 #define FIXTURE                                \
 	struct test_server servers[N_SERVERS]; \
-	struct client *client;                 \
-	struct rows rows;
+	struct client *client
 
 #define SETUP                                                 \
 	unsigned i_;                                          \
@@ -51,20 +50,6 @@
 
 /* Use the client connected to the server with the given ID. */
 #define SELECT(ID) f->client = test_server_client(&f->servers[ID - 1])
-
-/* Wait a bounded time until server ID has applied at least the entry at INDEX */
-#define AWAIT_REPLICATION(ID, INDEX)							  \
-	do {										  \
-		struct timespec _start = {0};						  \
-		struct timespec _end = {0};						  \
-		clock_gettime(CLOCK_MONOTONIC, &_start);				  \
-		clock_gettime(CLOCK_MONOTONIC, &_end);					  \
-		while((f->servers[ID].dqlite->raft.last_applied < INDEX)		  \
-		      && ((_end.tv_sec - _start.tv_sec) < 2)  ) {			  \
-			clock_gettime(CLOCK_MONOTONIC, &_end);				  \
-		}									  \
-		munit_assert_ullong(f->servers[ID].dqlite->raft.last_applied, >=, INDEX); \
-	} while(0)
 
 /******************************************************************************
  *
@@ -120,155 +105,5 @@ TEST(membership, join, setUp, tearDown, 0, NULL)
 	/* TODO: fix the standalone test for remove */
 	SELECT(1);
 	REMOVE(id);
-	return MUNIT_OK;
-}
-
-TEST(membership, transfer, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	unsigned id = 2;
-	const char *address = "@2";
-	unsigned stmt_id;
-	unsigned last_insert_id;
-	unsigned rows_affected;
-	raft_index last_applied;
-	struct client c_transfer; /* Client used for transfer requests */
-
-	HANDSHAKE;
-	ADD(id, address);
-	ASSIGN(id, 1 /* voter */);
-	OPEN;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	/* Transfer leadership and wait until first leader has applied a new
-	 * entry replicated from the new leader.  */
-	test_server_client_connect(&f->servers[0], &c_transfer);
-	HANDSHAKE_C(&c_transfer);
-	TRANSFER(2, &c_transfer);
-	test_server_client_close(&f->servers[0], &c_transfer);
-	last_applied = f->servers[0].dqlite->raft.last_applied;
-
-	SELECT(2);
-	HANDSHAKE;
-	OPEN;
-	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	AWAIT_REPLICATION(0, last_applied + 1);
-
-	return MUNIT_OK;
-}
-
-/* Transfer leadership away from a member that has a pending transaction */
-TEST(membership, transferPendingTransaction, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	unsigned id = 2;
-	const char *address = "@2";
-	unsigned stmt_id;
-	unsigned last_insert_id;
-	unsigned rows_affected;
-	raft_index last_applied;
-	struct client c_transfer; /* Client used for transfer requests */
-
-	HANDSHAKE;
-	ADD(id, address);
-	ASSIGN(id, 1 /* voter */);
-	OPEN;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	/* Pending transaction */
-	PREPARE("BEGIN", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-	PREPARE("SELECT * FROM test", &stmt_id);
-	QUERY(stmt_id, &f->rows);
-	clientCloseRows(&f->rows);
-
-	/* Transfer leadership and wait until first leader has applied a new
-	 * entry replicated from the new leader.  */
-	test_server_client_connect(&f->servers[0], &c_transfer);
-	HANDSHAKE_C(&c_transfer);
-	TRANSFER(2, &c_transfer);
-	test_server_client_close(&f->servers[0], &c_transfer);
-	last_applied = f->servers[0].dqlite->raft.last_applied;
-
-	SELECT(2);
-	HANDSHAKE;
-	OPEN;
-	PREPARE("INSERT INTO test(n) VALUES(2)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	AWAIT_REPLICATION(0, last_applied + 1);
-
-	return MUNIT_OK;
-}
-
-/* Transfer leadership back and forth from a member that has a pending transaction */
-TEST(membership, transferTwicePendingTransaction, setUp, tearDown, 0, NULL)
-{
-	struct fixture *f = data;
-	unsigned id = 2;
-	const char *address = "@2";
-	unsigned stmt_id;
-	unsigned last_insert_id;
-	unsigned rows_affected;
-	raft_index last_applied;
-	struct client c_transfer; /* Client used for transfer requests */
-
-	HANDSHAKE;
-	ADD(id, address);
-	ASSIGN(id, 1 /* voter */);
-	OPEN;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	/* Pending transaction */
-	PREPARE("BEGIN", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-	PREPARE("SELECT * FROM test", &stmt_id);
-	QUERY(stmt_id, &f->rows);
-	clientCloseRows(&f->rows);
-
-	/* Transfer leadership and wait until first leader has applied a new
-	 * entry replicated from the new leader.  */
-	test_server_client_connect(&f->servers[0], &c_transfer);
-	HANDSHAKE_C(&c_transfer);
-	TRANSFER(2, &c_transfer);
-	test_server_client_close(&f->servers[0], &c_transfer);
-	last_applied = f->servers[0].dqlite->raft.last_applied;
-
-	SELECT(2);
-	HANDSHAKE;
-	OPEN;
-	PREPARE("INSERT INTO test(n) VALUES(2)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	AWAIT_REPLICATION(0, last_applied + 1);
-
-	/* Transfer leadership back to original node, reconnect the client and
-	 * ensure queries can be executed. */
-	test_server_client_connect(&f->servers[1], &c_transfer);
-	HANDSHAKE_C(&c_transfer);
-	TRANSFER(1, &c_transfer);
-	test_server_client_close(&f->servers[1], &c_transfer);
-
-	last_applied = f->servers[1].dqlite->raft.last_applied;
-	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
-	SELECT(1);
-	HANDSHAKE;
-	OPEN;
-	PREPARE("INSERT INTO test(n) VALUES(3)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	AWAIT_REPLICATION(1, last_applied + 1);
-
 	return MUNIT_OK;
 }

--- a/test/lib/client.h
+++ b/test/lib/client.h
@@ -39,14 +39,6 @@
 		munit_assert_int(rv_, ==, 0);         \
 	}
 
-/* Send the initial client handshake for a specific client. */
-#define HANDSHAKE_C(CLIENT)                           \
-	{                                             \
-		int rv_;                              \
-		rv_ = clientSendHandshake(CLIENT);    \
-		munit_assert_int(rv_, ==, 0);         \
-	}
-
 /* Send an add request. */
 #define ADD(ID, ADDRESS)                                     \
 	{                                                    \
@@ -75,16 +67,6 @@
 		munit_assert_int(rv_, ==, 0);          \
 		rv_ = clientRecvEmpty(f->client);      \
 		munit_assert_int(rv_, ==, 0);          \
-	}
-
-/* Send a transfer request. */
-#define TRANSFER(ID, CLIENT)                             \
-	{                                                \
-		int rv_;                                 \
-		rv_ = clientSendTransfer(CLIENT, ID);    \
-		munit_assert_int(rv_, ==, 0);            \
-		rv_ = clientRecvEmpty(CLIENT);           \
-		munit_assert_int(rv_, ==, 0);            \
 	}
 
 /* Open a test database. */

--- a/test/lib/server.h
+++ b/test/lib/server.h
@@ -43,13 +43,7 @@ void test_server_network(struct test_server *servers, unsigned n_servers);
 /* Return a client connected to the server. */
 struct client *test_server_client(struct test_server *s);
 
-/* Closes and reopens a client connection to the server. */
-void test_server_client_reconnect(struct test_server *s, struct client *c);
-
-/* Opens a client connection to the server. */
-void test_server_client_connect(struct test_server *s, struct client *c);
-
-/* Closes a client connection to ther server. */
-void test_server_client_close(struct test_server *s, struct client *c);
+/* Closes and reopens the client connection to the server. */
+int test_server_client_reconnect(struct test_server *s);
 
 #endif /* TEST_SERVER_H */


### PR DESCRIPTION
Reverts canonical/dqlite#354

The LXD proxy is not liking the fact that I close the network connections, already have a fix for this, will revert for now.