### PR TITLE
Move endian-sensitive code to src/lib/byte.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,7 @@ unit_test_SOURCES += \
   test/unit/ext/test_uv.c \
   test/unit/lib/test_addr.c \
   test/unit/lib/test_buffer.c \
+  test/unit/lib/test_byte.c \
   test/unit/lib/test_registry.c \
   test/unit/lib/test_serialize.c \
   test/unit/lib/test_transport.c \

--- a/src/client.c
+++ b/src/client.c
@@ -51,7 +51,7 @@ int clientSendHandshake(struct client *c)
 
 	tracef("client send handshake fd %d", c->fd);
 	/* TODO: update to version 1 */
-	protocol = byte__flip64(DQLITE_PROTOCOL_VERSION_LEGACY);
+	protocol = ByteFlipLe64(DQLITE_PROTOCOL_VERSION_LEGACY);
 
 	rv = write(c->fd, &protocol, sizeof protocol);
 	if (rv < 0) {
@@ -277,7 +277,7 @@ int clientRecvRows(struct client *c, struct rows *rows)
 			/* No EOF marker fond */
 			return DQLITE_ERROR;
 		}
-		eof = byte__flip64(*(uint64_t *)cursor.p);
+		eof = ByteFlipLe64(*(uint64_t *)cursor.p);
 		if (eof == DQLITE_RESPONSE_ROWS_DONE ||
 		    eof == DQLITE_RESPONSE_ROWS_PART) {
 			break;

--- a/src/lib/byte.h
+++ b/src/lib/byte.h
@@ -89,6 +89,25 @@ DQLITE_INLINE uint64_t ByteFlipLe64(uint64_t v)
 #endif
 }
 
+DQLITE_INLINE uint16_t ByteGetBe16(const uint8_t *buf)
+{
+	return ((uint16_t)(buf[0]) << 8) | (uint16_t)(buf[1]);
+}
+
+DQLITE_INLINE uint32_t ByteGetBe32(const uint8_t *buf)
+{
+	return ((uint32_t)(buf[0]) << 24) | ((uint32_t)(buf[1]) << 16) |
+	       ((uint32_t)(buf[2]) << 8) | (uint32_t)(buf[3]);
+}
+
+DQLITE_INLINE void BytePutBe32(uint32_t v, uint8_t *buf)
+{
+	buf[0] = (uint8_t)(v >> 24);
+	buf[1] = (uint8_t)(v >> 16);
+	buf[2] = (uint8_t)(v >> 8);
+	buf[3] = (uint8_t)v;
+}
+
 /**
  * Add padding to size if it's not a multiple of 8. E.g. if 11 is passed, 16 is
  * returned.

--- a/src/lib/byte.h
+++ b/src/lib/byte.h
@@ -22,7 +22,7 @@
 #endif
 
 /* Flip a 16-bit number to little-endian byte order */
-DQLITE_INLINE uint16_t byte__flip16(uint16_t v)
+DQLITE_INLINE uint16_t ByteFlipLe16(uint16_t v)
 {
 #if defined(DQLITE_LITTLE_ENDIAN)
 	return v;
@@ -42,7 +42,7 @@ DQLITE_INLINE uint16_t byte__flip16(uint16_t v)
 }
 
 /* Flip a 32-bit number to little-endian byte order */
-DQLITE_INLINE uint32_t byte__flip32(uint32_t v)
+DQLITE_INLINE uint32_t ByteFlipLe32(uint32_t v)
 {
 #if defined(DQLITE_LITTLE_ENDIAN)
 	return v;
@@ -64,7 +64,7 @@ DQLITE_INLINE uint32_t byte__flip32(uint32_t v)
 }
 
 /* Flip a 64-bit number to little-endian byte order */
-DQLITE_INLINE uint64_t byte__flip64(uint64_t v)
+DQLITE_INLINE uint64_t ByteFlipLe64(uint64_t v)
 {
 #if defined(DQLITE_LITTLE_ENDIAN)
 	return v;
@@ -93,7 +93,7 @@ DQLITE_INLINE uint64_t byte__flip64(uint64_t v)
  * Add padding to size if it's not a multiple of 8. E.g. if 11 is passed, 16 is
  * returned.
  */
-DQLITE_INLINE size_t byte__pad64(size_t size)
+DQLITE_INLINE size_t BytePad64(size_t size)
 {
 	size_t rest = size % sizeof(uint64_t);
 	if (rest != 0) {

--- a/src/lib/byte.h
+++ b/src/lib/byte.h
@@ -11,13 +11,22 @@
 #define DQLITE_INLINE static inline
 #endif
 
-/* Flip a 16-bit number to network byte order (little endian) */
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define DQLITE_LITTLE_ENDIAN
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define DQLITE_BIG_ENDIAN
+#endif
+
+#if defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8
+#define DQLITE_HAVE_BSWAP
+#endif
+
+/* Flip a 16-bit number to little-endian byte order */
 DQLITE_INLINE uint16_t byte__flip16(uint16_t v)
 {
-#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __LITTLE_ENDIAN__)
+#if defined(DQLITE_LITTLE_ENDIAN)
 	return v;
-#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __BIG_ENDIAN__) && \
-    defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8
+#elif defined(DQLITE_BIG_ENDIAN) && defined(DQLITE_HAVE_BSWAP)
 	return __builtin_bswap16(v);
 #else
 	union {
@@ -32,13 +41,12 @@ DQLITE_INLINE uint16_t byte__flip16(uint16_t v)
 #endif
 }
 
-/* Flip a 32-bit number to network byte order (little endian) */
+/* Flip a 32-bit number to little-endian byte order */
 DQLITE_INLINE uint32_t byte__flip32(uint32_t v)
 {
-#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __LITTLE_ENDIAN__)
+#if defined(DQLITE_LITTLE_ENDIAN)
 	return v;
-#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __BIG_ENDIAN__) && \
-    defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8
+#elif defined(DQLITE_BIG_ENDIAN) && defined(DQLITE_HAVE_BSWAP)
 	return __builtin_bswap32(v);
 #else
 	union {
@@ -55,13 +63,12 @@ DQLITE_INLINE uint32_t byte__flip32(uint32_t v)
 #endif
 }
 
-/* Flip a 64-bit number to network byte order (little endian) */
+/* Flip a 64-bit number to little-endian byte order */
 DQLITE_INLINE uint64_t byte__flip64(uint64_t v)
 {
-#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __LITTLE_ENDIAN__)
+#if defined(DQLITE_LITTLE_ENDIAN)
 	return v;
-#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __BIG_ENDIAN__) && \
-    defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8
+#elif defined(DQLITE_BIG_ENDIAN) && defined(DQLITE_HAVE_BSWAP)
 	return __builtin_bswap64(v);
 #else
 	union {

--- a/src/lib/serialize.h
+++ b/src/lib/serialize.h
@@ -151,13 +151,13 @@ DQLITE_INLINE size_t float__sizeof(const float_t *value)
 
 DQLITE_INLINE size_t text__sizeof(const text_t *value)
 {
-	return byte__pad64(strlen(*value) + 1);
+	return BytePad64(strlen(*value) + 1);
 }
 
 DQLITE_INLINE size_t blob__sizeof(const blob_t *value)
 {
 	return sizeof(uint64_t) /* length */ +
-	       byte__pad64(value->len) /* data */;
+	       BytePad64(value->len) /* data */;
 }
 
 DQLITE_INLINE void uint8__encode(const uint8_t *value, void **cursor)
@@ -168,37 +168,37 @@ DQLITE_INLINE void uint8__encode(const uint8_t *value, void **cursor)
 
 DQLITE_INLINE void uint16__encode(const uint16_t *value, void **cursor)
 {
-	*(uint16_t *)(*cursor) = byte__flip16(*value);
+	*(uint16_t *)(*cursor) = ByteFlipLe16(*value);
 	*cursor += sizeof(uint16_t);
 }
 
 DQLITE_INLINE void uint32__encode(const uint32_t *value, void **cursor)
 {
-	*(uint32_t *)(*cursor) = byte__flip32(*value);
+	*(uint32_t *)(*cursor) = ByteFlipLe32(*value);
 	*cursor += sizeof(uint32_t);
 }
 
 DQLITE_INLINE void uint64__encode(const uint64_t *value, void **cursor)
 {
-	*(uint64_t *)(*cursor) = byte__flip64(*value);
+	*(uint64_t *)(*cursor) = ByteFlipLe64(*value);
 	*cursor += sizeof(uint64_t);
 }
 
 DQLITE_INLINE void int64__encode(const int64_t *value, void **cursor)
 {
-	*(int64_t *)(*cursor) = (int64_t)byte__flip64((uint64_t)*value);
+	*(int64_t *)(*cursor) = (int64_t)ByteFlipLe64((uint64_t)*value);
 	*cursor += sizeof(int64_t);
 }
 
 DQLITE_INLINE void float__encode(const float_t *value, void **cursor)
 {
-	*(uint64_t *)(*cursor) = byte__flip64(*(uint64_t *)value);
+	*(uint64_t *)(*cursor) = ByteFlipLe64(*(uint64_t *)value);
 	*cursor += sizeof(uint64_t);
 }
 
 DQLITE_INLINE void text__encode(const text_t *value, void **cursor)
 {
-	size_t len = byte__pad64(strlen(*value) + 1);
+	size_t len = BytePad64(strlen(*value) + 1);
 	memset(*cursor, 0, len);
 	strcpy(*cursor, *value);
 	*cursor += len;
@@ -206,7 +206,7 @@ DQLITE_INLINE void text__encode(const text_t *value, void **cursor)
 
 DQLITE_INLINE void blob__encode(const blob_t *value, void **cursor)
 {
-	size_t len = byte__pad64(value->len);
+	size_t len = BytePad64(value->len);
 	uint64_t value_len = value->len;
 	uint64__encode(&value_len, cursor);
 	memcpy(*cursor, value->base, value->len);
@@ -231,7 +231,7 @@ DQLITE_INLINE int uint16__decode(struct cursor *cursor, uint16_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = byte__flip16(*(uint16_t *)cursor->p);
+	*value = ByteFlipLe16(*(uint16_t *)cursor->p);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -243,7 +243,7 @@ DQLITE_INLINE int uint32__decode(struct cursor *cursor, uint32_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = byte__flip32(*(uint32_t *)cursor->p);
+	*value = ByteFlipLe32(*(uint32_t *)cursor->p);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -255,7 +255,7 @@ DQLITE_INLINE int uint64__decode(struct cursor *cursor, uint64_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = byte__flip64(*(uint64_t *)cursor->p);
+	*value = ByteFlipLe64(*(uint64_t *)cursor->p);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -267,7 +267,7 @@ DQLITE_INLINE int int64__decode(struct cursor *cursor, int64_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = (int64_t)byte__flip64((uint64_t)*(int64_t *)cursor->p);
+	*value = (int64_t)ByteFlipLe64((uint64_t)*(int64_t *)cursor->p);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -279,7 +279,7 @@ DQLITE_INLINE int float__decode(struct cursor *cursor, float_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*(uint64_t *)value = byte__flip64(*(uint64_t *)cursor->p);
+	*(uint64_t *)value = ByteFlipLe64(*(uint64_t *)cursor->p);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -294,7 +294,7 @@ DQLITE_INLINE int text__decode(struct cursor *cursor, text_t *value)
 		return DQLITE_PARSE;
 	}
 	*value = cursor->p;
-	n = byte__pad64(strlen(*value) + 1);
+	n = BytePad64(strlen(*value) + 1);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -309,7 +309,7 @@ DQLITE_INLINE int blob__decode(struct cursor *cursor, blob_t *value)
 	if (rv != 0) {
 		return rv;
 	}
-	n = byte__pad64((size_t)len);
+	n = BytePad64((size_t)len);
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}

--- a/src/transport.c
+++ b/src/transport.c
@@ -83,7 +83,7 @@ static void connect_work_cb(uv_work_t *work)
 	}
 
 	/* Send the initial dqlite protocol handshake. */
-	protocol = byte__flip64(DQLITE_PROTOCOL_VERSION);
+	protocol = ByteFlipLe64(DQLITE_PROTOCOL_VERSION);
 	rv = (int)write(r->fd, &protocol, sizeof protocol);
 	if (rv != sizeof protocol) {
                 tracef("write failed");

--- a/src/tuple.c
+++ b/src/tuple.c
@@ -22,13 +22,13 @@ static size_t calc_header_size(unsigned n, int format)
 		if (n % 2 != 0) {
 			size += sizeof(uint8_t);
 		}
-		size = byte__pad64(size);
+		size = BytePad64(size);
 	} else {
 		assert(format == TUPLE__PARAMS);
 		 /* Include params count for the purpose of calculating possible
 		  * padding, but then exclude it as we have already read it. */
 		size = sizeof(uint8_t) + n * sizeof(uint8_t);
-		size = byte__pad64(size);
+		size = BytePad64(size);
 		size -= sizeof(uint8_t);
 	}
 

--- a/test/unit/lib/test_byte.c
+++ b/test/unit/lib/test_byte.c
@@ -1,0 +1,126 @@
+#include "../../../src/lib/byte.h"
+
+#include "../../lib/runner.h"
+
+TEST_MODULE(lib_addr);
+TEST_SUITE(endian);
+
+static uint16_t vfsFlip16(uint16_t v)
+{
+#if defined(DQLITE_BIG_ENDIAN)
+	return v;
+#elif defined(DQLITE_LITTLE_ENDIAN) && defined(DQLITE_HAVE_BSWAP)
+    defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 8
+	return __builtin_bswap16(v);
+#else
+	union {
+		uint16_t u;
+		uint8_t v[4];
+	} s;
+
+	s.v[0] = (uint8_t)(v >> 8);
+	s.v[1] = (uint8_t)v;
+
+	return s.u;
+#endif
+}
+
+static uint32_t vfsFlip32(uint32_t v)
+{
+#if defined(DQLITE_BIG_ENDIAN)
+	return v;
+#elif defined(DQLITE_LITTLE_ENDIAN) && defined(DQLITE_HAVE_BSWAP)
+	return __builtin_bswap32(v);
+#else
+	union {
+		uint32_t u;
+		uint8_t v[4];
+	} s;
+
+	s.v[0] = (uint8_t)(v >> 24);
+	s.v[1] = (uint8_t)(v >> 16);
+	s.v[2] = (uint8_t)(v >> 8);
+	s.v[3] = (uint8_t)v;
+
+	return s.u;
+#endif
+}
+
+static uint16_t vfsGet16(const uint8_t *buf)
+{
+	union {
+		uint16_t u;
+		uint8_t v[2];
+	} s;
+
+	s.v[0] = buf[0];
+	s.v[1] = buf[1];
+
+	return vfsFlip16(s.u);
+}
+
+static uint32_t vfsGet32(const uint8_t *buf)
+{
+	union {
+		uint32_t u;
+		uint8_t v[4];
+	} s;
+
+	s.v[0] = buf[0];
+	s.v[1] = buf[1];
+	s.v[2] = buf[2];
+	s.v[3] = buf[3];
+
+	return vfsFlip32(s.u);
+}
+
+static void vfsPut32(uint32_t v, uint8_t *buf)
+{
+	uint32_t u = vfsFlip32(v);
+	memcpy(buf, &u, sizeof u);
+}
+
+TEST_CASE(endian, get16, NULL)
+{
+	(void)params;
+	(void)data;
+	uint16_t x, y;
+	uint8_t buf[2];
+	for (x = 0; x < 1 << 8; x++) {
+		for (y = 0; y < 1 << 8; y++) {
+			buf[0] = (uint8_t)x;
+			buf[1] = (uint8_t)y;
+			munit_assert_uint16(ByteGetBe16(buf), ==, vfsGet16(buf));
+		}
+	}
+	return MUNIT_OK;
+}
+
+TEST_CASE(endian, get32, NULL)
+{
+	(void)params;
+	(void)data;
+	uint8_t buf[4];
+	uint32_t i;
+	for (i = 0; i < 1 << 16; i++) {
+		munit_rand_memory(4, buf);
+		munit_assert_uint32(ByteGetBe32(buf), ==, vfsGet32(buf));
+	}
+	return MUNIT_OK;
+}
+
+TEST_CASE(endian, put32, NULL)
+{
+	(void)params;
+	(void)data;
+	uint32_t v;
+	uint8_t buf[4], vfs_buf[4];
+	uint32_t i;
+	for (i = 0; i < (1 << 16); i++) {
+		v = munit_rand_uint32();
+		BytePutBe32(v, buf);
+		vfsPut32(v, vfs_buf);
+		munit_assert_memory_equal(4, buf, vfs_buf);
+	}
+	return MUNIT_OK;
+}

--- a/test/unit/lib/test_serialize.c
+++ b/test/unit/lib/test_serialize.c
@@ -203,7 +203,7 @@ TEST_CASE(encode, padding, NULL)
 	cursor = buf;
 	person__encode(&f->person, &cursor);
 	munit_assert_string_equal(buf, "John Doh");
-	munit_assert_int(byte__flip64(*(uint64_t *)(buf + 16)), ==, 40);
+	munit_assert_int(ByteFlipLe64(*(uint64_t *)(buf + 16)), ==, 40);
 	free(buf);
 	return MUNIT_OK;
 }
@@ -223,7 +223,7 @@ TEST_CASE(encode, no_padding, NULL)
 	cursor = buf;
 	person__encode(&f->person, &cursor);
 	munit_assert_string_equal(buf, "Joe Doh");
-	munit_assert_int(byte__flip64(*(uint64_t *)(buf + 8)), ==, 40);
+	munit_assert_int(ByteFlipLe64(*(uint64_t *)(buf + 8)), ==, 40);
 	free(buf);
 	return MUNIT_OK;
 }
@@ -265,13 +265,13 @@ TEST_CASE(encode, custom, NULL)
 	munit_assert_string_equal(cursor, "Victor Hugo");
 	cursor += 16;
 
-	munit_assert_int(byte__flip64(*(uint64_t *)cursor), ==, 40);
+	munit_assert_int(ByteFlipLe64(*(uint64_t *)cursor), ==, 40);
 	cursor += 8;
 
-	munit_assert_int(byte__flip16(*(uint16_t *)cursor), ==, 2);
+	munit_assert_int(ByteFlipLe16(*(uint16_t *)cursor), ==, 2);
 	cursor += 2;
 
-	munit_assert_int(byte__flip16(*(uint16_t *)cursor), ==, 8);
+	munit_assert_int(ByteFlipLe16(*(uint16_t *)cursor), ==, 8);
 	cursor += 2;
 
 	cursor += 4; /* Unused */
@@ -305,7 +305,7 @@ TEST_CASE(decode, padding, NULL)
 	struct cursor cursor = {buf, 16 + 8};
 	(void)params;
 	strcpy(buf, "John Doh");
-	*(uint64_t *)(buf + 16) = byte__flip64(40);
+	*(uint64_t *)(buf + 16) = ByteFlipLe64(40);
 	person__decode(&cursor, &f->person);
 	munit_assert_string_equal(f->person.name, "John Doh");
 	munit_assert_int(f->person.age, ==, 40);
@@ -321,7 +321,7 @@ TEST_CASE(decode, no_padding, NULL)
 	struct cursor cursor = {buf, 16 + 8};
 	(void)params;
 	strcpy(buf, "Joe Doh");
-	*(uint64_t *)(buf + 8) = byte__flip64(40);
+	*(uint64_t *)(buf + 8) = ByteFlipLe64(40);
 	person__decode(&cursor, &f->person);
 	munit_assert_string_equal(f->person.name, "Joe Doh");
 	munit_assert_int(f->person.age, ==, 40);
@@ -366,13 +366,13 @@ TEST_CASE(decode, custom, NULL)
 	strcpy(p, "Victor Hugo");
 	p += 16;
 
-	*(uint64_t *)p = byte__flip64(40);
+	*(uint64_t *)p = ByteFlipLe64(40);
 	p += 8;
 
-	*(uint16_t *)p = byte__flip16(2);
+	*(uint16_t *)p = ByteFlipLe16(2);
 	p += 2;
 
-	*(uint16_t *)p = byte__flip16(8);
+	*(uint16_t *)p = ByteFlipLe16(8);
 	p += 2;
 
 	p += 4; /* Unused */

--- a/test/unit/test_tuple.c
+++ b/test/unit/test_tuple.c
@@ -214,7 +214,7 @@ TEST_CASE(decoder, type, float, NULL)
 
 	memcpy(buf[1], &pi, sizeof pi);
 	uint64_t *buf_value = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	*buf_value = byte__flip64(*buf_value);
+	*buf_value = ByteFlipLe64(*buf_value);
 
 	DECODER_INIT(1);
 	DECODER_NEXT;
@@ -343,7 +343,7 @@ TEST_CASE(encoder, row, one_value, NULL)
 	munit_assert_int(buf[0][0], ==, SQLITE_INTEGER);
 	/* malloc'ed buffer is aligned suitably */
 	uint64_t *value_ptr = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	munit_assert_uint64(*value_ptr, ==, byte__flip64(7));
+	munit_assert_uint64(*value_ptr, ==, ByteFlipLe64(7));
 
 	return MUNIT_OK;
 }
@@ -369,7 +369,7 @@ TEST_CASE(encoder, row, two_values, NULL)
 	munit_assert_int(buf[0][0], ==, SQLITE_INTEGER | SQLITE_TEXT << 4);
 	/* malloc'ed buffer is aligned suitably */
 	uint64_t *value_ptr = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	munit_assert_uint64(*value_ptr, ==, byte__flip64(7));
+	munit_assert_uint64(*value_ptr, ==, ByteFlipLe64(7));
 	munit_assert_string_equal((const char *)buf[2], "hello");
 
 	return MUNIT_OK;
@@ -394,7 +394,7 @@ TEST_CASE(encoder, params, one_value, NULL)
 	munit_assert_int(buf[0][0], ==, 1);
 	munit_assert_int(buf[0][1], ==, SQLITE_INTEGER);
 	uint64_t *value_ptr = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	munit_assert_uint64(*value_ptr, ==, byte__flip64(7));
+	munit_assert_uint64(*value_ptr, ==, ByteFlipLe64(7));
 
 	return MUNIT_OK;
 }
@@ -421,7 +421,7 @@ TEST_CASE(encoder, params, two_values, NULL)
 	munit_assert_int(buf[0][1], ==, SQLITE_INTEGER);
 	munit_assert_int(buf[0][2], ==, SQLITE_TEXT);
 	uint64_t *value_ptr = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	munit_assert_uint64(*value_ptr, ==, byte__flip64(7));
+	munit_assert_uint64(*value_ptr, ==, ByteFlipLe64(7));
 	munit_assert_string_equal((const char *)buf[2], "hello");
 
 	return MUNIT_OK;
@@ -445,7 +445,7 @@ TEST_CASE(encoder, type, float, NULL)
 
 	munit_assert_int(buf[0][0], ==, SQLITE_FLOAT);
 	uint64_t *value_ptr = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	munit_assert_uint64(*value_ptr, ==, byte__flip64(*(uint64_t *)&value.float_));
+	munit_assert_uint64(*value_ptr, ==, ByteFlipLe64(*(uint64_t *)&value.float_));
 
 	return MUNIT_OK;
 }
@@ -466,7 +466,7 @@ TEST_CASE(encoder, type, unixtime, NULL)
 
 	munit_assert_int(buf[0][0], ==, DQLITE_UNIXTIME);
 	uint64_t *value_ptr = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	munit_assert_uint64(*value_ptr, ==, byte__flip64((uint64_t)value.unixtime));
+	munit_assert_uint64(*value_ptr, ==, ByteFlipLe64((uint64_t)value.unixtime));
 
 	return MUNIT_OK;
 }
@@ -507,7 +507,7 @@ TEST_CASE(encoder, type, boolean, NULL)
 
 	munit_assert_int(buf[0][0], ==, DQLITE_BOOLEAN);
 	uint64_t *value_ptr = __builtin_assume_aligned(buf[1], sizeof(uint64_t));
-	munit_assert_uint64(*value_ptr, ==, byte__flip64(value.boolean));
+	munit_assert_uint64(*value_ptr, ==, ByteFlipLe64(value.boolean));
 
 	return MUNIT_OK;
 }


### PR DESCRIPTION
Also rename functions from that header in camel-case style.

Closes #385.

Signed-off-by: Cole Miller <cole.miller@canonical.com>