### PR TITLE
Issue 416/null deref

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -438,7 +438,9 @@ static int handle_exec(struct handle *req)
 	g->stmt = stmt->stmt;
 	rv = leader__exec(g->leader, &g->exec, stmt->stmt, leader_exec_cb);
 	if (rv != 0) {
-                tracef("handle exec leader exec failed %d", rv);
+		tracef("handle exec leader exec failed %d", rv);
+		g->stmt = NULL;
+		g->req = NULL;
 		return rv;
 	}
 	return 0;

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -730,7 +730,6 @@ static int handle_exec_sql(struct handle *req)
 	g->sql = request.sql;
 	rc = leader__barrier(g->leader, &g->barrier, execSqlBarrierCb);
 	if (rc != 0) {
-		g->req = NULL;
 		tracef("handle exec sql barrier failed %d", rc);
 		g->req = NULL;
 		g->sql = NULL;

--- a/src/leader.c
+++ b/src/leader.c
@@ -402,6 +402,8 @@ int leader__exec(struct leader *l,
 
 	rv = leader__barrier(l, &req->barrier, execBarrierCb);
 	if (rv != 0) {
+		l->exec->status = rv;
+		leaderExecDone(l->exec);
 		return rv;
 	}
 	return 0;

--- a/test/lib/util.h
+++ b/test/lib/util.h
@@ -1,0 +1,27 @@
+/**
+ * Utility macros and functions.
+ */
+
+#ifndef TEST_UTIL_H
+#define TEST_UTIL_H
+
+#include "munit.h"
+
+#include <time.h>
+
+/* Wait a bounded time in seconds until a condition is true. */
+#define AWAIT_TRUE(FN, ARG, SEC)                                           \
+	do {                                                               \
+		struct timespec _start = {0};                              \
+		struct timespec _end = {0};                                \
+		clock_gettime(CLOCK_MONOTONIC, &_start);                   \
+		clock_gettime(CLOCK_MONOTONIC, &_end);                     \
+		while(!FN(ARG) && ((_end.tv_sec - _start.tv_sec) < SEC)) { \
+			clock_gettime(CLOCK_MONOTONIC, &_end);             \
+		}                                                          \
+		if (!FN(ARG)) {                                            \
+			return MUNIT_FAIL;                                 \
+		}                                                          \
+	} while(0)
+
+#endif /* TEST_UTIL_H */


### PR DESCRIPTION
Fixes #416.

The test hits the same segfault as in the issue, the `leader->exec` was not cleaned up in case `leader__barrier` failed leading to inconsistent state.