### PR TITLE
utils: Define DBG macro

### DIFF
--- a/src/lib/util.h
+++ b/src/lib/util.h
@@ -1,7 +1,0 @@
-#ifndef LIB_UTIL_H_
-#define LIB_UTIL_H_
-
-#define LIKELY(x)       __builtin_expect(!!(x),1)
-#define UNLIKELY(x)     __builtin_expect(!!(x),0)
-
-#endif /* LIB_UTIL_H_ */

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#include "lib/util.h"
+#include "utils.h"
 
 /* This global variable is only written once at startup and is only read
  * from there on. Users should not manipulate the value of this variable. */

--- a/src/utils.h
+++ b/src/utils.h
@@ -8,4 +8,9 @@
 #define PTR_TO_UINT64(p) ((uint64_t)((uintptr_t)(p)))
 #define UINT64_TO_PTR(u, ptr_type) ((ptr_type)((uintptr_t)(u)))
 
+#define LIKELY(x)       __builtin_expect(!!(x),1)
+#define UNLIKELY(x)     __builtin_expect(!!(x),0)
+
+#define DBG()           fprintf(stderr, "%s:%d\n", __func__, __LINE__)
+
 #endif /* DQLITE_UTILS_H_ */


### PR DESCRIPTION
Often find myself using this macro to debug.
I also moved the contents from lib/util.h to utils.h, I didn't notice there was a `utils` header when I introduced the likely macro's.