### PR TITLE
vfs: fix include on musl

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/time.h>


### PR DESCRIPTION
On musl, this fails to compile due to -Werror=cpp:

```
  CC       src/vfs.lo
In file included from src/vfs.c:6:
/usr/include/sys/fcntl.h:1:2: error: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Werror=cpp]
    1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
      |  ^~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:1314: src/vfs.lo] Error 1
```

Signed-off-by: Cameron Nemo <cam@nohom.org>
