### PR TITLE
Add barriers before calling sqlite3_prepare_v2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,6 +53,7 @@ libtest_la_SOURCES = \
   test/lib/heap.c \
   test/lib/logger.c \
   test/lib/munit.c \
+  test/lib/raft_heap.c \
   test/lib/server.c \
   test/lib/sqlite.c \
   test/lib/uv.c

--- a/src/client.c
+++ b/src/client.c
@@ -105,7 +105,7 @@ int clientSendHandshake(struct client *c)
 		assert(_p != NULL);                                 \
 		_rv = read(c->fd, _p, _n);                          \
 		if (_rv != (int)_n) {                               \
-			tracef("read failed rv %zd)", _rv);         \
+			tracef("read head failed rv %zd", _rv);     \
 			return DQLITE_ERROR;                        \
 		}                                                   \
 		_cursor.p = _p;                                     \
@@ -120,12 +120,12 @@ int clientSendHandshake(struct client *c)
 		_n = _message.words * 8;                            \
 		_p = buffer__advance(&c->read, _n);                 \
 		if (_p == NULL) {                                   \
-			tracef("read buf adv failed rv %zd)", _rv); \
+			tracef("read buf adv failed rv %zd", _rv);  \
 			return DQLITE_ERROR;                        \
 		}                                                   \
 		_rv = read(c->fd, _p, _n);                          \
 		if (_rv != (int)_n) {                               \
-			tracef("read failed rv %zd)", _rv);         \
+			tracef("read body failed rv %zd", _rv);     \
 			return DQLITE_ERROR;                        \
 		}                                                   \
 	}

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -38,7 +38,7 @@ void gateway__leader_close(struct gateway *g, int reason)
 		return;
 	}
 
-	if (g->stmt != NULL) {
+	if (g->req != NULL) {
 		if (g->leader->inflight != NULL) {
 			tracef("finish inflight apply request");
 			struct raft_apply *req = &g->leader->inflight->req;
@@ -46,7 +46,7 @@ void gateway__leader_close(struct gateway *g, int reason)
 			assert(g->req == NULL);
 			assert(g->stmt == NULL);
 		} else if (g->barrier.cb != NULL) {
-			tracef("finish inflight query barrier");
+			tracef("finish inflight barrier");
 			/* This is not a typo, g->barrier.req.cb is a wrapper
 			 * around g->barrier.cb and when called, will set g->barrier.cb to NULL.
 			 * */
@@ -58,8 +58,8 @@ void gateway__leader_close(struct gateway *g, int reason)
 			struct raft_barrier *b = &g->leader->exec->barrier.req;
 			b->cb(b, reason);
 			assert(g->leader->exec == NULL);
-		} else if (g->req != NULL && g->req->type != DQLITE_REQUEST_QUERY
-					  && g->req->type != DQLITE_REQUEST_EXEC) {
+		} else if (g->stmt != NULL && g->req->type != DQLITE_REQUEST_QUERY
+					   && g->req->type != DQLITE_REQUEST_EXEC) {
 			/* Regular exec and query stmt's will be closed when the
 			 * registry is closed below. */
 			tracef("finalize exec_sql or query_sql type:%d", g->req->type);

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -98,8 +98,8 @@ void gateway__close(struct gateway *g)
 	}
 
 #define CHECK_LEADER(REQ)                                            \
-	if (raft_state(req->gateway->raft) != RAFT_LEADER) {         \
-		failure(req, SQLITE_IOERR_NOT_LEADER, "not leader"); \
+	if (raft_state(REQ->gateway->raft) != RAFT_LEADER) {         \
+		failure(REQ, SQLITE_IOERR_NOT_LEADER, "not leader"); \
 		return 0;                                            \
 	}
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -1101,6 +1101,8 @@ handle:
 	req->gateway = g;
 	req->cb = cb;
 	req->buffer = buffer;
+	req->db_id = 0;
+	req->stmt_id = 0;
 
 	switch (type) {
 #define DISPATCH(LOWER, UPPER, _)                 \

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -33,6 +33,7 @@ struct gateway
 	sqlite3_stmt *stmt;          /* Statement being processed */
 	bool stmt_finalize;          /* Whether to finalize the statement */
 	struct exec exec;            /* Low-level exec async request */
+	/* FIXME store this in the req */
 	const char *sql;             /* SQL query for exec_sql requests */
 	struct stmt__registry stmts; /* Registry of prepared statements */
 	struct barrier barrier;      /* Barrier for query requests */
@@ -54,15 +55,20 @@ void gateway__leader_close(struct gateway *g, int reason);
 
 /**
  * Asynchronous request to handle a client command.
+ *
+ * We also use the handle as a place to save request-scoped data that we need
+ * to access from a callback.
  */
 typedef void (*handle_cb)(struct handle *req, int status, int type);
 struct handle
 {
-	void *data; /* User data */
-	int type;   /* Request type */
+	void *data;              /* User data */
+	int type;                /* Request type */
 	struct gateway *gateway;
 	struct buffer *buffer;
 	struct cursor cursor;
+	size_t db_id;            /* For use by prepare callback */
+	size_t stmt_id;          /* For use by prepare callback */
 	handle_cb cb;
 };
 

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -62,6 +62,7 @@ struct handle
 	int type;   /* Request type */
 	struct gateway *gateway;
 	struct buffer *buffer;
+	struct cursor cursor;
 	handle_cb cb;
 };
 
@@ -72,14 +73,12 @@ struct handle
  * return an error if user code calls it and there's already a request in
  * progress.
  *
- * The @type parameter holds the request type code (e.g. #REQUEST_LEADER), the
- * @cursor parameter holds a cursor for reading the request payload, and the
- * @buffer parameter is a buffer for writing the response.
+ * The @type parameter holds the request type code (e.g. #REQUEST_LEADER), and
+ * the @buffer parameter is a buffer for writing the response.
  */
 int gateway__handle(struct gateway *g,
 		    struct handle *req,
 		    int type,
-		    struct cursor *cursor,
 		    struct buffer *buffer,
 		    handle_cb cb);
 

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -112,14 +112,14 @@ TEST(membership, join, setUp, tearDown, 0, NULL)
 	EXEC(stmt_id, &last_insert_id, &rows_affected);
 
 	/* The table is visible from the new node */
+	TRANSFER(id, f->client);
 	SELECT(2);
 	HANDSHAKE;
 	OPEN;
 	PREPARE("SELECT * FROM test", &stmt_id);
 
 	/* TODO: fix the standalone test for remove */
-	SELECT(1);
-	REMOVE(id);
+	REMOVE(1);
 	return MUNIT_OK;
 }
 

--- a/test/lib/raft_heap.c
+++ b/test/lib/raft_heap.c
@@ -1,0 +1,101 @@
+#include <raft.h>
+
+#include "fault.h"
+#include "raft_heap.h"
+
+struct heapFault
+{
+	struct test_fault fault;
+	const struct raft_heap *orig_heap;
+};
+
+static struct heapFault faulty;
+
+static void *faultyMalloc(void *data, size_t size)
+{
+	(void)data;
+	if (test_fault_tick(&faulty.fault)) {
+		return NULL;
+	} else {
+		return faulty.orig_heap->malloc(faulty.orig_heap->data, size);
+	}
+}
+
+static void faultyFree(void *data, void *ptr)
+{
+	(void)data;
+	faulty.orig_heap->free(faulty.orig_heap->data, ptr);
+}
+
+static void *faultyCalloc(void *data, size_t nmemb, size_t size)
+{
+	(void)data;
+	if (test_fault_tick(&faulty.fault)) {
+		return NULL;
+	} else {
+		return faulty.orig_heap->calloc(faulty.orig_heap->data, nmemb, size);
+	}
+}
+
+static void *faultyRealloc(void *data, void *ptr, size_t size)
+{
+	(void)data;
+	if (test_fault_tick(&faulty.fault)) {
+		return NULL;
+	} else {
+		return faulty.orig_heap->realloc(faulty.orig_heap->data, ptr, size);
+	}
+}
+
+static void *faultyAlignedAlloc(void *data, size_t alignment, size_t size)
+{
+	(void)data;
+	if (test_fault_tick(&faulty.fault)) {
+		return NULL;
+	} else {
+		return faulty.orig_heap->aligned_alloc(faulty.orig_heap->data, alignment, size);
+	}
+}
+
+static void faultyAlignedFree(void *data, size_t alignment, void *ptr)
+{
+	(void)data;
+	(void)alignment;
+	faulty.orig_heap->aligned_free(faulty.orig_heap->data, alignment, ptr);
+}
+
+void test_raft_heap_setup(const MunitParameter params[], void *user_data)
+{
+	(void)params;
+	(void)user_data;
+	struct raft_heap *heap = munit_malloc(sizeof(*heap));
+	test_fault_init(&faulty.fault);
+	faulty.orig_heap = raft_heap_get();
+	heap->data = NULL;
+	heap->malloc = faultyMalloc;
+	heap->free = faultyFree;
+	heap->calloc = faultyCalloc;
+	heap->realloc = faultyRealloc;
+	heap->aligned_alloc = faultyAlignedAlloc;
+	heap->aligned_free = faultyAlignedFree;
+	raft_heap_set(heap);
+}
+
+void test_raft_heap_tear_down(void *data)
+{
+	struct raft_heap *heap = (struct raft_heap *)raft_heap_get();
+	(void)data;
+	raft_heap_set((struct raft_heap *)faulty.orig_heap);
+	faulty.orig_heap = NULL;
+	free(heap);
+}
+
+void test_raft_heap_fault_config(int delay, int repeat)
+{
+	test_fault_config(&faulty.fault, delay, repeat);
+}
+
+void test_raft_heap_fault_enable(void)
+{
+	test_fault_enable(&faulty.fault);
+}

--- a/test/lib/raft_heap.h
+++ b/test/lib/raft_heap.h
@@ -1,0 +1,15 @@
+/**
+ * Helpers for injecting failures into raft's allocator.
+ */
+
+#ifndef DQLITE_TEST_RAFT_HEAP_H
+#define DQLITE_TEST_RAFT_HEAP_H
+
+#include "munit.h"
+
+void test_raft_heap_setup(const MunitParameter params[], void *user_data);
+void test_raft_heap_tear_down(void *data);
+void test_raft_heap_fault_config(int delay, int repeat);
+void test_raft_heap_fault_enable(void);
+
+#endif /* DQLITE_TEST_RAFT_HEAP_H */

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -135,6 +135,7 @@ static void fixture_handle_cb(struct handle *req, int status, int type)
 		prepare.sql = SQL;              \
 		ENCODE(C, &prepare, prepare);   \
 		HANDLE(C, PREPARE);             \
+		WAIT(C);                        \
 		ASSERT_CALLBACK(C, 0, STMT);    \
 		DECODE(C, &stmt, stmt);         \
 		*(STMT_ID) = stmt.id;           \

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -115,13 +115,12 @@ static void fixture_handle_cb(struct handle *req, int status, int type)
  * error occurs. */
 #define HANDLE(C, TYPE)                                                 \
 	{                                                               \
-		struct cursor cursor;                                   \
 		int rc2;                                                \
-		cursor.p = buffer__cursor(&C->request, 0);              \
-		cursor.cap = buffer__offset(&C->request);               \
+		C->handle.cursor.p = buffer__cursor(&C->request, 0);    \
+		C->handle.cursor.cap = buffer__offset(&C->request);     \
 		buffer__reset(&C->response);                            \
 		rc2 = gateway__handle(&C->gateway, &C->handle,          \
-				      DQLITE_REQUEST_##TYPE, &cursor,   \
+				      DQLITE_REQUEST_##TYPE,            \
 				      &C->response, fixture_handle_cb); \
 		munit_assert_int(rc2, ==, 0);                           \
 	}

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -571,6 +571,24 @@ TEST_CASE(prepare, barrier_error, NULL)
 	return MUNIT_OK;
 }
 
+/* Submit a prepare request to a non-leader node. */
+TEST_CASE(prepare, non_leader, NULL)
+{
+	struct prepare_fixture *f = data;
+	(void)params;
+
+	CLUSTER_ELECT(0);
+	SELECT(1);
+	f->request.db_id = 0;
+	f->request.sql = "CREATE TABLE test (n INT)";
+	ENCODE(&f->request, prepare);
+	HANDLE(PREPARE);
+	WAIT;
+	ASSERT_CALLBACK(0, FAILURE);
+	ASSERT_FAILURE(SQLITE_IOERR_NOT_LEADER, "not leader");
+	return MUNIT_OK;
+}
+
 /******************************************************************************
  *
  * exec

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -150,14 +150,14 @@ static void handleCb(struct handle *req, int status, int type)
 #define HANDLE(TYPE)                                                    \
 	{                                                               \
 		int rc2;                                                \
-		f->cursor->p = buffer__cursor(f->buf1, 0);              \
-		f->cursor->cap = buffer__offset(f->buf1);               \
+		f->handle->cursor.p = buffer__cursor(f->buf1, 0);       \
+		f->handle->cursor.cap = buffer__offset(f->buf1);        \
 		buffer__reset(f->buf2);                                 \
 		f->context->invoked = false;                            \
 		f->context->status = -1;                                \
 		f->context->type = -1;                                  \
 		rc2 = gateway__handle(f->gateway, f->handle,            \
-				      DQLITE_REQUEST_##TYPE, f->cursor, \
+				      DQLITE_REQUEST_##TYPE,            \
 				      f->buf2, handleCb);               \
 		munit_assert_int(rc2, ==, 0);                           \
 	}

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -182,6 +182,7 @@ static void handleCb(struct handle *req, int status, int type)
 		prepare.sql = SQL;              \
 		ENCODE(&prepare, prepare);      \
 		HANDLE(PREPARE);                \
+		WAIT;                           \
 		ASSERT_CALLBACK(0, STMT);       \
 		DECODE(&stmt, stmt);            \
 		stmt_id = stmt.id;              \
@@ -251,6 +252,7 @@ static void handleCb(struct handle *req, int status, int type)
 		prepare.sql = SQL;              \
 		ENCODE(&prepare, prepare);      \
 		HANDLE(PREPARE);                \
+		WAIT;                           \
 		ASSERT_CALLBACK(0, STMT);       \
 		DECODE(&stmt, stmt);            \
 		_stmt_id = stmt.id;             \
@@ -461,8 +463,10 @@ TEST_CASE(prepare, success, NULL)
 	(void)params;
 	f->request.db_id = 0;
 	f->request.sql = "CREATE TABLE test (n INT)";
+	CLUSTER_ELECT(0);
 	ENCODE(&f->request, prepare);
 	HANDLE(PREPARE);
+	WAIT;
 	ASSERT_CALLBACK(0, STMT);
 	DECODE(&f->response, stmt);
 	munit_assert_int(f->response.id, ==, 0);
@@ -476,8 +480,10 @@ TEST_CASE(prepare, empty1, NULL)
 	(void)params;
 	f->request.db_id = 0;
 	f->request.sql = "";
+	CLUSTER_ELECT(0);
 	ENCODE(&f->request, prepare);
 	HANDLE(PREPARE);
+	WAIT;
 	ASSERT_CALLBACK(0, FAILURE);
 	ASSERT_FAILURE(0, "empty statement");
 	munit_assert_int(f->response.id, ==, 0);
@@ -491,8 +497,10 @@ TEST_CASE(prepare, empty2, NULL)
 	(void)params;
 	f->request.db_id = 0;
 	f->request.sql = " -- This is a comment";
+	CLUSTER_ELECT(0);
 	ENCODE(&f->request, prepare);
 	HANDLE(PREPARE);
+	WAIT;
 	ASSERT_CALLBACK(0, FAILURE);
 	ASSERT_FAILURE(0, "empty statement");
 	munit_assert_int(f->response.id, ==, 0);
@@ -506,8 +514,10 @@ TEST_CASE(prepare, invalid, NULL)
 	(void)params;
 	f->request.db_id = 0;
 	f->request.sql = "NOT SQL";
+	CLUSTER_ELECT(0);
 	ENCODE(&f->request, prepare);
 	HANDLE(PREPARE);
+	WAIT;
 	ASSERT_CALLBACK(0, FAILURE);
 	ASSERT_FAILURE(SQLITE_ERROR, "near \"NOT\": syntax error");
 	munit_assert_int(f->response.id, ==, 0);
@@ -1367,6 +1377,7 @@ TEST_CASE(finalize, success, NULL)
 	uint64_t stmt_id;
 	struct finalize_fixture *f = data;
 	(void)params;
+	CLUSTER_ELECT(0);
 	PREPARE("CREATE TABLE test (n INT)");
 	f->request.db_id = 0;
 	f->request.stmt_id = stmt_id;

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -524,6 +524,20 @@ TEST_CASE(prepare, invalid, NULL)
 	return MUNIT_OK;
 }
 
+/* Prepare a statement and close the gateway early. */
+TEST_CASE(prepare, closing, NULL)
+{
+	struct prepare_fixture *f = data;
+	(void)params;
+
+	f->request.db_id = 0;
+	f->request.sql = "CREATE TABLE test (n INT)";
+	ENCODE(&f->request, prepare);
+	CLUSTER_ELECT(0);
+	HANDLE(PREPARE);
+	return MUNIT_OK;
+}
+
 /******************************************************************************
  *
  * exec
@@ -1485,6 +1499,18 @@ TEST_CASE(exec_sql, multi, NULL)
 	return MUNIT_OK;
 }
 
+/* Exec an SQL text and close the gateway early. */
+TEST_CASE(exec_sql, closing, NULL)
+{
+	struct exec_sql_fixture *f = data;
+	(void)params;
+	f->request.db_id = 0;
+	f->request.sql = "CREATE TABLE test (n INT)";
+	ENCODE(&f->request, exec_sql);
+	HANDLE(EXEC_SQL);
+	return MUNIT_OK;
+}
+
 /******************************************************************************
  *
  * query_sql
@@ -1710,5 +1736,18 @@ TEST_CASE(query_sql, params, NULL)
 
 	HANDLE(QUERY_SQL);
 	ASSERT_CALLBACK(0, ROWS);
+	return MUNIT_OK;
+}
+
+/* Perform a query and close the gateway early. */
+TEST_CASE(query_sql, closing, NULL)
+{
+	struct query_sql_fixture *f = data;
+	(void)params;
+	EXEC("INSERT INTO test VALUES(123)");
+	f->request.db_id = 0;
+	f->request.sql = "SELECT n FROM test";
+	ENCODE(&f->request, query_sql);
+	HANDLE(QUERY_SQL);
 	return MUNIT_OK;
 }


### PR DESCRIPTION
WIP, tests will need fixing. See https://github.com/canonical/raft/issues/302.

- [x] Fix compile errors in tests
- [x] Update failing tests
- [ ] New tests:
  - [x] Check calling gateway__close when the barrier from handle_prepare is in flight
  - [x] Other tests introduced in https://github.com/MathieuBordere/dqlite/tree/commit-previous-term
  - [x] inject failure of `leader__barrier`
  - [x] closing early while exec barrier is in flight
  - [x] prepare request to non-leader
  - [ ] ~~handling of malformed requests~~ lock down how different kinds of gateway errors are handled?
- [x] Remove redundant barrier from `querySqlBarrierCb`
- [x] Delete `handle->registered_stmt` on gateway close

Closes #210
Closes https://github.com/canonical/go-dqlite/issues/78