### PR TITLE
Remove the legacy "done" field from struct exec

### DIFF
--- a/src/leader.h
+++ b/src/leader.h
@@ -64,7 +64,6 @@ struct exec
 	struct leader *leader;
 	struct barrier barrier;
 	sqlite3_stmt *stmt;
-	bool done;
 	int status;
 	queue queue;
 	exec_cb cb;


### PR DESCRIPTION
This field was necessary only in the old implementation that used coroutines and
the patched SQLite version. It can be dropped now.