### PR TITLE
test: Make sure tracing is enabled

### DIFF
--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -7,6 +7,8 @@
 
 #include "munit.h"
 
+#include "../../src/tracing.h"
+
 /* Top-level suites array declaration.
  *
  * These top-level suites hold all module-level child suites and must be defined
@@ -27,6 +29,7 @@ extern int _main_suites_n;
 	int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc)])            \
 	{                                                                  \
 		signal(SIGPIPE, SIG_IGN);                                  \
+		dqliteTracingMaybeEnable(true);                            \
 		MunitSuite suite = {(char *)"", NULL, _main_suites, 1, 0}; \
 		return munit_suite_main(&suite, (void *)NAME, argc, argv); \
 	}


### PR DESCRIPTION
dqliteTracingMaybeEnable is called when we stand up a server, but that doesn't help for most of the unit tests, which call various internal bits of dqlite directly. So, add a separate call to dqliteTracingMaybeEnable in the generated main function for our test suites.

Signed-off-by: Cole Miller <cole.miller@canonical.com>