### PR TITLE
Fix non-dqlite return codes in public API

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -710,6 +710,7 @@ int dqlite_node_start(dqlite_node *t)
 	rv = pthread_create(&t->thread, 0, &taskStart, t);
 	if (rv != 0) {
 		tracef("pthread create failed %d", rv);
+		rv = DQLITE_ERROR;
 		goto err;
 	}
 

--- a/src/server.c
+++ b/src/server.c
@@ -61,9 +61,7 @@ int dqlite__init(struct dqlite_node *d,
 	rv = raft_init(&d->raft, &d->raft_io, &d->raft_fsm, d->config.id,
 		       d->config.address);
 	if (rv != 0) {
-		snprintf(d->errmsg, RAFT_ERRMSG_BUF_SIZE, "raft_init(): %s",
-			 raft_errmsg(&d->raft));
-		return rv;
+		return DQLITE_ERROR;
 	}
 	/* TODO: expose these values through some API */
 	raft_set_election_timeout(&d->raft, 3000);


### PR DESCRIPTION
This fixes a couple of cases where a function belonging to the dqlite public API could return with a non-dqlite error code. See #379 -- I've left src/vfs.c alone for now because I'm not sure whether the functions in src/vfs.h should be using dqlite return codes or sqlite codes, but I can add a commit addressing those functions once the convention is established.