### PR TITLE
vfs: Fix the short read check in vfsWalRead

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -837,10 +837,6 @@ static int vfsWalRead(struct vfsWal *w,
 	unsigned index;
 	struct vfsFrame *frame;
 
-	if (w->n_frames == 0) {
-		return SQLITE_IOERR_SHORT_READ;
-	}
-
 	if (offset == 0) {
 		/* Read the header. */
 		assert(amount == VFS__WAL_HEADER_SIZE);
@@ -887,6 +883,11 @@ static int vfsWalRead(struct vfsWal *w,
 	}
 
 	frame = vfsWalFrameLookup(w, index);
+	if (frame == NULL) {
+		// Again, the requested page doesn't exist.
+		memset(buf, 0, (size_t)amount);
+		return SQLITE_IOERR_SHORT_READ;
+	}
 
 	if (amount == FORMAT__WAL_FRAME_HDR_SIZE) {
 		memcpy(buf, frame->header, (size_t)amount);


### PR DESCRIPTION
### Problem

When trying to read a page from the WAL, we bail early with an error if there are no committed pages in `struct vfsWal`. But sometimes a transaction will want to read its own WAL frames that haven't been committed yet, and this check will prevent that if the transaction starts out with an empty WAL (because it's running right after a checkpoint, for example).

### Solution

Remove the separate check for `w->n_frame == 0` and just see whether `vfsWalFrameLookup` returns `NULL`, indicating that there's no frame at the given index. `vfsWalFrameLookup` can retrieve frames from either `w->frames` or `w->tx`.

Closes #432 

Signed-off-by: Cole Miller <cole.miller@canonical.com>