### PR TITLE
Add missing install of dependency liblz4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GOROOT=/usr/local/go
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
-RUN apt-get update && apt-get install -y git build-essential dh-autoreconf pkg-config libuv1-dev libsqlite3-dev tcl8.6 wget
+RUN apt-get update && apt-get install -y git build-essential dh-autoreconf pkg-config libuv1-dev libsqlite3-dev liblz4-dev tcl8.6 wget
 
 WORKDIR /opt
 


### PR DESCRIPTION
Trying to build using the Dockerfile lead to an error as liblz4 was not installed.

Unfortunately something else is also borked as it now stops when compiling dqlite:
```s
[..]
Step 13/22 : WORKDIR /opt/dqlite
 ---> Running in 5777fd6ffc1b
Removing intermediate container 5777fd6ffc1b
 ---> 3e24e33ab8a9
Step 14/22 : COPY . .
 ---> c86f93df29cf
Step 15/22 : RUN autoreconf -i && ./configure && make && make install
 ---> Running in f71c6f639f7d
autoreconf: error: 'configure.ac' is required
The command '/bin/sh -c autoreconf -i && ./configure && make && make install' returned a non-zero code: 1
```

I didnt have time so far to look into the issue.