### PR TITLE
Handle unrecognized values for a couple of fields

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -1028,6 +1028,9 @@ static int encodeServer(struct gateway *g,
 	uint64_t role;
 	text_t address;
 
+	assert(format == DQLITE_REQUEST_CLUSTER_FORMAT_V0 ||
+	       format == DQLITE_REQUEST_CLUSTER_FORMAT_V1);
+
 	id = g->raft->configuration.servers[i].id;
 	address = g->raft->configuration.servers[i].address;
 	role =
@@ -1067,6 +1070,13 @@ static int handle_cluster(struct handle *req)
 	void *cur;
 	int rv;
 	START(cluster, servers);
+
+	if (request.format != DQLITE_REQUEST_CLUSTER_FORMAT_V0 &&
+	    request.format != DQLITE_REQUEST_CLUSTER_FORMAT_V1) {
+		tracef("bad cluster format");
+		failure(req, DQLITE_PARSE, "unrecognized cluster format");
+		return 0;
+	}
 
 	response.n = g->raft->configuration.n;
 	cur = buffer__advance(req->buffer, response_servers__sizeof(&response));

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -1210,6 +1210,10 @@ handle:
 		rc = handle_##LOWER(req); \
 		break;
 		REQUEST__TYPES(DISPATCH);
+	default:
+		tracef("unrecognized request type %d", type);
+		failure(req, DQLITE_PARSE, "unrecognized request type");
+		rc = 0;
 	}
 
 	return rc;

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -1921,3 +1921,43 @@ TEST_CASE(request_cluster, unrecognizedFormat, NULL)
 	ASSERT_FAILURE(DQLITE_PARSE, "unrecognized cluster format");
 	return MUNIT_OK;
 }
+
+/******************************************************************************
+ *
+ * invalid
+ *
+ ******************************************************************************/
+
+struct invalid_fixture
+{
+	FIXTURE;
+	struct request_leader request;
+	struct response_server response;
+};
+
+TEST_SUITE(invalid);
+TEST_SETUP(invalid)
+{
+	struct invalid_fixture *f = munit_malloc(sizeof *f);
+	SETUP;
+	CLUSTER_ELECT(0);
+	return f;
+}
+TEST_TEAR_DOWN(invalid)
+{
+	struct invalid_fixture *f = data;
+	TEAR_DOWN;
+	free(f);
+}
+
+/* Submit a request with an unrecognized type. */
+TEST_CASE(invalid, requestType, NULL)
+{
+	struct invalid_fixture *f = data;
+	(void)params;
+	ENCODE(&f->request, leader);
+	HANDLE_STATUS(123, 0);
+	ASSERT_CALLBACK(0, FAILURE);
+	ASSERT_FAILURE(DQLITE_PARSE, "unrecognized request type");
+	return MUNIT_OK;
+}


### PR DESCRIPTION
This PR updates gateway.c to return a failure response in some cases when it sees a value for a version/type field that it doesn't recognize. The fields currently addressed are the request type (see [here](https://github.com/canonical/dqlite/issues/377#issuecomment-1255176012)) and the "format" field of the cluster request (see [here](https://github.com/canonical/dqlite/issues/400#issuecomment-1249472387)). I'd love to address this TODO as well:

https://github.com/canonical/dqlite/blob/607de645ca4ae282ac9267e220f91b6afc56e0f7/src/conn.c#L240-L247

But changing the handshake like that is a bigger deal and requires coordinating with go-dqlite, so I've left it alone for now.