### PR TITLE
Support building sqlite3 from amalgamation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,11 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_CFLAGS += $(CODE_COVERAGE_CFLAGS)
 AM_CFLAGS += $(SQLITE_CFLAGS) $(UV_CFLAGS) $(RAFT_CFLAGS) $(PTHREAD_CFLAGS)
-AM_LDFLAGS = $(SQLITE_LIBS) $(UV_LIBS) $(RAFT_LIBS) $(PTHREAD_LIBS)
+AM_LDFLAGS = $(UV_LIBS) $(RAFT_LIBS) $(PTHREAD_LIBS)
+
+if !BUILD_SQLITE_ENABLED
+AM_LDFLAGS += $(SQLITE_LIBS)
+endif
 
 include_HEADERS = include/dqlite.h
 
@@ -38,6 +42,10 @@ libdqlite_la_SOURCES = \
   src/translate.c \
   src/tuple.c \
   src/vfs.c
+
+if BUILD_SQLITE_ENABLED
+libdqlite_la_SOURCES += sqlite3.c
+endif
 
 check_PROGRAMS = \
   unit-test \

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,8 @@ AM_COND_IF(SANITIZE_ENABLED,
 
 AC_ARG_ENABLE(backtrace, AS_HELP_STRING([--enable-backtrace[=ARG]], [print backtrace on assertion failure [default=no]]))
 AM_CONDITIONAL(BACKTRACE_ENABLED, test "x$enable_backtrace" = "xyes")
+AC_ARG_ENABLE(build-sqlite, AS_HELP_STRING([--enable-build-sqlite[=ARG]], [build libsqlite3 from sqlite3.c in the build root [default=no]]))
+AM_CONDITIONAL(BUILD_SQLITE_ENABLED, test "x$enable_build_sqlite" = "xyes")
 
 # Whether to enable code coverage.
 AX_CODE_COVERAGE


### PR DESCRIPTION
This adds a `--enable-build-sqlite` option to our configure.ac. In this mode, the build will look for sqlite3.c in the build root and just add that to libdqlite_la_SOURCES, instead of linking with `-lsqlite3`.

The build system doesn't take care of fetching the SQLite amalgamation -- the idea is to obtain an SQLite source archive/checkout and do `make sqlite3.c`, or download the amalgamation from sqlite.org. It's important to use a version of the amalgamation that matches the version of sqlite.h that's on your include path.

Our build turns on a bunch of warnings that fire on the SQLite source code; I had to modify the amalgamation by adding

```
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wsign-conversion"
#pragma GCC diagnostic ignored "-Wconversion"
#pragma GCC diagnostic ignored "-Wfloat-equal"
#pragma GCC diagnostic ignored "-Wfloat-conversion"
#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
```

at the top and

```
#pragma GCC diagnostic pop
```

at the bottom.

The point is to be able to easily add printfs in SQLite code, turn on SQLITE_DEBUG, etc., to support debugging issues like #432 that arise from the interaction between SQLite and our VFS.

Signed-off-by: Cole Miller <cole.miller@canonical.com>