### PR TITLE
leader: Avoid firing failure twice.

### DIFF
--- a/src/leader.c
+++ b/src/leader.c
@@ -402,8 +402,7 @@ int leader__exec(struct leader *l,
 
 	rv = leader__barrier(l, &req->barrier, execBarrierCb);
 	if (rv != 0) {
-		l->exec->status = rv;
-		leaderExecDone(l->exec);
+		l->exec = NULL;
 		return rv;
 	}
 	return 0;


### PR DESCRIPTION
DRAFT - running CI

failure was called on the request twice, once in leaderExecDone and once as a result of a failed call to leader__exec.

This would then lead to an assertion in write_cb "t->write_cb == NULL"

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>