### PR TITLE
lib/byte: Rewrite to avoid triggering -Wconversion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,7 @@ TESTS = unit-test integration-test
 
 check_LTLIBRARIES = libtest.la
 
-libtest_la_CFLAGS = $(AM_CFLAGS) -DMUNIT_TEST_NAME_LEN=60 -Wno-unused-result -Wno-conversion -Wno-maybe-uninitialized -Wno-strict-prototypes -Wno-old-style-definition
+libtest_la_CFLAGS = $(AM_CFLAGS) -DMUNIT_TEST_NAME_LEN=60 -Wno-unknown-warning-option -Wno-unused-result -Wno-conversion -Wno-maybe-uninitialized -Wno-strict-prototypes -Wno-old-style-definition
 libtest_la_SOURCES = \
   test/lib/endpoint.c \
   test/lib/fault.c \
@@ -78,7 +78,7 @@ unit_test_SOURCES += \
   test/unit/test_tuple.c \
   test/unit/test_vfs.c \
   test/unit/main.c
-unit_test_CFLAGS = $(AM_CFLAGS) -Wno-maybe-uninitialized -Wno-float-equal -Wno-conversion
+unit_test_CFLAGS = $(AM_CFLAGS) -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-float-equal -Wno-conversion
 unit_test_LDFLAGS = $(AM_LDFLAGS)
 unit_test_LDADD = libtest.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,7 @@ CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
   -Wdate-time \
   -Wnested-externs \
   -Wconversion \
+  -Werror \
 ])
 # To enable:
 #

--- a/src/lib/byte.h
+++ b/src/lib/byte.h
@@ -91,13 +91,22 @@ DQLITE_INLINE uint64_t ByteFlipLe64(uint64_t v)
 
 DQLITE_INLINE uint16_t ByteGetBe16(const uint8_t *buf)
 {
-	return ((uint16_t)(buf[0]) << 8) | (uint16_t)(buf[1]);
+	uint16_t x = buf[0];
+	uint16_t y = buf[1];
+	x <<= 8;
+	return x | y;
 }
 
 DQLITE_INLINE uint32_t ByteGetBe32(const uint8_t *buf)
 {
-	return ((uint32_t)(buf[0]) << 24) | ((uint32_t)(buf[1]) << 16) |
-	       ((uint32_t)(buf[2]) << 8) | (uint32_t)(buf[3]);
+	uint32_t w = buf[0];
+	uint32_t x = buf[1];
+	uint32_t y = buf[2];
+	uint32_t z = buf[3];
+	w <<= 24;
+	x <<= 16;
+	y <<= 8;
+	return w | x | y | z;
 }
 
 DQLITE_INLINE void BytePutBe32(uint32_t v, uint8_t *buf)

--- a/src/lib/byte.h
+++ b/src/lib/byte.h
@@ -89,6 +89,12 @@ DQLITE_INLINE uint64_t ByteFlipLe64(uint64_t v)
 #endif
 }
 
+/* -Wconversion before GCC 10 is overly sensitive. */
+#if defined(__GNUC__) && __GNUC__ < 10
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+
 DQLITE_INLINE uint16_t ByteGetBe16(const uint8_t *buf)
 {
 	uint16_t x = buf[0];
@@ -129,5 +135,9 @@ DQLITE_INLINE size_t BytePad64(size_t size)
 	}
 	return size;
 }
+
+#if defined(__GNUC__) && __GNUC__ < 10
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* LIB_BYTE_H_ */

--- a/src/logger.c
+++ b/src/logger.c
@@ -36,7 +36,10 @@ void loggerDefaultEmit(void *data, int level, const char *fmt, va_list args)
 
 	/* Then render the message, possibly truncating it. */
 	n = EMIT_BUF_LEN - strlen(buf) - 1;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	vsnprintf(cursor, n, fmt, args);
+#pragma GCC diagnostic pop
 
 	fprintf(stderr, "%s\n", buf);
 }

--- a/test/lib/logger.c
+++ b/test/lib/logger.c
@@ -34,7 +34,10 @@ void test_logger_emit(void *data, int level, const char *format, va_list args)
 
 	sprintf(buf + strlen(buf), "%2d -> [%s] ", t->id, level_name);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	vsnprintf(buf + strlen(buf), 1024 - strlen(buf), format, args);
+#pragma GCC diagnostic pop
 	munit_log(MUNIT_LOG_INFO, buf);
 	return;
 


### PR DESCRIPTION
Should fix the Launchpad build failures we saw. I'm not sure why -Wconversion didn't fire in our GHA CI -- different compiler versions, maybe?

Signed-off-by: Cole Miller <cole.miller@canonical.com>