### PR TITLE
Close leader sql connection

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -365,6 +365,15 @@ int clientSendRemove(struct client *c, unsigned id)
 	return 0;
 }
 
+int clientSendTransfer(struct client *c, unsigned id)
+{
+	tracef("client send transfer fd %d id %u", c->fd, id);
+	struct request_transfer request;
+	request.id = id;
+	REQUEST(transfer, TRANSFER);
+	return 0;
+}
+
 int clientRecvEmpty(struct client *c)
 {
 	tracef("client recv empty fd %d", c->fd);

--- a/src/client.h
+++ b/src/client.h
@@ -79,6 +79,9 @@ int clientSendAssign(struct client *c, unsigned id, int role);
 /* Send a request to remove a server from the cluster. */
 int clientSendRemove(struct client *c, unsigned id);
 
+/* Send a request to transfer leadership to node with id `id`. */
+int clientSendTransfer(struct client *c, unsigned id);
+
 /* Receive an empty response. */
 int clientRecvEmpty(struct client *c);
 

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -47,6 +47,12 @@ void gateway__init(struct gateway *g,
 void gateway__close(struct gateway *g);
 
 /**
+ * Closes the leader connection to the database, reason should contain a raft
+ * error code.
+ */
+void gateway__leader_close(struct gateway *g, int reason);
+
+/**
  * Asynchronous request to handle a client command.
  */
 typedef void (*handle_cb)(struct handle *req, int status, int type);

--- a/src/lib/registry.h
+++ b/src/lib/registry.h
@@ -55,7 +55,7 @@
 /**
  * Define the methods of a registry
  */
-#define REGISTRY_METHODS(NAME, TYPE)                                        \
+#define REGISTRY_METHODS(NAME, TYPE)                                                \
 	void NAME##_init(struct NAME *r) {                                          \
 		assert(r != NULL);                                                  \
                                                                                     \
@@ -82,8 +82,11 @@
 			}                                                           \
 		}                                                                   \
                                                                                     \
+		r->len = 0;                                                         \
+		r->cap = 0;                                                         \
 		if (r->buf != NULL) {                                               \
 			sqlite3_free(r->buf);                                       \
+			r->buf = NULL;                                              \
 		}                                                                   \
 	}                                                                           \
                                                                                     \

--- a/src/server.c
+++ b/src/server.c
@@ -572,27 +572,21 @@ static void monitor_cb(uv_prepare_t *monitor)
 {
 	struct dqlite_node *d = monitor->data;
 	int state = raft_state(&d->raft);
-	/*
 	queue *head;
 	struct conn *conn;
-	*/
 
 	if (state == RAFT_UNAVAILABLE) {
 		return;
 	}
 
-	/* TODO: we should shutdown clients that are performing SQL requests,
-	 * but not the ones which are doing management-requests, such as
-	 * transfer leadership.  */
-	/*
 	if (d->raft_state == RAFT_LEADER && state != RAFT_LEADER) {
+		tracef("node %llu@%s: leadership lost", d->raft.id, d->raft.address);
 		QUEUE__FOREACH(head, &d->conns)
 		{
 			conn = QUEUE__DATA(head, struct conn, queue);
-			conn__stop(conn);
+			gateway__leader_close(&conn->gateway, RAFT_LEADERSHIPLOST);
 		}
 	}
-	*/
 
 	d->raft_state = state;
 }

--- a/test/integration/test_fsm.c
+++ b/test/integration/test_fsm.c
@@ -188,8 +188,7 @@ TEST(fsm, snapshotHeapFaultTwoDB, setUp, tearDown, 0, NULL)
 	EXEC(stmt_id, &last_insert_id, &rows_affected);
 
 	/* Close and reopen the client and open a second database */
-	rv = test_server_client_reconnect(&f->servers[0]);
-	munit_assert_int(rv, ==, 0);
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
 
 	HANDSHAKE;
 	OPEN_NAME("test2");
@@ -253,8 +252,7 @@ TEST(fsm, snapshotNewDbAddedBeforeFinalize, setUp, tearDown, 0, NULL)
 
 	/* Close and reopen the client and open a second database,
 	 * and ensure finalize succeeds. */
-	rv = test_server_client_reconnect(&f->servers[0]);
-	munit_assert_int(rv, ==, 0);
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
 
 	HANDSHAKE;
 	OPEN_NAME("test2");
@@ -391,8 +389,7 @@ TEST(fsm, snapshotRestore, setUp, tearDown, 0, num_writes_params)
 	munit_assert_int(rv, ==, 0);
 
 	/* Table is there on fresh connection. */
-	rv = test_server_client_reconnect(&f->servers[0]);
-	munit_assert_int(rv, ==, 0);
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
 	HANDSHAKE;
 	OPEN;
 	PREPARE("SELECT COUNT(*) from test", &stmt_id);
@@ -469,8 +466,7 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, NULL)
 	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
 	EXEC(stmt_id, &last_insert_id, &rows_affected);
 
-	rv = test_server_client_reconnect(&f->servers[0]);
-	munit_assert_int(rv, ==, 0);
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
 	HANDSHAKE;
 	OPEN_NAME("test2");
 	PREPARE("CREATE TABLE test2a (n INT)", &stmt_id);
@@ -498,8 +494,7 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, NULL)
 	munit_assert_int(rv, ==, 0);
 
 	/* Reopen connection */
-	rv = test_server_client_reconnect(&f->servers[0]);
-	munit_assert_int(rv, ==, 0);
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
 	HANDSHAKE;
 	OPEN_NAME("test2");
 
@@ -514,8 +509,7 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, NULL)
 	munit_assert_string_equal(msg, "no such table: test2b");
 
 	/* Table is there on first DB */
-	rv = test_server_client_reconnect(&f->servers[0]);
-	munit_assert_int(rv, ==, 0);
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
 	HANDSHAKE;
 	OPEN_NAME("test");
 	PREPARE("SELECT * from test", &stmt_id);

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -17,7 +17,8 @@
 #define N_SERVERS 3
 #define FIXTURE                                \
 	struct test_server servers[N_SERVERS]; \
-	struct client *client
+	struct client *client;                 \
+	struct rows rows;
 
 #define SETUP                                                 \
 	unsigned i_;                                          \
@@ -50,6 +51,20 @@
 
 /* Use the client connected to the server with the given ID. */
 #define SELECT(ID) f->client = test_server_client(&f->servers[ID - 1])
+
+/* Wait a bounded time until server ID has applied at least the entry at INDEX */
+#define AWAIT_REPLICATION(ID, INDEX)							  \
+	do {										  \
+		struct timespec _start = {0};						  \
+		struct timespec _end = {0};						  \
+		clock_gettime(CLOCK_MONOTONIC, &_start);				  \
+		clock_gettime(CLOCK_MONOTONIC, &_end);					  \
+		while((f->servers[ID].dqlite->raft.last_applied < INDEX)		  \
+		      && ((_end.tv_sec - _start.tv_sec) < 2)  ) {			  \
+			clock_gettime(CLOCK_MONOTONIC, &_end);				  \
+		}									  \
+		munit_assert_ullong(f->servers[ID].dqlite->raft.last_applied, >=, INDEX); \
+	} while(0)
 
 /******************************************************************************
  *
@@ -105,5 +120,155 @@ TEST(membership, join, setUp, tearDown, 0, NULL)
 	/* TODO: fix the standalone test for remove */
 	SELECT(1);
 	REMOVE(id);
+	return MUNIT_OK;
+}
+
+TEST(membership, transfer, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	unsigned id = 2;
+	const char *address = "@2";
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	raft_index last_applied;
+	struct client c_transfer; /* Client used for transfer requests */
+
+	HANDSHAKE;
+	ADD(id, address);
+	ASSIGN(id, 1 /* voter */);
+	OPEN;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	/* Transfer leadership and wait until first leader has applied a new
+	 * entry replicated from the new leader.  */
+	test_server_client_connect(&f->servers[0], &c_transfer);
+	HANDSHAKE_C(&c_transfer);
+	TRANSFER(2, &c_transfer);
+	test_server_client_close(&f->servers[0], &c_transfer);
+	last_applied = f->servers[0].dqlite->raft.last_applied;
+
+	SELECT(2);
+	HANDSHAKE;
+	OPEN;
+	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	AWAIT_REPLICATION(0, last_applied + 1);
+
+	return MUNIT_OK;
+}
+
+/* Transfer leadership away from a member that has a pending transaction */
+TEST(membership, transferPendingTransaction, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	unsigned id = 2;
+	const char *address = "@2";
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	raft_index last_applied;
+	struct client c_transfer; /* Client used for transfer requests */
+
+	HANDSHAKE;
+	ADD(id, address);
+	ASSIGN(id, 1 /* voter */);
+	OPEN;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	/* Pending transaction */
+	PREPARE("BEGIN", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("SELECT * FROM test", &stmt_id);
+	QUERY(stmt_id, &f->rows);
+	clientCloseRows(&f->rows);
+
+	/* Transfer leadership and wait until first leader has applied a new
+	 * entry replicated from the new leader.  */
+	test_server_client_connect(&f->servers[0], &c_transfer);
+	HANDSHAKE_C(&c_transfer);
+	TRANSFER(2, &c_transfer);
+	test_server_client_close(&f->servers[0], &c_transfer);
+	last_applied = f->servers[0].dqlite->raft.last_applied;
+
+	SELECT(2);
+	HANDSHAKE;
+	OPEN;
+	PREPARE("INSERT INTO test(n) VALUES(2)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	AWAIT_REPLICATION(0, last_applied + 1);
+
+	return MUNIT_OK;
+}
+
+/* Transfer leadership back and forth from a member that has a pending transaction */
+TEST(membership, transferTwicePendingTransaction, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	unsigned id = 2;
+	const char *address = "@2";
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	raft_index last_applied;
+	struct client c_transfer; /* Client used for transfer requests */
+
+	HANDSHAKE;
+	ADD(id, address);
+	ASSIGN(id, 1 /* voter */);
+	OPEN;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	/* Pending transaction */
+	PREPARE("BEGIN", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("SELECT * FROM test", &stmt_id);
+	QUERY(stmt_id, &f->rows);
+	clientCloseRows(&f->rows);
+
+	/* Transfer leadership and wait until first leader has applied a new
+	 * entry replicated from the new leader.  */
+	test_server_client_connect(&f->servers[0], &c_transfer);
+	HANDSHAKE_C(&c_transfer);
+	TRANSFER(2, &c_transfer);
+	test_server_client_close(&f->servers[0], &c_transfer);
+	last_applied = f->servers[0].dqlite->raft.last_applied;
+
+	SELECT(2);
+	HANDSHAKE;
+	OPEN;
+	PREPARE("INSERT INTO test(n) VALUES(2)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	AWAIT_REPLICATION(0, last_applied + 1);
+
+	/* Transfer leadership back to original node, reconnect the client and
+	 * ensure queries can be executed. */
+	test_server_client_connect(&f->servers[1], &c_transfer);
+	HANDSHAKE_C(&c_transfer);
+	TRANSFER(1, &c_transfer);
+	test_server_client_close(&f->servers[1], &c_transfer);
+
+	last_applied = f->servers[1].dqlite->raft.last_applied;
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+	SELECT(1);
+	HANDSHAKE;
+	OPEN;
+	PREPARE("INSERT INTO test(n) VALUES(3)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	AWAIT_REPLICATION(1, last_applied + 1);
+
 	return MUNIT_OK;
 }

--- a/test/lib/client.h
+++ b/test/lib/client.h
@@ -39,6 +39,14 @@
 		munit_assert_int(rv_, ==, 0);         \
 	}
 
+/* Send the initial client handshake for a specific client. */
+#define HANDSHAKE_C(CLIENT)                           \
+	{                                             \
+		int rv_;                              \
+		rv_ = clientSendHandshake(CLIENT);    \
+		munit_assert_int(rv_, ==, 0);         \
+	}
+
 /* Send an add request. */
 #define ADD(ID, ADDRESS)                                     \
 	{                                                    \
@@ -67,6 +75,16 @@
 		munit_assert_int(rv_, ==, 0);          \
 		rv_ = clientRecvEmpty(f->client);      \
 		munit_assert_int(rv_, ==, 0);          \
+	}
+
+/* Send a transfer request. */
+#define TRANSFER(ID, CLIENT)                             \
+	{                                                \
+		int rv_;                                 \
+		rv_ = clientSendTransfer(CLIENT, ID);    \
+		munit_assert_int(rv_, ==, 0);            \
+		rv_ = clientRecvEmpty(CLIENT);           \
+		munit_assert_int(rv_, ==, 0);            \
 	}
 
 /* Open a test database. */

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -17,8 +17,7 @@ static int endpointConnect(void *data,
 	*fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	munit_assert_int(*fd, !=, -1);
 	rv = connect(*fd, (struct sockaddr *)&addr, sizeof(sa_family_t) + strlen(address + 1) + 1);
-	munit_assert_int(rv, ==, 0);
-	return 0;
+	return rv;
 }
 
 void test_server_setup(struct test_server *s,

--- a/test/lib/server.h
+++ b/test/lib/server.h
@@ -43,7 +43,13 @@ void test_server_network(struct test_server *servers, unsigned n_servers);
 /* Return a client connected to the server. */
 struct client *test_server_client(struct test_server *s);
 
-/* Closes and reopens the client connection to the server. */
-int test_server_client_reconnect(struct test_server *s);
+/* Closes and reopens a client connection to the server. */
+void test_server_client_reconnect(struct test_server *s, struct client *c);
+
+/* Opens a client connection to the server. */
+void test_server_client_connect(struct test_server *s, struct client *c);
+
+/* Closes a client connection to ther server. */
+void test_server_client_close(struct test_server *s, struct client *c);
 
 #endif /* TEST_SERVER_H */


### PR DESCRIPTION
As discussed in https://github.com/canonical/go-dqlite/pull/186, similar to https://github.com/canonical/dqlite/pull/354, but instead of closing the network connection, it only closes the `gateway->leader` and the SQLite connection it contains. Only the last commit contains unreviewed changes.

Ongoing requests will be canceled with `LEADERSHIP_LOST`, future requests will err out with `SQLITE_NOTFOUND` because the database is not opened. This should be viewed in conjunction with https://github.com/canonical/go-dqlite/pull/187 that will mark the connection as bad resulting in the driver to reopen a new connection.

`LOOKUP_DB` at the start of the gateway functions that deal with the SQLite leader connection will err out with `SQLITE_NOTFOUND` after the node has lost leadership, so a leader connection that has lost leadership once will remain broken.

fixes https://github.com/canonical/dqlite/issues/355