### PR TITLE
Expose string errors from dqlite_node_create

### DIFF
--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -60,6 +60,12 @@ typedef unsigned long long dqlite_node_id;
  * No reference to the memory pointed to by @address and @data_dir is kept by
  * the dqlite library, so any memory associated with them can be released after
  * the function returns.
+ *
+ * Even if an error is returned, the caller should call dqlite_node_destroy()
+ * on the dqlite_node* value pointed to by @n, and calling dqlite_node_errmsg()
+ * with that value will return a valid error string. (In some cases *n will be
+ * set to NULL, but dqlite_node_destroy() and dqlite_node_errmsg() will handle
+ * this gracefully.)
  */
 int dqlite_node_create(dqlite_node_id id,
 		       const char *address,

--- a/src/server.c
+++ b/src/server.c
@@ -400,7 +400,7 @@ static int maybeBootstrap(dqlite_node *d,
 		if (rv == RAFT_CANTBOOTSTRAP) {
 			rv = 0;
 		} else {
-			snprintf(d->errmsg, RAFT_ERRMSG_BUF_SIZE, "raft_bootstrap(): %s",
+			snprintf(d->errmsg, DQLITE_ERRMSG_BUF_SIZE, "raft_bootstrap(): %s",
 				 raft_errmsg(&d->raft));
 			rv = DQLITE_ERROR;
 		}
@@ -625,7 +625,7 @@ static int taskRun(struct dqlite_node *d)
 	d->raft.data = d;
 	rv = raft_start(&d->raft);
 	if (rv != 0) {
-		snprintf(d->errmsg, RAFT_ERRMSG_BUF_SIZE, "raft_start(): %s",
+		snprintf(d->errmsg, DQLITE_ERRMSG_BUF_SIZE, "raft_start(): %s",
 			 raft_errmsg(&d->raft));
 		/* Unblock any client of taskReady */
 #ifdef __APPLE__

--- a/src/server.h
+++ b/src/server.h
@@ -13,6 +13,8 @@
 #include "logger.h"
 #include "registry.h"
 
+#define DQLITE_ERRMSG_BUF_SIZE 300
+
 /**
  * A single dqlite server instance.
  */
@@ -45,7 +47,7 @@ struct dqlite_node
 	struct uv_prepare_s monitor;             /* Raft state change monitor */
 	int raft_state;                          /* Previous raft state */
 	char *bind_address;                      /* Listen address */
-	char errmsg[RAFT_ERRMSG_BUF_SIZE];       /* Last error occurred */
+	char errmsg[DQLITE_ERRMSG_BUF_SIZE];     /* Last error occurred */
 };
 
 int dqlite__init(struct dqlite_node *d,

--- a/src/server.h
+++ b/src/server.h
@@ -18,6 +18,8 @@
  */
 struct dqlite_node
 {
+	bool initialized;                        /* dqlite__init succeeded */
+
 	pthread_t thread;                        /* Main run loop thread. */
 	struct config config;                    /* Config values */
 	struct sqlite3_vfs vfs;                  /* In-memory VFS */


### PR DESCRIPTION
This implements roughly @freeekanayaka's suggestion in https://github.com/canonical/raft/issues/228. If we agree this is the way to go, I'll make a PR to go-dqlite to adjust its behavior accordingly.

Note that unlike Free's sample code in that thread, I don't differentiate in the public API between DQLITE_NOMEM errors and other kinds of errors. Instead, dqlite_node_errmsg and dqlite_node_destroy just handle NULL arguments gracefully. I went this route because it makes callers' lives simpler and because DQLITE_NOMEM is an ambiguous signal -- was it the `struct dqlite_node` allocation that failed, or some other allocation along the way?