### PR TITLE
Proof-of-concept for instrumentation with bpftrace

### DIFF
--- a/bt/request
+++ b/bt/request
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -o errexit
+
+libraft_path="${LIBRAFT_SO_PATH:-/usr/local/lib/libraft.so.2}"
+exec bpftrace -I resources -I include $@ - <<EOF
+#include <raft.h>
+
+struct request
+{
+    void *data;
+    int type;
+    raft_index index;
+    void *queue[2];
+};
+
+uprobe:$libraft_path:lifecycleRequestStart
+{
+	\$req = (struct request *)arg1;
+	@start_request[\$req->data, \$req->type, \$req->index] = nsecs;
+}
+
+uprobe:$libraft_path:lifecycleRequestEnd
+{
+	\$req = (struct request *)arg1;
+	\$start = @start_request[\$req->data, \$req->type, \$req->index];
+	\$end = nsecs;
+	@full[\$req->data, \$req->type, \$req->index] = (\$start, \$end);
+	\$elapsed_msecs = (\$end - \$start) / 1000;
+	@hist = lhist(\$elapsed_msecs, 100, 1000, 10);
+	delete(@start_request[\$req->data, \$req->type, \$req->index]);
+}
+EOF

--- a/resources/stdbool.h
+++ b/resources/stdbool.h
@@ -1,0 +1,34 @@
+/*===---- stdbool.h - Standard header for booleans -------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __STDBOOL_H
+#define __STDBOOL_H
+
+#define __bool_true_false_are_defined 1
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ > 201710L
+/* FIXME: We should be issuing a deprecation warning here, but cannot yet due
+ * to system headers which include this header file unconditionally.
+ */
+#elif !defined(__cplusplus)
+#define bool _Bool
+#define true 1
+#define false 0
+#elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
+/* Define _Bool as a GNU extension. */
+#define _Bool bool
+#if defined(__cplusplus) && __cplusplus < 201103L
+/* For C++98, define bool, false, true as a GNU extension. */
+#define bool bool
+#define false false
+#define true true
+#endif
+#endif
+
+#endif /* __STDBOOL_H */


### PR DESCRIPTION
This adds a single, simple script that can be used to run bpftrace against a dqlite app and record a histogram of the time spent by each raft request between enqueueing and dequeueing. Example usage:

```sh
$ make integration-test
$ sudo bt/request -I ../raft/include -c ./integration-test
```

Notes:

- Ubuntu Jammy currently packages bpftrace 0.14.0, which is unable to find some system headers on its own (this is fixed in 0.15.0); so you may have to add `-I /usr/include/x86_64-linux-gnu` to that invocation
- bpftrace knows about some libc headers, but not yet stdbool.h, so we vendor that ourselves for the moment
- raft and dqlite need to be built with debug info (`--enable-debug`)
- The environment variable `LIBRAFT_SO_PATH` is supported to point bpftrace in the right direction in case libraft.so is installed somewhere other than /usr/local/lib (a similar customization point will be needed for libdqlite.so in scripts that probe dqlite function calls)

Signed-off-by: Cole Miller <cole.miller@canonical.com>