### PR TITLE
integration-tests: Control raft snapshot threshold

### DIFF
--- a/test/integration/test_client.c
+++ b/test/integration/test_client.c
@@ -25,7 +25,7 @@ static void *setUp(const MunitParameter params[], void *user_data)
 	test_heap_setup(params, user_data);
 	test_sqlite_setup(params);
 	test_server_setup(&f->server, 1, params);
-	test_server_start(&f->server);
+	test_server_start(&f->server, params);
 	f->client = test_server_client(&f->server);
 	HANDSHAKE;
 	OPEN;

--- a/test/integration/test_cluster.c
+++ b/test/integration/test_cluster.c
@@ -30,7 +30,7 @@
 	test_server_network(f->servers, N_SERVERS);           \
 	for (i_ = 0; i_ < N_SERVERS; i_++) {                  \
 		struct test_server *server = &f->servers[i_]; \
-		test_server_start(server);                    \
+		test_server_start(server, params);            \
 	}                                                     \
 	SELECT(1)
 
@@ -109,7 +109,7 @@ TEST(cluster, restart, setUp, tearDown, 0, num_records_params)
 
 	struct test_server *server = &f->servers[0];
 	test_server_stop(server);
-	test_server_start(server);
+	test_server_start(server, params);
 
 	/* The table is visible after restart. */
 	HANDSHAKE;

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -31,7 +31,7 @@
 	test_server_network(f->servers, N_SERVERS);           \
 	for (i_ = 0; i_ < N_SERVERS; i_++) {                  \
 		struct test_server *server = &f->servers[i_]; \
-		test_server_start(server);                    \
+		test_server_start(server, params);            \
 	}                                                     \
 	SELECT(1)
 

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -50,7 +50,7 @@ void test_server_tear_down(struct test_server *s)
 	test_dir_tear_down(s->dir);
 }
 
-void test_server_start(struct test_server *s)
+void test_server_start(struct test_server *s, const MunitParameter params[])
 {
 	int rv;
 
@@ -65,6 +65,13 @@ void test_server_start(struct test_server *s)
 
 	rv = dqlite_node_set_network_latency_ms(s->dqlite, 10);
 	munit_assert_int(rv, ==, 0);
+
+	if (munit_parameters_get(params, SNAPSHOT_THRESHOLD_PARAM) != NULL) {
+		unsigned threshold = (unsigned)atoi(munit_parameters_get(
+			    params, SNAPSHOT_THRESHOLD_PARAM));
+		rv = dqlite_node_set_snapshot_params(s->dqlite, threshold, threshold);
+		munit_assert_int(rv, ==, 0);
+	}
 
 	rv = dqlite_node_start(s->dqlite);
 	munit_assert_int(rv, ==, 0);

--- a/test/lib/server.h
+++ b/test/lib/server.h
@@ -13,6 +13,8 @@
 #include "endpoint.h"
 #include "munit.h"
 
+#define SNAPSHOT_THRESHOLD_PARAM "snapshot-threshold"
+
 struct test_server
 {
 	unsigned id;                   /* Server ID. */
@@ -32,7 +34,7 @@ void test_server_setup(struct test_server *s,
 void test_server_tear_down(struct test_server *s);
 
 /* Start the test server. */
-void test_server_start(struct test_server *s);
+void test_server_start(struct test_server *s, const MunitParameter params[]);
 
 /* Stop the test server. */
 void test_server_stop(struct test_server *s);


### PR DESCRIPTION
Don't allow snapshots scheduled by raft to interfere with the snapshots
scheduled by the tests.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>

--------------------------

Should fix https://github.com/canonical/dqlite/issues/374

Excerpt from log:
```
LIBRAFT   1657742953408318749 src/replication.c:472 leader: written 1 entries starting at 2204: status 0
LIBRAFT   1657742953408321889 src/replication.c:1595 new commit index 2204
LIBDQLITE 1657742953408323819 fsm__apply:311 fsm apply
LIBDQLITE 1657742953408325839 apply_frames:184 fsm apply frames
LIBDQLITE 1657742953408328429 VfsApply:2390 vfs apply filename test n 1
LIBDQLITE 1657742953408331719 maybeCheckpoint:86 maybe checkpoint
LIBDQLITE 1657742953408333709 maybeCheckpoint:103 busy snapshot -1
LIBDQLITE 1657742953408335579 leaderApplyFramesCb:224 apply frames cb
LIBDQLITE 1657742953408337389 leaderMaybeCheckpointLegacy:170 leader maybe checkpoint legacy
LIBDQLITE 1657742953408342149 gateway__resume:1101 gateway resume - finished
LIBDQLITE 1657742953408345289 clientRecvResult:219 client recv result fd 14 last_insert_id 2200 rows_affected 1
Error: test/integration/test_fsm.c:379: assertion failed: rv == 0 (17 == 0)
```

A snapshot scheduled by raft is still busy while the test tries to take a snapshot, resulting in a `RAFT_BUSY` return code.
This is the second snapshot taken during the test and the timing is consistent with the time it took to take the first snapshot, so it's not a snapshot that somehow failed to clean up state.