### PR TITLE
Initial disk mode support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ libdqlite_la_SOURCES = \
   src/leader.c \
   src/lib/addr.c \
   src/lib/buffer.c \
+  src/lib/fs.c \
   src/lib/transport.c \
   src/logger.c \
   src/message.c \

--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -198,6 +198,16 @@ int dqlite_node_set_snapshot_params(dqlite_node *n, unsigned snapshot_threshold,
                                     unsigned snapshot_trailing);
 
 /**
+ * WARNING: This is an experimental API.
+ *
+ * By default dqlite holds the SQLite database file and WAL in memory. By enabling
+ * disk-mode, dqlite will hold the SQLite database file on-disk while keeping the WAL
+ * in memory. Has to be called after `dqlite_node_create` and before
+ * `dqlite_node_start`.
+ */
+int dqlite_node_enable_disk_mode(dqlite_node *n);
+
+/**
  * Start a dqlite node.
  *
  * A background thread will be spawned which will run the node's main loop. If
@@ -305,6 +315,8 @@ dqlite_node_id dqlite_generate_node_id(const char *address);
  */
 int dqlite_vfs_init(sqlite3_vfs *vfs, const char *name);
 
+int dqlite_vfs_enable_disk(sqlite3_vfs *vfs);
+
 /**
  * Release all memory used internally by a SQLite VFS object that was
  * initialized using @qlite_vfs_init.
@@ -386,6 +398,11 @@ int dqlite_vfs_shallow_snapshot(sqlite3_vfs *vfs,
 				struct dqlite_buffer bufs[],
 				unsigned n);
 
+int dqlite_vfs_snapshot_disk(sqlite3_vfs *vfs,
+				const char *filename,
+				struct dqlite_buffer bufs[],
+				unsigned n);
+
 /**
  * Return the number of database pages (excluding WAL).
  */
@@ -401,4 +418,12 @@ int dqlite_vfs_restore(sqlite3_vfs *vfs,
 		       const void *data,
 		       size_t n);
 
+/**
+ * Restore a snapshot of the main database file and of the WAL file.
+ */
+int dqlite_vfs_restore_disk(sqlite3_vfs *vfs,
+		       const char *filename,
+		       const void *data,
+		       size_t main_size,
+		       size_t wal_size);
 #endif /* DQLITE_H */

--- a/src/config.c
+++ b/src/config.c
@@ -28,7 +28,8 @@
  * TODO: make this thread safe. */
 static unsigned serial = 1;
 
-int config__init(struct config *c, dqlite_node_id id, const char *address)
+int config__init(struct config *c, dqlite_node_id id,
+		 const char *address, const char *dir)
 {
 	int rv;
 	c->id = id;
@@ -46,6 +47,9 @@ int config__init(struct config *c, dqlite_node_id id, const char *address)
 	c->logger.emit = loggerDefaultEmit;
 	c->failure_domain = 0;
 	c->weight = 0;
+	strncpy(c->dir, dir, sizeof(c->dir)-1);
+	c->dir[sizeof(c->dir)-1] = '\0';
+	c->disk = false;
 	serial++;
 	return 0;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -17,7 +17,7 @@ struct config
 	char name[256];                /* VFS/replication registriatio name */
 	unsigned long long failure_domain; /* User-provided failure domain */
 	unsigned long long int weight;     /* User-provided node weight */
-	char dir[1024];                /* Data dir */
+	char dir[1024];                /* Data dir for on-disk database */
 	bool disk;                     /* Disk-mode or not */
 };
 

--- a/src/config.h
+++ b/src/config.h
@@ -17,13 +17,16 @@ struct config
 	char name[256];                /* VFS/replication registriatio name */
 	unsigned long long failure_domain; /* User-provided failure domain */
 	unsigned long long int weight;     /* User-provided node weight */
+	char dir[1024];                /* Data dir */
+	bool disk;                     /* Disk-mode or not */
 };
 
 /**
  * Initialize the config object with required values and set the rest to sane
  * defaults. A copy will be made of the given @address.
  */
-int config__init(struct config *c, dqlite_node_id id, const char *address);
+int config__init(struct config *c, dqlite_node_id id,
+		 const char *address, const char *dir);
 
 /**
  * Release any memory held by the config object.

--- a/src/db.h
+++ b/src/db.h
@@ -13,6 +13,7 @@ struct db
 {
 	struct config *config; /* Dqlite configuration */
 	char *filename;        /* Database filename */
+	char *path;            /* Used for on-disk db */
 	sqlite3 *follower;     /* Follower connection */
 	queue leaders;         /* Open leader connections */
 	unsigned tx_id;        /* Current ongoing transaction ID, if any */
@@ -24,8 +25,9 @@ struct db
  * Initialize a database object.
  *
  * The given @filename will be copied.
+ * Return 0 on success.
  */
-void db__init(struct db *db, struct config *config, const char *filename);
+int db__init(struct db *db, struct config *config, const char *filename);
 
 /**
  * Release all memory associated with a database object.

--- a/src/dqlite.c
+++ b/src/dqlite.c
@@ -12,6 +12,11 @@ int dqlite_vfs_init(sqlite3_vfs *vfs, const char *name)
 	return VfsInit(vfs, name);
 }
 
+int dqlite_vfs_enable_disk(sqlite3_vfs *vfs)
+{
+	return VfsEnableDisk(vfs);
+}
+
 void dqlite_vfs_close(sqlite3_vfs *vfs)
 {
 	VfsClose(vfs);
@@ -47,6 +52,25 @@ int dqlite_vfs_snapshot(sqlite3_vfs *vfs,
 	return VfsSnapshot(vfs, filename, data, n);
 }
 
+int dqlite_vfs_snapshot_disk(sqlite3_vfs *vfs,
+			const char *filename,
+			struct dqlite_buffer bufs[],
+			unsigned n)
+{
+	int rv;
+	if (n != 2) {
+		return -1;
+	}
+
+	rv = VfsDiskSnapshotDb(vfs, filename, &bufs[0]);
+	if (rv != 0) {
+		return rv;
+	}
+
+	rv = VfsDiskSnapshotWal(vfs, filename, &bufs[1]);
+	return rv;
+}
+
 int dqlite_vfs_num_pages(sqlite3_vfs *vfs,
 			 const char *filename,
 			 unsigned *n)
@@ -68,4 +92,13 @@ int dqlite_vfs_restore(sqlite3_vfs *vfs,
 		       size_t n)
 {
 	return VfsRestore(vfs, filename, data, n);
+}
+
+int dqlite_vfs_restore_disk(sqlite3_vfs *vfs,
+		       const char *filename,
+		       const void *data,
+		       size_t main_size,
+		       size_t wal_size)
+{
+	return VfsDiskRestore(vfs, filename, data, main_size, wal_size);
 }

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -8,6 +8,8 @@
 #include "tracing.h"
 #include "vfs.h"
 
+#include <sys/mman.h>
+
 struct fsm
 {
 	struct logger *logger;
@@ -199,7 +201,7 @@ static int apply_frames(struct fsm *f, const struct command_frames *c)
 
 	/* Check if the database file exists, and create it by opening a
 	 * connection if it doesn't. */
-	rv = vfs->xAccess(vfs, c->filename, 0, &exists);
+	rv = vfs->xAccess(vfs, db->path, 0, &exists);
 	assert(rv == 0);
 
 	if (!exists) {
@@ -238,7 +240,7 @@ static int apply_frames(struct fsm *f, const struct command_frames *c)
 				return DQLITE_NOMEM;
 			}
 			rv =
-			    VfsApply(vfs, db->filename, f->pending.n_pages,
+			    VfsApply(vfs, db->path, f->pending.n_pages,
 				     f->pending.page_numbers, f->pending.pages);
 			if (rv != 0) {
 				tracef("VfsApply failed %d", rv);
@@ -251,7 +253,7 @@ static int apply_frames(struct fsm *f, const struct command_frames *c)
 			f->pending.page_numbers = NULL;
 			f->pending.pages = NULL;
 		} else {
-			rv = VfsApply(vfs, db->filename, c->frames.n_pages,
+			rv = VfsApply(vfs, db->path, c->frames.n_pages,
 				      page_numbers, pages);
 			if (rv != 0) {
 				tracef("VfsApply failed %d", rv);
@@ -661,7 +663,8 @@ static int fsm__snapshot_finalize(struct raft_fsm *fsm,
 			break;
 		}
 		db = QUEUE__DATA(head, struct db, queue);
-		databaseReadUnlock(db);
+		rv = databaseReadUnlock(db);
+		assert(rv == 0);
 		n_db++;
 	}
 
@@ -733,4 +736,413 @@ void fsm__close(struct raft_fsm *fsm)
         tracef("fsm close");
 	struct fsm *f = fsm->data;
 	raft_free(f);
+}
+
+/******************************************************************************
+ Disk-based FSM
+ *****************************************************************************/
+
+/* The synchronous part of the database encoding */
+static int encodeDiskDatabaseSync(struct db *db, struct raft_buffer* r_buf)
+{
+	sqlite3_vfs *vfs;
+	struct dqlite_buffer *buf = (struct dqlite_buffer*) r_buf;
+	int rv;
+
+	vfs = sqlite3_vfs_find(db->config->name);
+	rv = VfsDiskSnapshotWal(vfs, db->path, buf);
+	if (rv != 0) {
+		goto err;
+	}
+
+	return 0;
+
+err:
+	assert(rv != 0);
+	return rv;
+}
+
+/* The asynchronous part of the database encoding */
+static int encodeDiskDatabaseAsync(struct db *db, struct raft_buffer r_bufs[], uint32_t n)
+{
+	struct snapshotDatabase header;
+	sqlite3_vfs *vfs;
+	void *cursor;
+	struct dqlite_buffer *bufs = (struct dqlite_buffer*) r_bufs;
+	int rv;
+
+	assert(n == 3);
+
+	vfs = sqlite3_vfs_find(db->config->name);
+	rv = VfsDiskSnapshotDb(vfs, db->path, &bufs[1]);
+	if (rv != 0) {
+		goto err;
+	}
+
+	/* Database header. */
+	header.filename = db->filename;
+	header.main_size = bufs[1].len;
+	header.wal_size = bufs[2].len;
+	bufs[0].len = snapshotDatabase__sizeof(&header);
+	bufs[0].base = sqlite3_malloc64(bufs[0].len);
+	if (bufs[0].base == NULL) {
+		rv = RAFT_NOMEM;
+		goto err;
+	}
+
+	cursor = bufs[0].base;
+	snapshotDatabase__encode(&header, &cursor);
+	return 0;
+
+	/* Cleanup is performed by call to snapshot_finalize */
+err:
+	assert(rv != 0);
+	return rv;
+}
+
+/* Determine the total number of raft buffers needed
+ * for a snapshot in disk-mode */
+static unsigned snapshotNumBufsDisk(struct fsm *f)
+{
+	queue *head;
+	unsigned n = 1; /* snapshot header */
+
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		n += 3; /* database header, database file and wal */
+	}
+
+	return n;
+}
+
+/* An example array of snapshot buffers looks like this:
+ *
+ * bufs:  SH DH1 DBMMAP1 WAL1 DH2 DMMAP2 WAL2
+ * index:  0   1       2    3   4      5    6
+ *
+ * SH:     Snapshot Header
+ * DHx:    Database Header
+ * DBMMAP: Pointer to mmap'ed database file
+ * WALx:   a WAL
+ * */
+static void freeSnapshotBufsDisk(struct fsm *f,
+			         struct raft_buffer bufs[],
+			         unsigned n_bufs)
+{
+	queue *head;
+	unsigned i;
+
+	if (bufs == NULL || n_bufs == 0) {
+		return;
+	}
+
+	/* Free snapshot header */
+	sqlite3_free(bufs[0].base);
+
+	i = 1;
+	/* Free all database headers & WAL buffers. Unmap the DB file. */
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		if (i == n_bufs) {
+		    break;
+		}
+		/* i is the index of the database header */
+		sqlite3_free(bufs[i].base);
+		if (bufs[i+1].base != NULL) {
+			munmap(bufs[i+1].base, bufs[i+1].len);
+		}
+		sqlite3_free(bufs[i+2].base);
+		/* i is now the index of the next database header (if any) */
+		i += 3;
+	}
+}
+
+static int fsm__snapshot_disk(struct raft_fsm *fsm,
+			 struct raft_buffer *bufs[],
+			 unsigned *n_bufs)
+{
+	struct fsm *f = fsm->data;
+	queue *head;
+	struct db *db = NULL;
+	unsigned n_db = 0;
+	unsigned i;
+	int rv;
+
+	/* First count how many databases we have and check that no transaction
+	 * nor checkpoint nor other snapshot is in progress. */
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		db = QUEUE__DATA(head, struct db, queue);
+		if (db->tx_id != 0 || db->read_lock) {
+			return RAFT_BUSY;
+		}
+		n_db++;
+	}
+
+	/* Lock all databases, preventing the checkpoint from running. This
+	 * ensures the database is not written while it is mmap'ed and copied by
+	 * raft. */
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		db = QUEUE__DATA(head, struct db, queue);
+		rv = databaseReadLock(db);
+		assert(rv == 0);
+	}
+
+
+	*n_bufs = snapshotNumBufsDisk(f);
+	*bufs = sqlite3_malloc64(*n_bufs * sizeof **bufs);
+	if (*bufs == NULL) {
+		rv = RAFT_NOMEM;
+		goto err;
+	}
+
+	/* zero-init buffers, helps with cleanup */
+	for (unsigned j = 0; j < *n_bufs; j++) {
+		(*bufs)[j].base = NULL;
+		(*bufs)[j].len = 0;
+	}
+
+	rv = encodeSnapshotHeader(n_db, &(*bufs)[0]);
+	if (rv != 0) {
+		goto err_after_bufs_alloc;
+	}
+
+	/* Copy WAL of all databases. */
+	i = 1;
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		db = QUEUE__DATA(head, struct db, queue);
+		/* database_header + db + WAL */
+		unsigned n = 3;
+		/* pass pointer to buffer that will contain WAL. */
+		rv = encodeDiskDatabaseSync(db, &(*bufs)[i+n-1]);
+		if (rv != 0) {
+			goto err_after_encode_sync;
+		}
+		i += n;
+	}
+
+	assert(i == *n_bufs);
+	return 0;
+
+err_after_encode_sync:
+	freeSnapshotBufsDisk(f, *bufs, i);
+err_after_bufs_alloc:
+	sqlite3_free(*bufs);
+err:
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		db = QUEUE__DATA(head, struct db, queue);
+		databaseReadUnlock(db);
+	}
+	assert(rv != 0);
+	return rv;
+}
+
+static int fsm__snapshot_async_disk(struct raft_fsm *fsm,
+			 struct raft_buffer *bufs[],
+			 unsigned *n_bufs)
+{
+	struct fsm *f = fsm->data;
+	queue *head;
+	struct snapshotHeader header;
+	struct db *db = NULL;
+	unsigned i;
+	int rv;
+
+	/* Decode the header to determine the number of databases. */
+	struct cursor cursor = {(*bufs)[0].base, (*bufs)[0].len};
+	rv = snapshotHeader__decode(&cursor, &header);
+	if (rv != 0) {
+		tracef("decode failed %d", rv);
+		return -1;
+	}
+	if (header.format != SNAPSHOT_FORMAT) {
+		tracef("bad format");
+		return -1;
+	}
+
+	/* Encode individual databases. */
+	i = 1;
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		if (i == *n_bufs) {
+			/* In case a db was added in meanwhile */
+			break;
+		}
+		db = QUEUE__DATA(head, struct db, queue);
+		/* database_header + database file + wal */
+		unsigned n = 3;
+		rv = encodeDiskDatabaseAsync(db, &(*bufs)[i], n);
+		if (rv != 0) {
+			goto err;
+		}
+		i += n;
+	}
+
+	return 0;
+
+err:
+	assert(rv != 0);
+	return rv;
+}
+
+static int fsm__snapshot_finalize_disk(struct raft_fsm *fsm,
+				  struct raft_buffer *bufs[],
+				  unsigned *n_bufs)
+{
+	struct fsm *f = fsm->data;
+	queue *head;
+	struct db *db;
+	unsigned n_db;
+	struct snapshotHeader header;
+	int rv;
+
+	if (bufs == NULL) {
+		return 0;
+	}
+
+	/* Decode the header to determine the number of databases. */
+	struct cursor cursor = {(*bufs)[0].base, (*bufs)[0].len};
+	rv = snapshotHeader__decode(&cursor, &header);
+	if (rv != 0) {
+		tracef("decode failed %d", rv);
+		return -1;
+	}
+	if (header.format != SNAPSHOT_FORMAT) {
+		tracef("bad format");
+		return -1;
+	}
+
+	/* Free allocated buffers */
+	freeSnapshotBufsDisk(f, *bufs, *n_bufs);
+	sqlite3_free(*bufs);
+	*bufs = NULL;
+	*n_bufs = 0;
+
+	/* Unlock all databases that were locked for the snapshot, this is safe
+	 * because DB's are only ever added at the back of the queue. */
+	n_db = 0;
+	QUEUE__FOREACH(head, &f->registry->dbs)
+	{
+		if (n_db == header.n) {
+			break;
+		}
+		db = QUEUE__DATA(head, struct db, queue);
+		databaseReadUnlock(db);
+		n_db++;
+	}
+
+	return 0;
+}
+
+/* Decode the disk database contained in a snapshot. */
+static int decodeDiskDatabase(struct fsm *f, struct cursor *cursor)
+{
+	struct snapshotDatabase header;
+	struct db *db;
+	sqlite3_vfs *vfs;
+	int exists;
+	int rv;
+
+	rv = snapshotDatabase__decode(cursor, &header);
+	if (rv != 0) {
+		return rv;
+	}
+	rv = registry__db_get(f->registry, header.filename, &db);
+	if (rv != 0) {
+		return rv;
+	}
+
+	vfs = sqlite3_vfs_find(db->config->name);
+
+	/* Check if the database file exists, and create it by opening a
+	 * connection if it doesn't. */
+	rv = vfs->xAccess(vfs, db->path, 0, &exists);
+	assert(rv == 0);
+
+	if (!exists) {
+		rv = db__open_follower(db);
+		if (rv != 0) {
+			return rv;
+		}
+		sqlite3_close(db->follower);
+		db->follower = NULL;
+	}
+
+	if (header.main_size + header.wal_size > SIZE_MAX) {
+		tracef("main_size + wal_size would overflow max DB size");
+		return -1;
+	}
+
+	rv = VfsDiskRestore(vfs, db->path, cursor->p, header.main_size, header.wal_size);
+	if (rv != 0) {
+		tracef("VfsDiskRestore %d", rv);
+		return rv;
+	}
+
+	cursor->p += header.main_size + header.wal_size;
+	return 0;
+}
+
+static int fsm__restore_disk(struct raft_fsm *fsm, struct raft_buffer *buf)
+{
+        tracef("fsm restore disk");
+	struct fsm *f = fsm->data;
+	struct cursor cursor = {buf->base, buf->len};
+	struct snapshotHeader header;
+	unsigned i;
+	int rv;
+
+	rv = snapshotHeader__decode(&cursor, &header);
+	if (rv != 0) {
+                tracef("decode failed %d", rv);
+		return rv;
+	}
+	if (header.format != SNAPSHOT_FORMAT) {
+                tracef("bad format");
+		return RAFT_MALFORMED;
+	}
+
+	for (i = 0; i < header.n; i++) {
+		rv = decodeDiskDatabase(f, &cursor);
+		if (rv != 0) {
+                        tracef("decode failed");
+			return rv;
+		}
+	}
+
+	/* Don't use sqlite3_free as this buffer is allocated by raft. */
+	raft_free(buf->base);
+
+	return 0;
+}
+
+int fsm__init_disk(struct raft_fsm *fsm,
+	           struct config *config,
+	           struct registry *registry)
+{
+        tracef("fsm init");
+	struct fsm *f = raft_malloc(sizeof *f);
+
+	if (f == NULL) {
+		return DQLITE_NOMEM;
+	}
+
+	f->logger = &config->logger;
+	f->registry = registry;
+	f->pending.n_pages = 0;
+	f->pending.page_numbers = NULL;
+	f->pending.pages = NULL;
+
+	fsm->version = 3;
+	fsm->data = f;
+	fsm->apply = fsm__apply;
+	fsm->snapshot = fsm__snapshot_disk;
+	fsm->snapshot_async = fsm__snapshot_async_disk;
+	fsm->snapshot_finalize = fsm__snapshot_finalize_disk;
+	fsm->restore = fsm__restore_disk;
+
+	return 0;
 }

--- a/src/fsm.h
+++ b/src/fsm.h
@@ -18,6 +18,14 @@ int fsm__init(struct raft_fsm *fsm,
 	      struct config *config,
 	      struct registry *registry);
 
+/**
+ * Initialize the given SQLite replication interface with dqlite's on-disk
+ * raft based implementation.
+ */
+int fsm__init_disk(struct raft_fsm *fsm,
+		   struct config *config,
+	           struct registry *registry);
+
 void fsm__close(struct raft_fsm *fsm);
 
 #endif /* DQLITE_REPLICATION_METHODS_H_ */

--- a/src/leader.c
+++ b/src/leader.c
@@ -115,7 +115,7 @@ int leader__init(struct leader *l, struct db *db, struct raft *raft)
 	int rc;
 	l->db = db;
 	l->raft = raft;
-	rc = openConnection(db->filename, db->config->name,
+	rc = openConnection(db->path, db->config->name,
 			    db->config->page_size, &l->conn);
 	if (rc != 0) {
                 tracef("open failed %d", rc);
@@ -261,7 +261,7 @@ static void leaderApplyFramesCb(struct raft_apply *req,
 				l->exec->status = SQLITE_IOERR;
 				break;
 		}
-		VfsAbort(vfs, l->db->filename);
+		VfsAbort(vfs, l->db->path);
 	}
 
 	raft_free(apply);
@@ -344,7 +344,7 @@ static void leaderExecV2(struct exec *req)
 
 	req->status = sqlite3_step(req->stmt);
 
-	rv = VfsPoll(vfs, l->db->filename, &frames, &n);
+	rv = VfsPoll(vfs, db->path, &frames, &n);
 	if (rv != 0 || n == 0) {
                 tracef("vfs poll");
 		goto finish;
@@ -356,7 +356,7 @@ static void leaderExecV2(struct exec *req)
 	}
 	sqlite3_free(frames);
 	if (rv != 0) {
-		VfsAbort(vfs, l->db->filename);
+		VfsAbort(vfs, l->db->path);
 		goto finish;
 	}
 

--- a/src/lib/fs.c
+++ b/src/lib/fs.c
@@ -1,0 +1,61 @@
+#include <ftw.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "fs.h"
+#include "../tracing.h"
+
+int FsEnsureDir(const char *path)
+{
+	int rv;
+	struct stat st = {0};
+
+	rv = stat(path, &st);
+	if (rv == 0) {
+		if (!S_ISDIR(st.st_mode)) {
+			tracef("%s is not a directory", path);
+			return -1;
+		}
+	}
+
+	/* Directory does not exist */
+	if (rv == -1) {
+		return mkdir(path, 0755);
+	}
+
+	return 0;
+}
+
+
+static int fsRemoveDirFilesNftwFn(const char *       path,
+                                  const struct stat *sb,
+                                  int                type,
+                                  struct FTW *       ftwb)
+{
+	int rv;
+
+	(void)sb;
+	(void)type;
+	(void)ftwb;
+
+	rv = 0;
+
+	/* Don't remove directory */
+	if (S_ISREG(sb->st_mode)) {
+		rv = remove(path);
+	}
+
+	return rv;
+}
+
+int FsRemoveDirFiles(const char *path)
+{
+	int rv;
+
+	rv = nftw(path, fsRemoveDirFilesNftwFn,
+	          10, FTW_DEPTH | FTW_MOUNT | FTW_PHYS);
+	return rv;
+
+}

--- a/src/lib/fs.h
+++ b/src/lib/fs.h
@@ -1,0 +1,11 @@
+#ifndef DQLITE_LIB_FS_H
+#define DQLITE_LIB_FS_H
+
+
+/* Create a directory if it does not already exist. */
+int FsEnsureDir(const char *path);
+
+/* Removes all files from a directory. */
+int FsRemoveDirFiles(const char *path);
+
+#endif /* DQLITE_LIB_FS_H */

--- a/src/server.c
+++ b/src/server.c
@@ -29,7 +29,7 @@ int dqlite__init(struct dqlite_node *d,
 	int rv;
 	d->initialized = false;
 	memset(d->errmsg, 0, sizeof d->errmsg);
-	rv = config__init(&d->config, id, address);
+	rv = config__init(&d->config, id, address, dir);
 	if (rv != 0) {
 		goto err;
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -10,6 +10,7 @@
 #include "fsm.h"
 #include "lib/addr.h"
 #include "lib/assert.h"
+#include "lib/fs.h"
 #include "logger.h"
 #include "protocol.h"
 #include "tracing.h"
@@ -21,16 +22,28 @@
 /* Special ID for the bootstrap node. Equals to raft_digest("1", 0). */
 #define BOOTSTRAP_ID 0x2dc171858c3155be
 
+#define DATABASE_DIR_FMT "%s/database"
+
 int dqlite__init(struct dqlite_node *d,
 		 dqlite_node_id id,
 		 const char *address,
 		 const char *dir)
 {
 	int rv;
+	char db_dir_path[1024];
+
 	d->initialized = false;
 	memset(d->errmsg, 0, sizeof d->errmsg);
-	rv = config__init(&d->config, id, address, dir);
+
+	rv = snprintf(db_dir_path, sizeof db_dir_path, DATABASE_DIR_FMT, dir);
+	if (rv == -1 || rv >= (int)(sizeof db_dir_path)) {
+		snprintf(d->errmsg, DQLITE_ERRMSG_BUF_SIZE, "failed to init: snprintf(rv:%d)", rv);
+		goto err;
+	}
+
+	rv = config__init(&d->config, id, address, db_dir_path);
 	if (rv != 0) {
+		snprintf(d->errmsg, DQLITE_ERRMSG_BUF_SIZE, "config__init(rv:%d)", rv);
 		goto err;
 	}
 	rv = VfsInit(&d->vfs, d->config.name);
@@ -162,15 +175,12 @@ int dqlite_node_create(dqlite_node_id id,
 		       const char *data_dir,
 		       dqlite_node **t)
 {
-	int rv;
-
 	*t = sqlite3_malloc(sizeof **t);
 	if (*t == NULL) {
 		return DQLITE_NOMEM;
 	}
 
-	rv = dqlite__init(*t, id, address, data_dir);
-	return rv;
+	return dqlite__init(*t, id, address, data_dir);
 }
 
 int dqlite_node_set_bind_address(dqlite_node *t, const char *address)
@@ -317,24 +327,49 @@ int dqlite_node_set_failure_domain(dqlite_node *n, unsigned long long code)
 int dqlite_node_set_snapshot_params(dqlite_node *n, unsigned snapshot_threshold,
                                     unsigned snapshot_trailing)
 {
-    if (n->running) {
-        return DQLITE_MISUSE;
-    }
+	if (n->running) {
+		return DQLITE_MISUSE;
+	}
 
-    if (snapshot_trailing < 4) {
-        return DQLITE_MISUSE;
-    }
+	if (snapshot_trailing < 4) {
+		return DQLITE_MISUSE;
+	}
 
-    /* This is a safety precaution and allows to recover data from the second
-     * last raft snapshot and segment files in case the last raft snapshot is
-     * unusable. */
-    if (snapshot_trailing < snapshot_threshold) {
-        return DQLITE_MISUSE;
-    }
+	/* This is a safety precaution and allows to recover data from the second
+	 * last raft snapshot and segment files in case the last raft snapshot is
+	 * unusable. */
+	if (snapshot_trailing < snapshot_threshold) {
+		return DQLITE_MISUSE;
+	}
 
-    raft_set_snapshot_threshold(&n->raft, snapshot_threshold);
-    raft_set_snapshot_trailing(&n->raft, snapshot_trailing);
-    return 0;
+	raft_set_snapshot_threshold(&n->raft, snapshot_threshold);
+	raft_set_snapshot_trailing(&n->raft, snapshot_trailing);
+	return 0;
+}
+
+int dqlite_node_enable_disk_mode(dqlite_node *n)
+{
+	int rv;
+
+	if (n->running) {
+		return DQLITE_MISUSE;
+	}
+
+	rv = dqlite_vfs_enable_disk(&n->vfs);
+	if (rv != 0) {
+		return rv;
+	}
+
+	n->registry.config->disk = true;
+
+	/* Close the default fsm and initialize the disk one. */
+	fsm__close(&n->raft_fsm);
+	rv = fsm__init_disk(&n->raft_fsm, &n->config, &n->registry);
+	if (rv != 0) {
+		return rv;
+	}
+
+	return 0;
 }
 
 static int maybeBootstrap(dqlite_node *d,
@@ -652,12 +687,42 @@ static bool taskReady(struct dqlite_node *d)
 	return d->running;
 }
 
+static int dqliteDatabaseDirSetup(dqlite_node *t)
+{
+	int rv;
+	if (!t->config.disk) {
+		// nothing to do
+		return 0;
+	}
+
+	rv = FsEnsureDir(t->config.dir);
+	if (rv != 0) {
+		snprintf(t->errmsg, DQLITE_ERRMSG_BUF_SIZE, "Error creating database dir: %d", rv);
+		return rv;
+	}
+
+	rv = FsRemoveDirFiles(t->config.dir);
+	if (rv != 0) {
+		snprintf(t->errmsg, DQLITE_ERRMSG_BUF_SIZE, "Error removing files in database dir: %d", rv);
+		return rv;
+	}
+
+	return rv;
+}
+
 int dqlite_node_start(dqlite_node *t)
 {
 	int rv;
+	tracef("dqlite node start");
 
 	dqliteTracingMaybeEnable(true);
-	tracef("dqlite node start");
+
+	rv = dqliteDatabaseDirSetup(t);
+	if (rv != 0) {
+		tracef("database dir setup failed %s", t->errmsg);
+		goto err;
+	}
+
 	rv = maybeBootstrap(t, t->config.id, t->config.address);
 	if (rv != 0) {
 		tracef("bootstrap failed %d", rv);

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1198,10 +1198,7 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fnctl)
 	assert(left != NULL);
 
 	if (strcmp(left, "page_size") == 0 && right) {
-		/* When the user executes 'PRAGMA page_size=N' we save the
-		 * size internally.
-		 *
-		 * The page size must be between 512 and 65536, and be a
+		/* The page size must be between 512 and 65536, and be a
 		 * power of two. The check below was copied from
 		 * sqlite3BtreeSetPageSize in btree.c.
 		 *

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -9,6 +9,8 @@
  * implementation. */
 int VfsInit(struct sqlite3_vfs *vfs, const char *name);
 
+int VfsEnableDisk(struct sqlite3_vfs *vfs);
+
 /* Release all memory associated with the given dqlite in-memory VFS
  * implementation.
  *
@@ -38,16 +40,29 @@ int VfsSnapshot(sqlite3_vfs *vfs, const char *filename, void **data, size_t *n);
 
 /* Makes a full, shallow snapshot of a database. The first n-1 buffers will each
  * contain a pointer to the actual database pages, while the n'th buffer
- * will contain a copy of the wal. `bufs` MUST point to an array of n
+ * will contain a copy of the WAL. `bufs` MUST point to an array of n
  * `dqlite_buffer` structs and n MUST equal 1 + the number of pages in
  * the database. */
 int VfsShallowSnapshot(sqlite3_vfs *vfs, const char *filename, struct dqlite_buffer bufs[], uint32_t n);
+
+/* Copies the WAL into buf */
+int VfsDiskSnapshotWal(sqlite3_vfs *vfs, const char *path, struct dqlite_buffer *buf);
+
+/* `mmap` the database into buf. */
+int VfsDiskSnapshotDb(sqlite3_vfs *vfs, const char *path, struct dqlite_buffer *buf);
 
 /* Restore a database snapshot. */
 int VfsRestore(sqlite3_vfs *vfs,
 	       const char *filename,
 	       const void *data,
 	       size_t n);
+
+/* Restore a disk database snapshot. */
+int VfsDiskRestore(sqlite3_vfs *vfs,
+	       const char *path,
+	       const void *data,
+	       size_t main_size,
+	       size_t wal_size);
 
 /* Number of pages in the database. */
 int VfsDatabaseNumPages(sqlite3_vfs *vfs,

--- a/test/integration/test_client.c
+++ b/test/integration/test_client.c
@@ -12,6 +12,15 @@
 
 SUITE(client);
 
+static char* bools[] = {
+    "0", "1", NULL
+};
+
+static MunitParameterEnum client_params[] = {
+    { "disk_mode", bools },
+    { NULL, NULL },
+};
+
 struct fixture
 {
 	struct test_server server;
@@ -42,7 +51,7 @@ static void tearDown(void *data)
 	free(f);
 }
 
-TEST(client, exec, setUp, tearDown, 0, NULL)
+TEST(client, exec, setUp, tearDown, 0, client_params)
 {
 	struct fixture *f = data;
 	unsigned stmt_id;
@@ -54,7 +63,7 @@ TEST(client, exec, setUp, tearDown, 0, NULL)
 	return MUNIT_OK;
 }
 
-TEST(client, query, setUp, tearDown, 0, NULL)
+TEST(client, query, setUp, tearDown, 0, client_params)
 {
 	struct fixture *f = data;
 	unsigned stmt_id;

--- a/test/integration/test_cluster.c
+++ b/test/integration/test_cluster.c
@@ -72,6 +72,10 @@ static void tearDown(void *data)
 	free(f);
 }
 
+static char* bools[] = {
+    "0", "1", NULL
+};
+
 static char* num_records[] = {
     "0", "1", "256",
     /* WAL will just have been checkpointed after 993 writes. */
@@ -80,13 +84,14 @@ static char* num_records[] = {
     "2200", NULL
 };
 
-static MunitParameterEnum num_records_params[] = {
+static MunitParameterEnum cluster_params[] = {
     { "num_records", num_records },
+    { "disk_mode", bools },
     { NULL, NULL },
 };
 
 /* Restart a node and check if all data is there */
-TEST(cluster, restart, setUp, tearDown, 0, num_records_params)
+TEST(cluster, restart, setUp, tearDown, 0, cluster_params)
 {
 	struct fixture *f = data;
 	unsigned stmt_id;
@@ -122,7 +127,7 @@ TEST(cluster, restart, setUp, tearDown, 0, num_records_params)
 }
 
 /* Add data to a node, add a new node and make sure data is there. */
-TEST(cluster, dataOnNewNode, setUp, tearDown, 0, num_records_params)
+TEST(cluster, dataOnNewNode, setUp, tearDown, 0, cluster_params)
 {
 	struct fixture *f = data;
 	unsigned stmt_id;

--- a/test/integration/test_fsm.c
+++ b/test/integration/test_fsm.c
@@ -50,11 +50,16 @@
 /* Use the client connected to the server with the given ID. */
 #define SELECT(ID) f->client = test_server_client(&f->servers[ID - 1])
 
+static char* bools[] = {
+    "0", "1", NULL
+};
+
 /* Make sure the snapshots scheduled by raft don't interfere with the snapshots
  * scheduled by the tests. */
 static char *snapshot_threshold[] = {"8192", NULL};
 static MunitParameterEnum snapshot_params[] = {
 	{SNAPSHOT_THRESHOLD_PARAM, snapshot_threshold},
+	{ "disk_mode", bools },
 	{NULL, NULL},
 };
 
@@ -93,9 +98,20 @@ TEST(fsm, snapshotFreshDb, setUp, tearDown, 0, snapshot_params)
 	unsigned n_bufs = 0;
 	int rv;
 
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
+
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_uint(n_bufs, ==, 1); /* Snapshot header */
+
+	if (disk_mode) {
+		rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, ==, 0);
+	}
 
 	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, ==, 0);
@@ -116,6 +132,12 @@ TEST(fsm, snapshotWrittenDb, setUp, tearDown, 0, snapshot_params)
 	unsigned last_insert_id;
 	unsigned rows_affected;
 
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
+
 	/* Add some data to database */
 	HANDSHAKE;
 	OPEN;
@@ -127,6 +149,11 @@ TEST(fsm, snapshotWrittenDb, setUp, tearDown, 0, snapshot_params)
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_uint(n_bufs, >, 1);
+
+	if (disk_mode) {
+		rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, ==, 0);
+	}
 
 	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, ==, 0);
@@ -146,6 +173,12 @@ TEST(fsm, snapshotHeapFaultSingleDB, setUp, tearDown, 0, snapshot_params)
 	unsigned stmt_id;
 	unsigned last_insert_id;
 	unsigned rows_affected;
+
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
 
 	/* Add some data to database */
 	HANDSHAKE;
@@ -169,9 +202,60 @@ TEST(fsm, snapshotHeapFaultSingleDB, setUp, tearDown, 0, snapshot_params)
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, !=, 0);
 
-	test_heap_fault_config(3, 1);
+	/* disk_mode does fewer allocations */
+	if (!disk_mode) {
+		test_heap_fault_config(3, 1);
+		rv = fsm->snapshot(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, !=, 0);
+	}
+
+	return MUNIT_OK;
+}
+
+/* Inject faults into the async stage of the snapshot process */
+TEST(fsm, snapshotHeapFaultSingleDBAsyncDisk, setUp, tearDown, 0, snapshot_params)
+{
+	struct fixture *f = data;
+	struct raft_fsm *fsm = &f->servers[0].dqlite->raft_fsm;
+	struct raft_buffer *bufs;
+	unsigned n_bufs = 0;
+	int rv;
+
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
+
+	if (!disk_mode) {
+		return MUNIT_SKIP;
+	}
+
+	/* Add some data to database */
+	HANDSHAKE;
+	OPEN;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	/* Sync stage succeeds */
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
+
+	/* Inject heap fault in first call to encodeDiskDatabaseAsync */
+	test_heap_fault_config(0, 1);
+	test_heap_fault_enable();
+	rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, !=, 0);
+
+	/* Cleanup should succeed */
+	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
 
 	return MUNIT_OK;
 }
@@ -187,6 +271,12 @@ TEST(fsm, snapshotHeapFaultTwoDB, setUp, tearDown, 0, snapshot_params)
 	unsigned stmt_id;
 	unsigned last_insert_id;
 	unsigned rows_affected;
+
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
 
 	/* Open 2 databases and add data to them */
 	HANDSHAKE;
@@ -224,13 +314,86 @@ TEST(fsm, snapshotHeapFaultTwoDB, setUp, tearDown, 0, snapshot_params)
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, !=, 0);
 
-	test_heap_fault_config(4, 1);
+	/* disk_mode does fewer allocations */
+	if (!disk_mode) {
+		test_heap_fault_config(4, 1);
+		rv = fsm->snapshot(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, !=, 0);
+
+		test_heap_fault_config(5, 1);
+		rv = fsm->snapshot(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, !=, 0);
+	}
+
+	return MUNIT_OK;
+}
+
+TEST(fsm, snapshotHeapFaultTwoDBAsync, setUp, tearDown, 0, snapshot_params)
+{
+	struct fixture *f = data;
+	struct raft_fsm *fsm = &f->servers[0].dqlite->raft_fsm;
+	struct raft_buffer *bufs;
+	unsigned n_bufs = 0;
+	int rv;
+
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
+
+	if (!disk_mode) {
+		return MUNIT_SKIP;
+	}
+
+	/* Open 2 databases and add data to them */
+	HANDSHAKE;
+	OPEN_NAME("test");
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	/* Close and reopen the client and open a second database */
+	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);
+
+	HANDSHAKE;
+	OPEN_NAME("test2");
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	/* sync fsm__snapshot succeeds. */
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
+
+	/* async step fails at different stages. */
+	test_heap_fault_enable();
+
+	test_heap_fault_config(0, 1);
+	rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, !=, 0);
 
-	test_heap_fault_config(5, 1);
+	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
+
+	/* Inject fault when encoding second Database */
+
+	/* sync fsm__snapshot succeeds. */
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
+
+	test_heap_fault_config(1, 1);
+	rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, !=, 0);
+
+	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
 
 	return MUNIT_OK;
 }
@@ -246,6 +409,12 @@ TEST(fsm, snapshotNewDbAddedBeforeFinalize, setUp, tearDown, 0, snapshot_params)
 	unsigned stmt_id;
 	unsigned last_insert_id;
 	unsigned rows_affected;
+
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
 
 	/* Add some data to database */
 	HANDSHAKE;
@@ -267,6 +436,12 @@ TEST(fsm, snapshotNewDbAddedBeforeFinalize, setUp, tearDown, 0, snapshot_params)
 	OPEN_NAME("test2");
 	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
 	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	if (disk_mode) {
+		rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, ==, 0);
+	}
+
 	PREPARE("INSERT INTO test(n) VALUES(1)", &stmt_id);
 	EXEC(stmt_id, &last_insert_id, &rows_affected);
 
@@ -289,6 +464,12 @@ TEST(fsm, snapshotWritesBeforeFinalize, setUp, tearDown, 0, snapshot_params)
 	char sql[128];
 	int rv;
 
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
+
 	/* Add some data to database */
 	HANDSHAKE;
 	OPEN;
@@ -303,9 +484,13 @@ TEST(fsm, snapshotWritesBeforeFinalize, setUp, tearDown, 0, snapshot_params)
 
 	/* Add (a lot) more data to the database */
 	for (unsigned i = 0; i < 1000; ++i) {
-	    sprintf(sql, "INSERT INTO test(n) VALUES(%d)", i + 1);
-	    PREPARE(sql, &stmt_id);
-	    EXEC(stmt_id, &last_insert_id, &rows_affected);
+		sprintf(sql, "INSERT INTO test(n) VALUES(%d)", i + 1);
+		PREPARE(sql, &stmt_id);
+		EXEC(stmt_id, &last_insert_id, &rows_affected);
+		if (disk_mode && i == 512) {
+			rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
+			munit_assert_int(rv, ==, 0);
+		}
 	}
 
 	/* Finalize succeeds */
@@ -320,6 +505,60 @@ TEST(fsm, snapshotWritesBeforeFinalize, setUp, tearDown, 0, snapshot_params)
 
 	return MUNIT_OK;
 }
+
+TEST(fsm, concurrentSnapshots, setUp, tearDown, 0, snapshot_params)
+{
+	struct fixture *f = data;
+	struct raft_fsm *fsm = &f->servers[0].dqlite->raft_fsm;
+	struct raft_buffer *bufs;
+	struct raft_buffer *bufs2;
+	unsigned n_bufs = 0;
+	unsigned n_bufs2 = 0;
+	unsigned stmt_id;
+	unsigned last_insert_id;
+	unsigned rows_affected;
+	int rv;
+
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
+
+	/* Add some data to database */
+	HANDSHAKE;
+	OPEN;
+	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
+	EXEC(stmt_id, &last_insert_id, &rows_affected);
+
+	/* Second snapshot fails when first isn't finalized */
+	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
+	rv = fsm->snapshot(fsm, &bufs2, &n_bufs2);
+	munit_assert_int(rv, ==, RAFT_BUSY);
+
+	if (disk_mode) {
+		rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, ==, 0);
+	}
+
+	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);
+	munit_assert_int(rv, ==, 0);
+
+	/* Second snapshot succeeds after first is finalized */
+	rv = fsm->snapshot(fsm, &bufs2, &n_bufs2);
+	munit_assert_int(rv, ==, 0);
+	if (disk_mode) {
+		rv = fsm->snapshot_async(fsm, &bufs2, &n_bufs2);
+		munit_assert_int(rv, ==, 0);
+	}
+
+	rv = fsm->snapshot_finalize(fsm, &bufs2, &n_bufs2);
+	munit_assert_int(rv, ==, 0);
+
+	return MUNIT_OK;
+}
+
 
 /* Copies n raft buffers to a single raft buffer */
 static struct raft_buffer n_bufs_to_buf(struct raft_buffer bufs[], unsigned n)
@@ -356,6 +595,7 @@ static char* num_records[] = {
 static MunitParameterEnum restore_params[] = {
     { "num_records", num_records },
     { SNAPSHOT_THRESHOLD_PARAM, snapshot_threshold},
+    { "disk_mode", bools },
     { NULL, NULL },
 };
 
@@ -374,6 +614,13 @@ TEST(fsm, snapshotRestore, setUp, tearDown, 0, restore_params)
 	int rv;
 	char sql[128];
 
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
+
+
 	/* Add some data to database */
 	HANDSHAKE;
 	OPEN;
@@ -387,6 +634,11 @@ TEST(fsm, snapshotRestore, setUp, tearDown, 0, restore_params)
 
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, ==, 0);
+
+	if (disk_mode) {
+		rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, ==, 0);
+	}
 
 	/* Deep copy snapshot */
 	snapshot = n_bufs_to_buf(bufs, n_bufs);
@@ -417,42 +669,6 @@ TEST(fsm, snapshotRestore, setUp, tearDown, 0, restore_params)
 	return MUNIT_OK;
 }
 
-TEST(fsm, concurrentSnapshots, setUp, tearDown, 0, snapshot_params)
-{
-	struct fixture *f = data;
-	struct raft_fsm *fsm = &f->servers[0].dqlite->raft_fsm;
-	struct raft_buffer *bufs;
-	struct raft_buffer *bufs2;
-	unsigned n_bufs = 0;
-	unsigned n_bufs2 = 0;
-	unsigned stmt_id;
-	unsigned last_insert_id;
-	unsigned rows_affected;
-	int rv;
-
-	/* Add some data to database */
-	HANDSHAKE;
-	OPEN;
-	PREPARE("CREATE TABLE test (n INT)", &stmt_id);
-	EXEC(stmt_id, &last_insert_id, &rows_affected);
-
-	/* Second snapshot fails when first isn't finalized */
-	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
-	munit_assert_int(rv, ==, 0);
-	rv = fsm->snapshot(fsm, &bufs2, &n_bufs2);
-	munit_assert_int(rv, ==, RAFT_BUSY);
-	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);
-	munit_assert_int(rv, ==, 0);
-
-	/* Second snapshot succeeds after first is finalized */
-	rv = fsm->snapshot(fsm, &bufs2, &n_bufs2);
-	munit_assert_int(rv, ==, 0);
-	rv = fsm->snapshot_finalize(fsm, &bufs2, &n_bufs2);
-	munit_assert_int(rv, ==, 0);
-
-	return MUNIT_OK;
-}
-
 TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, snapshot_params)
 {
 	struct fixture *f = data;
@@ -467,6 +683,12 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, snapshot_params)
 	uint64_t code;
 	const char *msg;
 	int rv;
+
+	bool disk_mode = false;
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		disk_mode = (bool)atoi(disk_mode_param);
+	}
 
 	/* Create 2 databases and add data to them. */
 	HANDSHAKE;
@@ -487,6 +709,12 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, snapshot_params)
 	/* Snapshot both databases and restore the data. */
 	rv = fsm->snapshot(fsm, &bufs, &n_bufs);
 	munit_assert_int(rv, ==, 0);
+
+	if (disk_mode) {
+		rv = fsm->snapshot_async(fsm, &bufs, &n_bufs);
+		munit_assert_int(rv, ==, 0);
+	}
+
 	/* Copy the snapshot to restore it */
 	snapshot = n_bufs_to_buf(bufs, n_bufs);
 	rv = fsm->snapshot_finalize(fsm, &bufs, &n_bufs);

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -59,6 +59,15 @@
  *
  ******************************************************************************/
 
+static char* bools[] = {
+    "0", "1", NULL
+};
+
+static MunitParameterEnum membership_params[] = {
+    { "disk_mode", bools },
+    { NULL, NULL },
+};
+
 SUITE(membership)
 
 struct fixture
@@ -80,7 +89,7 @@ static void tearDown(void *data)
 	free(f);
 }
 
-TEST(membership, join, setUp, tearDown, 0, NULL)
+TEST(membership, join, setUp, tearDown, 0, membership_params)
 {
 	struct fixture *f = data;
 	unsigned id = 2;
@@ -122,7 +131,7 @@ static bool last_applied_cond(struct id_last_applied arg)
 	return arg.f->servers[arg.id].dqlite->raft.last_applied >= arg.last_applied;
 }
 
-TEST(membership, transfer, setUp, tearDown, 0, NULL)
+TEST(membership, transfer, setUp, tearDown, 0, membership_params)
 {
 	struct fixture *f = data;
 	unsigned id = 2;
@@ -166,7 +175,7 @@ TEST(membership, transfer, setUp, tearDown, 0, NULL)
 }
 
 /* Transfer leadership away from a member that has a pending transaction */
-TEST(membership, transferPendingTransaction, setUp, tearDown, 0, NULL)
+TEST(membership, transferPendingTransaction, setUp, tearDown, 0, membership_params)
 {
 	struct fixture *f = data;
 	unsigned id = 2;
@@ -273,7 +282,7 @@ TEST(membership, transferAndSqlExecWithBarrier, setUp, tearDown, 0, NULL)
 }
 
 /* Transfer leadership back and forth from a member that has a pending transaction */
-TEST(membership, transferTwicePendingTransaction, setUp, tearDown, 0, NULL)
+TEST(membership, transferTwicePendingTransaction, setUp, tearDown, 0, membership_params)
 {
 	struct fixture *f = data;
 	unsigned id = 2;

--- a/test/integration/test_node.c
+++ b/test/integration/test_node.c
@@ -13,6 +13,15 @@
  *
  ******************************************************************************/
 
+static char* bools[] = {
+    "0", "1", NULL
+};
+
+static MunitParameterEnum node_params[] = {
+    { "disk_mode", bools },
+    { NULL, NULL },
+};
+
 struct fixture
 {
 	char *dir;         /* Data directory. */
@@ -34,6 +43,15 @@ static void *setUp(const MunitParameter params[], void *user_data)
 	rv = dqlite_node_set_bind_address(f->node, "@123");
 	munit_assert_int(rv, ==, 0);
 
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		bool disk_mode = (bool)atoi(disk_mode_param);
+		if (disk_mode) {
+			rv = dqlite_node_enable_disk_mode(f->node);
+			munit_assert_int(rv, ==, 0);
+		}
+	}
+
 	return f;
 }
 
@@ -51,6 +69,15 @@ static void *setUpInet(const MunitParameter params[], void *user_data)
 
 	rv = dqlite_node_set_bind_address(f->node, "127.0.0.1:9001");
 	munit_assert_int(rv, ==, 0);
+
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		bool disk_mode = (bool)atoi(disk_mode_param);
+		if (disk_mode) {
+			rv = dqlite_node_enable_disk_mode(f->node);
+			munit_assert_int(rv, ==, 0);
+		}
+	}
 
 	return f;
 }
@@ -76,6 +103,15 @@ static void *setUpForRecovery(const MunitParameter params[], void *user_data)
         rv = dqlite_node_set_bind_address(f->node, "@123");
         munit_assert_int(rv, ==, 0);
 
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		bool disk_mode = (bool)atoi(disk_mode_param);
+		if (disk_mode) {
+			rv = dqlite_node_enable_disk_mode(f->node);
+			munit_assert_int(rv, ==, 0);
+		}
+	}
+
         return f;
 }
 
@@ -99,7 +135,7 @@ SUITE(node);
  *
  ******************************************************************************/
 
-TEST(node, start, setUp, tearDown, 0, NULL)
+TEST(node, start, setUp, tearDown, 0, node_params)
 {
 	struct fixture *f = data;
 	int rv;
@@ -113,7 +149,7 @@ TEST(node, start, setUp, tearDown, 0, NULL)
 	return MUNIT_OK;
 }
 
-TEST(node, startInet, setUpInet, tearDown, 0, NULL)
+TEST(node, startInet, setUpInet, tearDown, 0, node_params)
 {
 	struct fixture *f = data;
 	int rv;
@@ -127,7 +163,7 @@ TEST(node, startInet, setUpInet, tearDown, 0, NULL)
 	return MUNIT_OK;
 }
 
-TEST(node, snapshotParams, setUp, tearDown, 0, NULL)
+TEST(node, snapshotParams, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -139,7 +175,7 @@ TEST(node, snapshotParams, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, snapshotParamsRunning, setUp, tearDown, 0, NULL)
+TEST(node, snapshotParamsRunning, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -156,7 +192,7 @@ TEST(node, snapshotParamsRunning, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, snapshotParamsTrailingTooSmall, setUp, tearDown, 0, NULL)
+TEST(node, snapshotParamsTrailingTooSmall, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -168,7 +204,7 @@ TEST(node, snapshotParamsTrailingTooSmall, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, snapshotParamsThresholdLargerThanTrailing, setUp, tearDown, 0, NULL)
+TEST(node, snapshotParamsThresholdLargerThanTrailing, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -180,7 +216,7 @@ TEST(node, snapshotParamsThresholdLargerThanTrailing, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, networkLatency, setUp, tearDown, 0, NULL)
+TEST(node, networkLatency, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -192,7 +228,7 @@ TEST(node, networkLatency, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, networkLatencyRunning, setUp, tearDown, 0, NULL)
+TEST(node, networkLatencyRunning, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -209,7 +245,7 @@ TEST(node, networkLatencyRunning, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, networkLatencyTooLarge, setUp, tearDown, 0, NULL)
+TEST(node, networkLatencyTooLarge, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -221,7 +257,7 @@ TEST(node, networkLatencyTooLarge, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, networkLatencyMs, setUp, tearDown, 0, NULL)
+TEST(node, networkLatencyMs, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -235,7 +271,7 @@ TEST(node, networkLatencyMs, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, networkLatencyMsRunning, setUp, tearDown, 0, NULL)
+TEST(node, networkLatencyMsRunning, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -252,7 +288,7 @@ TEST(node, networkLatencyMsRunning, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, networkLatencyMsTooSmall, setUp, tearDown, 0, NULL)
+TEST(node, networkLatencyMsTooSmall, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -264,7 +300,7 @@ TEST(node, networkLatencyMsTooSmall, setUp, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, networkLatencyMsTooLarge, setUp, tearDown, 0, NULL)
+TEST(node, networkLatencyMsTooLarge, setUp, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -282,7 +318,7 @@ TEST(node, networkLatencyMsTooLarge, setUp, tearDown, 0, NULL)
  * dqlite_node_recover
  *
  ******************************************************************************/
-TEST(node, recover, setUpForRecovery, tearDown, 0, NULL)
+TEST(node, recover, setUpForRecovery, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -301,7 +337,7 @@ TEST(node, recover, setUpForRecovery, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, recoverExt, setUpForRecovery, tearDown, 0, NULL)
+TEST(node, recoverExt, setUpForRecovery, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -324,7 +360,7 @@ TEST(node, recoverExt, setUpForRecovery, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, recoverExtUnaligned, setUpForRecovery, tearDown, 0, NULL)
+TEST(node, recoverExtUnaligned, setUpForRecovery, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -343,7 +379,7 @@ TEST(node, recoverExtUnaligned, setUpForRecovery, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, recoverExtTooSmall, setUpForRecovery, tearDown, 0, NULL)
+TEST(node, recoverExtTooSmall, setUpForRecovery, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -368,7 +404,7 @@ struct dqlite_node_info_ext_new {
     uint64_t new2;
 };
 
-TEST(node, recoverExtNewFields, setUpForRecovery, tearDown, 0, NULL)
+TEST(node, recoverExtNewFields, setUpForRecovery, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -389,7 +425,7 @@ TEST(node, recoverExtNewFields, setUpForRecovery, tearDown, 0, NULL)
         return MUNIT_OK;
 }
 
-TEST(node, recoverExtNewFieldsNotZero, setUpForRecovery, tearDown, 0, NULL)
+TEST(node, recoverExtNewFieldsNotZero, setUpForRecovery, tearDown, 0, node_params)
 {
         struct fixture *f = data;
         int rv;
@@ -422,7 +458,7 @@ TEST(node, errMsgNodeNull, NULL, NULL, 0, NULL)
 	return MUNIT_OK;
 }
 
-TEST(node, errMsg, setUp, tearDown, 0, NULL)
+TEST(node, errMsg, setUp, tearDown, 0, node_params)
 {
 	struct fixture *f = data;
 	int rv;

--- a/test/integration/test_vfs.c
+++ b/test/integration/test_vfs.c
@@ -8,9 +8,23 @@
 
 #include "../../include/dqlite.h"
 
+#include <sys/mman.h>
+
 SUITE(vfs);
 
 #define N_VFS 2
+
+static char* bools[] = {
+    "0", "1", NULL
+};
+
+#define SNAPSHOT_SHALLOW_PARAM "snapshot-shallow-param"
+static MunitParameterEnum vfs_params[] = {
+	{SNAPSHOT_SHALLOW_PARAM, bools},
+	{ "disk_mode", bools },
+	{NULL, NULL},
+};
+
 
 struct fixture
 {
@@ -33,6 +47,15 @@ static void *setUp(const MunitParameter params[], void *user_data)
 		sprintf(f->names[i], "%u", i + 1);
 		rv = dqlite_vfs_init(&f->vfs[i], f->names[i]);
 		munit_assert_int(rv, ==, 0);
+		const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+		if (disk_mode_param != NULL) {
+			bool disk_mode = (bool)atoi(disk_mode_param);
+			if (disk_mode) {
+				f->dirs[i] = test_dir_setup();
+				rv = dqlite_vfs_enable_disk(&f->vfs[i]);
+				munit_assert_int(rv, ==, 0);
+			}
+		}
 		rv = sqlite3_vfs_register(&f->vfs[i], 0);
 		munit_assert_int(rv, ==, 0);
 	}
@@ -50,9 +73,7 @@ static void tearDown(void *data)
 		rv = sqlite3_vfs_unregister(&f->vfs[i]);
 		munit_assert_int(rv, ==, 0);
 		dqlite_vfs_close(&f->vfs[i]);
-		if (f->dirs[i] != NULL) {
-			test_dir_tear_down(f->dirs[i]);
-		}
+		test_dir_tear_down(f->dirs[i]);
 	}
 
 	TEAR_DOWN_SQLITE;
@@ -79,12 +100,29 @@ static void tearDownRestorePendingByte(void *data)
 			     sqlite3_errmsg(DB), _rv);               \
 	}
 
+#define VFS_PATH_SZ 512
+static void vfsFillDbPath(struct fixture *f, char *vfs, char *filename, char *path)
+{
+	    int rv;
+	    char *dir = f->dirs[atoi(vfs)-1];
+	    if (dir != NULL) {
+		    rv = snprintf(path, VFS_PATH_SZ, "%s/%s", dir, filename);
+	    } else {
+		    rv = snprintf(path, VFS_PATH_SZ, "%s", filename);
+	    }
+	    munit_assert_int(rv, >, 0);
+	    munit_assert_int(rv, <, VFS_PATH_SZ);
+}
+
 /* Open a new database connection on the given VFS. */
 #define OPEN(VFS, DB)                                                         \
 	do {                                                                  \
 		int _flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;      \
 		int _rv;                                                      \
-		_rv = sqlite3_open_v2("test.db", &DB, _flags, VFS);           \
+		char path[VFS_PATH_SZ];                                       \
+		struct fixture *f = data;                                     \
+		vfsFillDbPath(f, VFS, "test.db", path);                       \
+		_rv = sqlite3_open_v2(path, &DB, _flags, VFS);           \
 		munit_assert_int(_rv, ==, SQLITE_OK);                         \
 		_rv = sqlite3_extended_result_codes(DB, 1);                   \
 		munit_assert_int(_rv, ==, SQLITE_OK);                         \
@@ -170,7 +208,10 @@ struct tx
 		unsigned _i;                                               \
 		int _rv;                                                   \
 		memset(&TX, 0, sizeof TX);                                 \
-		_rv = dqlite_vfs_poll(vfs, "test.db", &_frames, &TX.n);    \
+		char path[VFS_PATH_SZ];                                    \
+		struct fixture *f = data;                                  \
+		vfsFillDbPath(f, VFS, "test.db", path);                    \
+		_rv = dqlite_vfs_poll(vfs, path, &_frames, &TX.n);         \
 		munit_assert_int(_rv, ==, 0);                              \
 		if (_frames != NULL) {                                     \
 			TX.page_numbers =                                  \
@@ -192,8 +233,11 @@ struct tx
 	do {                                                                  \
 		sqlite3_vfs *vfs = sqlite3_vfs_find(VFS);                     \
 		int _rv;                                                      \
-		_rv = dqlite_vfs_apply(vfs, "test.db", TX.n, TX.page_numbers, \
-				       TX.frames);                            \
+		char path[VFS_PATH_SZ];                                       \
+		struct fixture *f = data;                                     \
+		vfsFillDbPath(f, VFS, "test.db", path);                       \
+		_rv = dqlite_vfs_apply(vfs, path, TX.n, TX.page_numbers,      \
+				       TX.frames);                 \
 		munit_assert_int(_rv, ==, 0);                                 \
 	} while (0)
 
@@ -202,7 +246,10 @@ struct tx
 	do {                                              \
 		sqlite3_vfs *vfs = sqlite3_vfs_find(VFS); \
 		int _rv;                                  \
-		_rv = dqlite_vfs_abort(vfs, "test.db");   \
+		char path[VFS_PATH_SZ];                   \
+		struct fixture *f = data;                 \
+		vfsFillDbPath(f, VFS, "test.db", path);   \
+		_rv = dqlite_vfs_abort(vfs, path);        \
 		munit_assert_int(_rv, ==, 0);             \
 	} while (0)
 
@@ -254,6 +301,8 @@ struct snapshot
 {
 	void *data;
 	size_t n;
+	size_t main_size;
+	size_t wal_size;
 };
 
 /* Copies n dqlite_buffers to a single dqlite buffer */
@@ -265,6 +314,7 @@ static struct dqlite_buffer n_bufs_to_buf(struct dqlite_buffer bufs[], unsigned 
 	/* Allocate a suitable buffer */
 	for (unsigned i = 0; i < n; ++i) {
 		buf.len += bufs[i].len;
+		tracef("buf.len %zu", buf.len);
 	}
 	buf.base = raft_malloc(buf.len);
 	munit_assert_ptr_not_null(buf.base);
@@ -280,12 +330,31 @@ static struct dqlite_buffer n_bufs_to_buf(struct dqlite_buffer bufs[], unsigned 
 	return buf;
 }
 
-#define SNAPSHOT_SHALLOW_PARAM "snapshot-shallow-param"
-static char *snapshot_shallow[] = {"0", "1", NULL};
-static MunitParameterEnum snapshot_params[] = {
-	{SNAPSHOT_SHALLOW_PARAM, snapshot_shallow},
-	{NULL, NULL},
-};
+#define SNAPSHOT_DISK(VFS, SNAPSHOT)                             \
+	do {                                                     \
+		sqlite3_vfs *vfs = sqlite3_vfs_find(VFS);        \
+		int _rv;                                         \
+		unsigned _n;                                     \
+		struct dqlite_buffer *_bufs;                     \
+		struct dqlite_buffer _all_data;                  \
+		_n = 2;	                                         \
+		_bufs = sqlite3_malloc64(_n * sizeof(*_bufs));   \
+		char path[VFS_PATH_SZ];                          \
+		struct fixture *f = data;                        \
+		vfsFillDbPath(f, VFS, "test.db", path);          \
+		_rv = dqlite_vfs_snapshot_disk(vfs, path, _bufs, \
+					  _n);                   \
+		munit_assert_int(_rv, ==, 0);                    \
+		_all_data = n_bufs_to_buf(_bufs, _n);            \
+		/* Free WAL buffer after copy. */                \
+		SNAPSHOT.main_size = _bufs[0].len; \
+		SNAPSHOT.wal_size = _bufs[1].len; \
+		sqlite3_free(_bufs[1].base);                     \
+		munmap(_bufs[0].base, _bufs[0].len);             \
+		sqlite3_free(_bufs);                             \
+		SNAPSHOT.data = _all_data.base;                  \
+		SNAPSHOT.n = _all_data.len;                      \
+	} while (0)
 
 /* Take a snapshot of the database on the given VFS. */
 #define SNAPSHOT_DEEP(VFS, SNAPSHOT)                                      \
@@ -323,28 +392,45 @@ static MunitParameterEnum snapshot_params[] = {
 #define SNAPSHOT(VFS, SNAPSHOT)                                                                \
 	do {                                                                                   \
 		bool _shallow = false;                                                         \
+		bool _disk_mode = false; \
 		if (munit_parameters_get(params, SNAPSHOT_SHALLOW_PARAM) != NULL) {            \
 			_shallow = atoi(munit_parameters_get(params, SNAPSHOT_SHALLOW_PARAM)); \
 		}                                                                              \
-		if (_shallow) {                                                                \
+		if (munit_parameters_get(params, "disk_mode") != NULL) {            \
+			_disk_mode = atoi(munit_parameters_get(params, "disk_mode")); \
+		}                                                                              \
+		if (_shallow && !_disk_mode) {                                                                \
 			SNAPSHOT_SHALLOW(VFS, SNAPSHOT);                                       \
-		} else {                                                                       \
+		} else if (!_shallow && !_disk_mode) {                                                                       \
 			SNAPSHOT_DEEP(VFS, SNAPSHOT);                                          \
+		} else { \
+			SNAPSHOT_DISK(VFS, SNAPSHOT);                                          \
 		}                                                                              \
 	} while (0)
 
 /* Restore a snapshot onto the given VFS. */
 #define RESTORE(VFS, SNAPSHOT)                                          \
 	do {                                                            \
+		bool _disk_mode = false; \
+		if (munit_parameters_get(params, "disk_mode") != NULL) {            \
+			_disk_mode = atoi(munit_parameters_get(params, "disk_mode")); \
+		}                                                                              \
 		sqlite3_vfs *vfs = sqlite3_vfs_find(VFS);               \
 		int _rv;                                                \
-		_rv = dqlite_vfs_restore(vfs, "test.db", SNAPSHOT.data, \
+		char path[VFS_PATH_SZ];                                       \
+		struct fixture *f = data;                                     \
+		vfsFillDbPath(f, VFS, "test.db", path);                       \
+		if (_disk_mode) {\
+			_rv = dqlite_vfs_restore_disk(vfs, path, SNAPSHOT.data, SNAPSHOT.main_size, SNAPSHOT.wal_size);\
+		} else {\
+			_rv = dqlite_vfs_restore(vfs, path, SNAPSHOT.data, \
 					 SNAPSHOT.n);                   \
+		}\
 		munit_assert_int(_rv, ==, 0);                           \
 	} while (0)
 
 /* Open and close a new connection using the dqlite VFS. */
-TEST(vfs, open, setUp, tearDown, 0, NULL)
+TEST(vfs, open, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	OPEN("1", db);
@@ -355,7 +441,7 @@ TEST(vfs, open, setUp, tearDown, 0, NULL)
 /* New frames appended to the WAL file by a sqlite3_step() call that has
  * triggered a write transactions are not immediately visible to other
  * connections after sqlite3_step() has returned. */
-TEST(vfs, writeTransactionNotImmediatelyVisible, setUp, tearDown, 0, NULL)
+TEST(vfs, writeTransactionNotImmediatelyVisible, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -378,7 +464,7 @@ TEST(vfs, writeTransactionNotImmediatelyVisible, setUp, tearDown, 0, NULL)
 
 /* Invoking dqlite_vfs_poll() after a call to sqlite3_step() has triggered a
  * write transaction returns the newly appended WAL frames. */
-TEST(vfs, pollAfterWriteTransaction, setUp, tearDown, 0, NULL)
+TEST(vfs, pollAfterWriteTransaction, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -410,7 +496,7 @@ TEST(vfs, pollAfterWriteTransaction, setUp, tearDown, 0, NULL)
  * write transaction sets a write lock on the WAL, so calls to sqlite3_step()
  * from other connections return SQLITE_BUSY if they try to start a write
  * transaction. */
-TEST(vfs, pollAcquireWriteLock, setUp, tearDown, 0, NULL)
+TEST(vfs, pollAcquireWriteLock, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -445,7 +531,7 @@ TEST(vfs, pollAcquireWriteLock, setUp, tearDown, 0, NULL)
  * triggered a write transaction, some WAL frames will be written and then
  * overwritten before the final commit. Only the final version of the frame is
  * included in the set returned by dqlite_vfs_poll(). */
-TEST(vfs, pollAfterPageStress, setUp, tearDown, 0, NULL)
+TEST(vfs, pollAfterPageStress, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -507,7 +593,7 @@ TEST(vfs, pollAfterPageStress, setUp, tearDown, 0, NULL)
 /* Set the SQLite PENDING_BYTE at the start of the second page and make sure
  * all data entry is successful.
  */
-TEST(vfs, adaptPendingByte, setUp, tearDownRestorePendingByte, 0, NULL)
+TEST(vfs, adaptPendingByte, setUp, tearDownRestorePendingByte, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -560,7 +646,7 @@ TEST(vfs, adaptPendingByte, setUp, tearDownRestorePendingByte, 0, NULL)
 /* Use dqlite_vfs_apply() to actually modify the WAL after a write transaction
  * was triggered by a call to sqlite3_step(), then perform a read transaction
  * and check that it can see the transaction changes. */
-TEST(vfs, applyMakesTransactionVisible, setUp, tearDown, 0, NULL)
+TEST(vfs, applyMakesTransactionVisible, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -586,7 +672,7 @@ TEST(vfs, applyMakesTransactionVisible, setUp, tearDown, 0, NULL)
 /* Use dqlite_vfs_apply() to actually modify the WAL after a write transaction
  * was triggered by an explicit "COMMIT" statement and check that changes are
  * visible. */
-TEST(vfs, applyExplicitTransaction, setUp, tearDown, 0, NULL)
+TEST(vfs, applyExplicitTransaction, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -626,7 +712,7 @@ TEST(vfs, applyExplicitTransaction, setUp, tearDown, 0, NULL)
 /* Perform two consecutive full write transactions using sqlite3_step(),
  * dqlite_vfs_poll() and dqlite_vfs_apply(), then run a read transaction and
  * check that it can see all committed changes. */
-TEST(vfs, consecutiveWriteTransactions, setUp, tearDown, 0, NULL)
+TEST(vfs, consecutiveWriteTransactions, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -661,7 +747,7 @@ TEST(vfs, consecutiveWriteTransactions, setUp, tearDown, 0, NULL)
 /* Perform three consecutive write transactions, then re-open the database and
  * finally run a read transaction and check that it can see all committed
  * changes. */
-TEST(vfs, reopenAfterConsecutiveWriteTransactions, setUp, tearDown, 0, NULL)
+TEST(vfs, reopenAfterConsecutiveWriteTransactions, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -700,7 +786,7 @@ TEST(vfs, reopenAfterConsecutiveWriteTransactions, setUp, tearDown, 0, NULL)
 /* Use dqlite_vfs_apply() to actually modify the WAL after a write transaction
  * was triggered by sqlite3_step(), and verify that the transaction is visible
  * from another existing connection. */
-TEST(vfs, transactionIsVisibleFromExistingConnection, setUp, tearDown, 0, NULL)
+TEST(vfs, transactionIsVisibleFromExistingConnection, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -729,7 +815,7 @@ TEST(vfs, transactionIsVisibleFromExistingConnection, setUp, tearDown, 0, NULL)
 /* Use dqlite_vfs_apply() to actually modify the WAL after a write transaction
  * was triggered by sqlite3_step(), and verify that the transaction is visible
  * from a brand new connection. */
-TEST(vfs, transactionIsVisibleFromNewConnection, setUp, tearDown, 0, NULL)
+TEST(vfs, transactionIsVisibleFromNewConnection, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -760,7 +846,7 @@ TEST(vfs, transactionIsVisibleFromNewConnection, setUp, tearDown, 0, NULL)
  * was triggered by sqlite3_step(), then close the connection and open a new
  * one. A read transaction started in the new connection can see the changes
  * committed by the first one. */
-TEST(vfs, transactionIsVisibleFromReopenedConnection, setUp, tearDown, 0, NULL)
+TEST(vfs, transactionIsVisibleFromReopenedConnection, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -789,7 +875,7 @@ TEST(vfs, transactionIsVisibleFromReopenedConnection, setUp, tearDown, 0, NULL)
  * different VFS than the one that initially generated it. In that case it's
  * necessary to initialize the database file on the other VFS by opening and
  * closing a connection. */
-TEST(vfs, firstApplyOnDifferentVfs, setUp, tearDown, 0, NULL)
+TEST(vfs, firstApplyOnDifferentVfs, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -820,7 +906,7 @@ TEST(vfs, firstApplyOnDifferentVfs, setUp, tearDown, 0, NULL)
 /* Use dqlite_vfs_apply() to replicate a second write transaction on a different
  * VFS than the one that initially generated it. In that case it's not necessary
  * to do anything special before calling dqlite_vfs_apply(). */
-TEST(vfs, secondApplyOnDifferentVfs, setUp, tearDown, 0, NULL)
+TEST(vfs, secondApplyOnDifferentVfs, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -855,7 +941,7 @@ TEST(vfs, secondApplyOnDifferentVfs, setUp, tearDown, 0, NULL)
 /* Use dqlite_vfs_apply() to replicate a second write transaction on a different
  * VFS than the one that initially generated it and that has an open connection
  * which has built the WAL index header by preparing a statement. */
-TEST(vfs, applyOnDifferentVfsWithOpenConnection, setUp, tearDown, 0, NULL)
+TEST(vfs, applyOnDifferentVfsWithOpenConnection, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -900,7 +986,7 @@ TEST(vfs, applyOnDifferentVfsWithOpenConnection, setUp, tearDown, 0, NULL)
 
 /* A write transaction that gets replicated to a different VFS is visible to a
  * new connection opened on that VFS. */
-TEST(vfs, transactionVisibleOnDifferentVfs, setUp, tearDown, 0, NULL)
+TEST(vfs, transactionVisibleOnDifferentVfs, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -931,7 +1017,7 @@ TEST(vfs, transactionVisibleOnDifferentVfs, setUp, tearDown, 0, NULL)
 
 /* Calling dqlite_vfs_abort() to cancel a transaction releases the write
  * lock on the WAL. */
-TEST(vfs, abort, setUp, tearDown, 0, NULL)
+TEST(vfs, abort, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -965,7 +1051,7 @@ TEST(vfs, abort, setUp, tearDown, 0, NULL)
 /* Perform a checkpoint after a write transaction has completed, then perform
  * another write transaction and check that changes both before and after the
  * checkpoint are visible. */
-TEST(vfs, checkpoint, setUp, tearDown, 0, NULL)
+TEST(vfs, checkpoint, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	sqlite3 *db2;
@@ -1006,7 +1092,7 @@ TEST(vfs, checkpoint, setUp, tearDown, 0, NULL)
 }
 
 /* Replicate a write transaction that happens after a checkpoint. */
-TEST(vfs, applyOnDifferentVfsAfterCheckpoint, setUp, tearDown, 0, NULL)
+TEST(vfs, applyOnDifferentVfsAfterCheckpoint, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -1062,7 +1148,7 @@ TEST(vfs, applyOnDifferentVfsAfterCheckpoint, setUp, tearDown, 0, NULL)
 
 /* Replicate a write transaction that happens after a checkpoint, without
  * performing the checkpoint on the replicated DB. */
-TEST(vfs, applyOnDifferentVfsAfterCheckpointOtherVfsNoCheckpoint, setUp, tearDown, 0, NULL)
+TEST(vfs, applyOnDifferentVfsAfterCheckpointOtherVfsNoCheckpoint, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -1132,7 +1218,7 @@ TEST(vfs, applyOnDifferentVfsAfterCheckpointOtherVfsNoCheckpoint, setUp, tearDow
 
 /* Replicate a write transaction that happens before a checkpoint, and is
  * replicated on a DB that has been checkpointed. */
-TEST(vfs, applyOnDifferentVfsExtraCheckpointsOnOtherVfs, setUp, tearDown, 0, NULL)
+TEST(vfs, applyOnDifferentVfsExtraCheckpointsOnOtherVfs, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -1203,7 +1289,7 @@ TEST(vfs, applyOnDifferentVfsExtraCheckpointsOnOtherVfs, setUp, tearDown, 0, NUL
 
 /* Replicate to another VFS a series of changes including a checkpoint, then
  * perform a new write transaction on that other VFS. */
-TEST(vfs, checkpointThenPerformTransaction, setUp, tearDown, 0, NULL)
+TEST(vfs, checkpointThenPerformTransaction, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db1;
 	struct tx tx1;
@@ -1253,7 +1339,7 @@ TEST(vfs, checkpointThenPerformTransaction, setUp, tearDown, 0, NULL)
 
 /* Rollback a transaction that didn't hit the page cache limit and hence didn't
  * perform any pre-commit WAL writes. */
-TEST(vfs, rollbackTransactionWithoutPageStress, setUp, tearDown, 0, NULL)
+TEST(vfs, rollbackTransactionWithoutPageStress, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	struct tx tx;
@@ -1293,7 +1379,7 @@ TEST(vfs, rollbackTransactionWithoutPageStress, setUp, tearDown, 0, NULL)
 
 /* Rollback a transaction that hit the page cache limit and hence performed some
  * pre-commit WAL writes. */
-TEST(vfs, rollbackTransactionWithPageStress, setUp, tearDown, 0, NULL)
+TEST(vfs, rollbackTransactionWithPageStress, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -1339,7 +1425,7 @@ TEST(vfs, rollbackTransactionWithPageStress, setUp, tearDown, 0, NULL)
 }
 
 /* Try and fail to checkpoint a WAL that performed some pre-commit WAL writes. */
-TEST(vfs, checkpointTransactionWithPageStress, setUp, tearDown, 0, NULL)
+TEST(vfs, checkpointTransactionWithPageStress, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	struct tx tx;
@@ -1372,7 +1458,7 @@ TEST(vfs, checkpointTransactionWithPageStress, setUp, tearDown, 0, NULL)
 
 /* A snapshot of a brand new database that has been just initialized contains
  * just the first page of the main database file. */
-TEST(vfs, snapshotInitialDatabase, setUp, tearDown, 0, snapshot_params)
+TEST(vfs, snapshotInitialDatabase, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	struct snapshot snapshot;
@@ -1399,7 +1485,7 @@ TEST(vfs, snapshotInitialDatabase, setUp, tearDown, 0, snapshot_params)
 /* A snapshot of a database after the first write transaction gets applied
  * contains the first page of the database plus the WAL file containing the
  * transaction frames. */
-TEST(vfs, snapshotAfterFirstTransaction, setUp, tearDown, 0, snapshot_params)
+TEST(vfs, snapshotAfterFirstTransaction, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	struct snapshot snapshot;
@@ -1432,7 +1518,7 @@ TEST(vfs, snapshotAfterFirstTransaction, setUp, tearDown, 0, snapshot_params)
 
 /* A snapshot of a database after a checkpoint contains all checkpointed pages
  * and no WAL frames. */
-TEST(vfs, snapshotAfterCheckpoint, setUp, tearDown, 0, snapshot_params)
+TEST(vfs, snapshotAfterCheckpoint, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	struct snapshot snapshot;
@@ -1467,7 +1553,7 @@ TEST(vfs, snapshotAfterCheckpoint, setUp, tearDown, 0, snapshot_params)
 
 /* Restore a snapshot taken after a brand new database has been just
  * initialized. */
-TEST(vfs, restoreInitialDatabase, setUp, tearDown, 0, snapshot_params)
+TEST(vfs, restoreInitialDatabase, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	struct snapshot snapshot;
@@ -1489,7 +1575,7 @@ TEST(vfs, restoreInitialDatabase, setUp, tearDown, 0, snapshot_params)
 
 /* Restore a snapshot of a database taken after the first write transaction gets
  * applied. */
-TEST(vfs, restoreAfterFirstTransaction, setUp, tearDown, 0, snapshot_params)
+TEST(vfs, restoreAfterFirstTransaction, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -1526,7 +1612,7 @@ TEST(vfs, restoreAfterFirstTransaction, setUp, tearDown, 0, snapshot_params)
 }
 
 /* Restore a snapshot of a database while a connection is open. */
-TEST(vfs, restoreWithOpenConnection, setUp, tearDown, 0, snapshot_params)
+TEST(vfs, restoreWithOpenConnection, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	sqlite3_stmt *stmt;
@@ -1560,7 +1646,7 @@ TEST(vfs, restoreWithOpenConnection, setUp, tearDown, 0, snapshot_params)
 }
 
 /* Changing page_size to non-default value fails. */
-TEST(vfs, changePageSize, setUp, tearDown, 0, NULL)
+TEST(vfs, changePageSize, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	int rv;
@@ -1576,7 +1662,7 @@ TEST(vfs, changePageSize, setUp, tearDown, 0, NULL)
 }
 
 /* Changing page_size to current value succeeds. */
-TEST(vfs, changePageSizeSameValue, setUp, tearDown, 0, NULL)
+TEST(vfs, changePageSizeSameValue, setUp, tearDown, 0, vfs_params)
 {
 	sqlite3 *db;
 	int rv;

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -89,7 +89,7 @@ struct server
                                                                        \
 		registry__init(&_s->registry, &_s->config);            \
                                                                        \
-		_rc = VfsInit(&_s->vfs, _s->config.name);            \
+		_rc = VfsInit(&_s->vfs, _s->config.name);              \
 		munit_assert_int(_rc, ==, 0);                          \
 		_rc = sqlite3_vfs_register(&_s->vfs, 0);               \
 		munit_assert_int(_rc, ==, 0);                          \

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -23,6 +23,7 @@
 #include "../../src/registry.h"
 #include "../../src/vfs.h"
 
+#include "../lib/fs.h"
 #include "../lib/heap.h"
 #include "../lib/logger.h"
 #include "../lib/sqlite.h"
@@ -38,6 +39,7 @@ struct server
 	struct config config;
 	sqlite3_vfs vfs;
 	struct registry registry;
+	char *dir;
 };
 
 #define FIXTURE_CLUSTER                   \
@@ -79,7 +81,10 @@ struct server
                                                                        \
 		sprintf(address, "%d", I + 1);                         \
                                                                        \
-		_rc = config__init(&_s->config, I + 1, address);       \
+		char *dir = test_dir_setup();                          \
+		_s->dir = dir;                                         \
+                                                                       \
+		_rc = config__init(&_s->config, I + 1, address, dir);  \
 		munit_assert_int(_rc, ==, 0);                          \
                                                                        \
 		registry__init(&_s->registry, &_s->config);            \
@@ -113,6 +118,7 @@ struct server
 		sqlite3_vfs_unregister(&s->vfs);     \
 		VfsClose(&s->vfs);                   \
 		config__close(&s->config);           \
+		test_dir_tear_down(s->dir);          \
 		test_logger_tear_down(&s->logger);   \
 	}
 

--- a/test/lib/config.h
+++ b/test/lib/config.h
@@ -14,7 +14,7 @@
 #define SETUP_CONFIG                                          \
 	{                                                     \
 		int rc;                                       \
-		rc = config__init(&f->config, 1, "1");        \
+		rc = config__init(&f->config, 1, "1", "dir"); \
 		munit_assert_int(rc, ==, 0);                  \
 		test_logger_setup(params, &f->config.logger); \
 	}

--- a/test/lib/fs.c
+++ b/test/lib/fs.c
@@ -36,6 +36,10 @@ static int test__dir_tear_down_nftw_fn(const char *       path,
 void test_dir_tear_down(char *dir) {
 	int rc;
 
+	if (dir == NULL) {
+		return;
+	}
+
 	rc = nftw(dir,
 	          test__dir_tear_down_nftw_fn,
 	          10,

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -66,11 +66,21 @@ void test_server_start(struct test_server *s, const MunitParameter params[])
 	rv = dqlite_node_set_network_latency_ms(s->dqlite, 10);
 	munit_assert_int(rv, ==, 0);
 
-	if (munit_parameters_get(params, SNAPSHOT_THRESHOLD_PARAM) != NULL) {
-		unsigned threshold = (unsigned)atoi(munit_parameters_get(
-			    params, SNAPSHOT_THRESHOLD_PARAM));
+	const char *snapshot_threshold_param = munit_parameters_get(params,
+							    SNAPSHOT_THRESHOLD_PARAM);
+	if (snapshot_threshold_param != NULL) {
+		unsigned threshold = (unsigned)atoi(snapshot_threshold_param);
 		rv = dqlite_node_set_snapshot_params(s->dqlite, threshold, threshold);
 		munit_assert_int(rv, ==, 0);
+	}
+
+	const char *disk_mode_param = munit_parameters_get(params, "disk_mode");
+	if (disk_mode_param != NULL) {
+		bool disk_mode = (bool)atoi(disk_mode_param);
+		if (disk_mode) {
+			rv = dqlite_node_enable_disk_mode(s->dqlite);
+			munit_assert_int(rv, ==, 0);
+		}
 	}
 
 	rv = dqlite_node_start(s->dqlite);

--- a/test/lib/sqlite.c
+++ b/test/lib/sqlite.c
@@ -5,7 +5,7 @@
 void test_sqlite_setup(const MunitParameter params[]) {
 	int rc;
 	(void)params;
-	rc = sqlite3_shutdown();
+	rc = sqlite3_initialize();
 	if (rc != SQLITE_OK) {
 		munit_errorf("sqlite_init(): %s", sqlite3_errstr(rc));
 	}


### PR DESCRIPTION
~WIP - don't review~

- Have tried to run all existing tests with the new disk vfs. Most failures come from the fsm snapshot functionality not being in place for the on-disk case.
- Not yet 100% sure about the abstraction, I feel like a user should be able to choose the VFS per database, but currently I just put the whole of dqlite in disk-mode, i.e. every database will be stored on disk. If the snapshotting behaviour is different for in-memory/on-disk, different VFS's for different databases could lead to complex snapshotting behaviour in raft, where we have to mix different methods to snapshot. Would like to avoid that.
- SYNCs are still turned off, the real transaction is the raft log being stored to disk, the database writes to disk from SQLite don't have to be synced I think.
- Still needs a bunch of cleanup.
