### PR TITLE
vfs: Correct include path for fcntl.h

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/time.h>


### PR DESCRIPTION
See #451

Signed-off-by: Cole Miller <cole.miller@canonical.com>