### PR TITLE
lib/buffer: Sanity-check argument of buffer__advance

### DIFF
--- a/src/lib/buffer.c
+++ b/src/lib/buffer.c
@@ -12,6 +12,8 @@
 /* How many remaining bytes the buffer currently */
 #define CAP(B) (SIZE(B) - B->offset)
 
+#define MAX_REASONABLE_SIZE (1 << 30) // XXX
+
 int buffer__init(struct buffer *b)
 {
 	b->page_size = (unsigned)sysconf(_SC_PAGESIZE);
@@ -48,6 +50,10 @@ static bool ensure(struct buffer *b, size_t size)
 void *buffer__advance(struct buffer *b, size_t size)
 {
 	void *cursor;
+
+	if (size > MAX_REASONABLE_SIZE) {
+		return NULL;
+	}
 
 	if (!ensure(b, size)) {
 		return NULL;


### PR DESCRIPTION
This should address some defects that were reported in the most recent Coverity run.

I don't have a strong sense of what `MAX_REASONABLE_SIZE` should be (hence the `// XXX`) -- suggestions welcome.

Signed-off-by: Cole Miller <cole.miller@canonical.com>