### PR TITLE
vfs fnctl fix

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1218,7 +1218,7 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fnctl)
 			    page_size !=
 				(int)vfsDatabaseGetPageSize(f->database)) {
 				fnctl[0] =
-				    "changing page size is not supported";
+				    sqlite3_mprintf("changing page size is not supported");
 				return SQLITE_IOERR;
 			}
 		}
@@ -1226,7 +1226,7 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fnctl)
 		/* When the user executes 'PRAGMA journal_mode=x' we ensure
 		 * that the desired mode is 'wal'. */
 		if (strcasecmp(right, "wal") != 0) {
-			fnctl[0] = "only WAL mode is supported";
+			fnctl[0] = sqlite3_mprintf("only WAL mode is supported");
 			return SQLITE_IOERR;
 		}
 	}

--- a/test/integration/test_vfs.c
+++ b/test/integration/test_vfs.c
@@ -1552,3 +1552,35 @@ TEST(vfs, restoreWithOpenConnection, setUp, tearDown, 0, snapshot_params)
 
 	return MUNIT_OK;
 }
+
+/* Changing page_size to non-default value fails. */
+TEST(vfs, changePageSize, setUp, tearDown, 0, NULL)
+{
+	sqlite3 *db;
+	int rv;
+
+	OPEN("1", db);
+
+	rv = sqlite3_exec(db, "PRAGMA page_size=1024", NULL, NULL, NULL);
+	munit_assert_int(rv, !=, 0);
+
+	CLOSE(db);
+
+	return MUNIT_OK;
+}
+
+/* Changing page_size to current value succeeds. */
+TEST(vfs, changePageSizeSameValue, setUp, tearDown, 0, NULL)
+{
+	sqlite3 *db;
+	int rv;
+
+	OPEN("1", db);
+
+	rv = sqlite3_exec(db, "PRAGMA page_size=512", NULL, NULL, NULL);
+	munit_assert_int(rv, ==, 0);
+
+	CLOSE(db);
+
+	return MUNIT_OK;
+}

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1256,6 +1256,9 @@ TEST(VfsFileControl, journal, setUp, tearDown, 0, NULL)
 
 	free(file);
 
+	/* Free allocated memory from call to sqlite3_mprintf */
+	sqlite3_free(fnctl[0]);
+
 	return MUNIT_OK;
 }
 


### PR DESCRIPTION
Avoids memory corruption uncovered by the added tests. 