### PR TITLE
Support printing backtrace when an assertion fails

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,10 @@ endif
 if SANITIZE_ENABLED
   AM_CFLAGS += -fsanitize=address
 endif
+if BACKTRACE_ENABLED
+  AM_CFLAGS += -DDQLITE_ASSERT_WITH_BACKTRACE
+  AM_LDFLAGS += -lbacktrace
+endif
 
 if CODE_COVERAGE_ENABLED
 

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,9 @@ AM_COND_IF(SANITIZE_ENABLED,
    [true],
    [AC_MSG_ERROR([address sanitizer not supported])]))
 
+AC_ARG_ENABLE(backtrace, AS_HELP_STRING([--enable-backtrace[=ARG]], [print backtrace on assertion failure [default=no]]))
+AM_CONDITIONAL(BACKTRACE_ENABLED, test "x$enable_backtrace" = "xyes")
+
 # Whether to enable code coverage.
 AX_CODE_COVERAGE
 

--- a/src/lib/assert.h
+++ b/src/lib/assert.h
@@ -8,6 +8,20 @@
 #if defined(DQLITE_TEST)
   #include "../../test/lib/munit.h"
   #define assert(expr) munit_assert(expr)
+#elif defined(DQLITE_ASSERT_WITH_BACKTRACE)
+  #include <assert.h> /* for __assert_fail */
+  #include <backtrace.h>
+  #include <stdio.h>
+  #undef assert
+  #define assert(x)                                                             \
+	  do {                                                                  \
+		  struct backtrace_state *state_;                               \
+		  if (!(x)) {                                                   \
+			  state_ = backtrace_create_state(NULL, 0, NULL, NULL); \
+			  backtrace_print(state_, 0, stderr);                   \
+			  __assert_fail(#x, __FILE__, __LINE__, __func__);      \
+		  }                                                             \
+	  } while (0)
 #else
   #include <assert.h>
 #endif


### PR DESCRIPTION
Ditto canonical/raft#330

Signed-off-by: Cole Miller <cole.miller@canonical.com>