### PR TITLE
gateway: Assign IDs to exec and config requests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ libdqlite_la_SOURCES = \
   src/format.c \
   src/fsm.c \
   src/gateway.c \
+  src/id.c \
   src/leader.c \
   src/lib/addr.c \
   src/lib/buffer.c \

--- a/src/conn.c
+++ b/src/conn.c
@@ -283,6 +283,7 @@ int conn__start(struct conn *c,
 		struct raft *raft,
 		struct uv_stream_s *stream,
 		struct raft_uv_transport *uv_transport,
+		struct id_state seed,
 		conn_close_cb close_cb)
 {
 	int rv;
@@ -297,7 +298,7 @@ int conn__start(struct conn *c,
 	c->transport.data = c;
 	c->uv_transport = uv_transport;
 	c->close_cb = close_cb;
-	gateway__init(&c->gateway, config, registry, raft);
+	gateway__init(&c->gateway, config, registry, raft, seed);
 	rv = buffer__init(&c->read);
 	if (rv != 0) {
 		goto err_after_transport_init;

--- a/src/conn.h
+++ b/src/conn.h
@@ -12,6 +12,7 @@
 #include "lib/transport.h"
 
 #include "gateway.h"
+#include "id.h"
 #include "message.h"
 
 /**
@@ -50,6 +51,7 @@ int conn__start(struct conn *c,
 		struct raft *raft,
 		struct uv_stream_s *stream,
 		struct raft_uv_transport *uv_transport,
+		struct id_state seed,
 		conn_close_cb close_cb);
 
 /**

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -13,6 +13,7 @@
 #include "lib/serialize.h"
 
 #include "config.h"
+#include "id.h"
 #include "leader.h"
 #include "registry.h"
 #include "stmt.h"
@@ -25,25 +26,27 @@ struct handle;
  */
 struct gateway
 {
-	struct config *config;       /* Configuration */
-	struct registry *registry;   /* Register of existing databases */
-	struct raft *raft;           /* Raft instance */
-	struct leader *leader;       /* Leader connection to the database */
-	struct handle *req;          /* Asynchronous request being handled */
-	sqlite3_stmt *stmt;          /* Statement being processed */
-	bool stmt_finalize;          /* Whether to finalize the statement */
-	struct exec exec;            /* Low-level exec async request */
+	struct config *config;        /* Configuration */
+	struct registry *registry;    /* Register of existing databases */
+	struct raft *raft;            /* Raft instance */
+	struct leader *leader;        /* Leader connection to the database */
+	struct handle *req;           /* Asynchronous request being handled */
+	sqlite3_stmt *stmt;           /* Statement being processed */
+	bool stmt_finalize;           /* Whether to finalize the statement */
+	struct exec exec;             /* Low-level exec async request */
 	/* FIXME store this in the req */
-	const char *sql;             /* SQL query for exec_sql requests */
-	struct stmt__registry stmts; /* Registry of prepared statements */
-	struct barrier barrier;      /* Barrier for query requests */
-	uint64_t protocol;           /* Protocol format version */
+	const char *sql;              /* SQL query for exec_sql requests */
+	struct stmt__registry stmts;  /* Registry of prepared statements */
+	struct barrier barrier;       /* Barrier for query requests */
+	uint64_t protocol;            /* Protocol format version */
+	struct id_state random_state; /* For generating IDs */
 };
 
 void gateway__init(struct gateway *g,
 		   struct config *config,
 		   struct registry *registry,
-		   struct raft *raft);
+		   struct raft *raft,
+		   struct id_state seed);
 
 void gateway__close(struct gateway *g);
 

--- a/src/id.c
+++ b/src/id.c
@@ -1,0 +1,73 @@
+#include "id.h"
+
+#include <string.h>
+
+/* The PRNG used for generating request IDs is xoshiro256**, developed by
+ * David Blackman and Sebastiano Vigna and released into the public domain.
+ * See <https://xoshiro.di.unimi.it/xoshiro256starstar.c>. */
+
+static uint64_t rotl(uint64_t x, int k) {
+	return (x << k) | (x >> (64 - k));
+}
+
+uint64_t idNext(struct id_state *state)
+{
+	uint64_t result = rotl(state->data[1] * 5, 7) * 9;
+	uint64_t t = state->data[1] << 17;
+
+	state->data[2] ^= state->data[0];
+	state->data[3] ^= state->data[1];
+	state->data[1] ^= state->data[2];
+	state->data[0] ^= state->data[3];
+
+	state->data[2] ^= t;
+
+	state->data[3] = rotl(state->data[3], 45);
+
+	return result;
+}
+
+void idJump(struct id_state *state)
+{
+	static const uint64_t JUMP[] = {
+		0x180ec6d33cfd0aba,
+		0xd5a61266f0c9392c,
+		0xa9582618e03fc9aa,
+		0x39abdc4529b1661c
+	};
+
+	uint64_t s0 = 0;
+	uint64_t s1 = 0;
+	uint64_t s2 = 0;
+	uint64_t s3 = 0;
+	for (size_t i = 0; i < sizeof(JUMP)/sizeof(*JUMP); i++) {
+		for (size_t b = 0; b < 64; b++) {
+			if (JUMP[i] & UINT64_C(1) << b) {
+				s0 ^= state->data[0];
+				s1 ^= state->data[1];
+				s2 ^= state->data[2];
+				s3 ^= state->data[3];
+			}
+			idNext(state);	
+		}
+	}
+
+	state->data[0] = s0;
+	state->data[1] = s1;
+	state->data[2] = s2;
+	state->data[3] = s3;
+}
+
+uint64_t idExtract(const uint8_t buf[16])
+{
+	uint64_t id;
+	memcpy(&id, buf, sizeof(id));
+	return id;
+}
+
+void idSet(uint8_t buf[16], uint64_t id)
+{
+	memset(buf, 0, 16);
+	memcpy(buf, &id, sizeof(id));
+	buf[15] = (uint8_t)-1;
+}

--- a/src/id.h
+++ b/src/id.h
@@ -1,0 +1,46 @@
+/**
+ * Generate, set, and extract dqlite-generated request IDs.
+ *
+ * A fresh ID is generated for each config or exec client request that
+ * arrives at a gateway. These IDs are passed down into raft via the
+ * req_id field of RAFT__REQUEST, and are suitable for diagnostic use
+ * only.
+ */
+
+#ifndef DQLITE_ID_H_
+#define DQLITE_ID_H_
+
+#include <stdint.h>
+
+/**
+ * State used to generate a request ID.
+ */
+struct id_state
+{
+	uint64_t data[4];
+};
+
+/**
+ * Generate a request ID, mutating the input state in the process.
+ */
+uint64_t idNext(struct id_state *state);
+
+/**
+ * Cause the given state to yield a different sequence of IDs.
+ *
+ * This is used to ensure that the sequences of IDs generated for
+ * distinct clients are (in practice) disjoint.
+ */
+void idJump(struct id_state *state);
+
+/**
+ * Read a request ID from the req_id field of RAFT__REQUEST.
+ */
+uint64_t idExtract(const uint8_t buf[16]);
+
+/**
+ * Write a request ID to the req_id field of RAFT__REQUEST.
+ */
+void idSet(uint8_t buf[16], uint64_t id);
+
+#endif /* DQLITE_ID_H_ */

--- a/src/leader.h
+++ b/src/leader.h
@@ -64,6 +64,7 @@ struct exec
 	struct leader *leader;
 	struct barrier barrier;
 	sqlite3_stmt *stmt;
+	uint64_t id;
 	int status;
 	queue queue;
 	exec_cb cb;
@@ -98,6 +99,7 @@ void leader__close(struct leader *l);
 int leader__exec(struct leader *l,
 		 struct exec *req,
 		 sqlite3_stmt *stmt,
+		 uint64_t id,
 		 exec_cb cb);
 
 /**

--- a/src/server.h
+++ b/src/server.h
@@ -9,6 +9,7 @@
 #endif
 
 #include "config.h"
+#include "id.h"
 #include "lib/assert.h"
 #include "logger.h"
 #include "registry.h"
@@ -31,11 +32,11 @@ struct dqlite_node
 	struct raft_io raft_io;                  /* libuv I/O */
 	struct raft_fsm raft_fsm;                /* dqlite FSM */
 #ifdef __APPLE__
-	dispatch_semaphore_t ready;                 /* Server is ready */
-	dispatch_semaphore_t stopped;               /* Notifiy loop stopped */
+	dispatch_semaphore_t ready;              /* Server is ready */
+	dispatch_semaphore_t stopped;            /* Notifiy loop stopped */
 #else
-	sem_t ready;                                /* Server is ready */
-	sem_t stopped;                              /* Notifiy loop stopped */
+	sem_t ready;                             /* Server is ready */
+	sem_t stopped;                           /* Notifiy loop stopped */
 #endif
 	queue queue;                             /* Incoming connections */
 	queue conns;                             /* Active connections */
@@ -48,6 +49,7 @@ struct dqlite_node
 	int raft_state;                          /* Previous raft state */
 	char *bind_address;                      /* Listen address */
 	char errmsg[DQLITE_ERRMSG_BUF_SIZE];     /* Last error occurred */
+	struct id_state random_state;            /* For seeding ID generation */
 };
 
 int dqlite__init(struct dqlite_node *d,

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -47,8 +47,10 @@ struct connection
 		struct connection *c = &f->connections[i];           \
 		struct request_open open;                            \
 		struct response_db db;                               \
+		struct id_state seed = {{1}};                        \
 		gateway__init(&c->gateway, CLUSTER_CONFIG(0),        \
-			      CLUSTER_REGISTRY(0), CLUSTER_RAFT(0)); \
+			      CLUSTER_REGISTRY(0), CLUSTER_RAFT(0),  \
+		              seed);                                 \
 		c->handle.data = &c->context;                        \
 		rc = buffer__init(&c->request);                      \
 		munit_assert_int(rc, ==, 0);                         \

--- a/test/unit/test_conn.c
+++ b/test/unit/test_conn.c
@@ -43,25 +43,27 @@ static void connCloseCb(struct conn *conn)
 	struct conn conn;    \
 	bool closed;
 
-#define SETUP                                                                \
-	struct uv_stream_s *stream;                                          \
-	int rv;                                                              \
-	SETUP_HEAP;                                                          \
-	SETUP_SQLITE;                                                        \
-	SETUP_LOGGER;                                                        \
-	SETUP_VFS;                                                           \
-	SETUP_CONFIG;                                                        \
-	SETUP_REGISTRY;                                                      \
-	SETUP_RAFT;                                                          \
-	SETUP_CLIENT;                                                        \
-	RAFT_BOOTSTRAP;                                                      \
-	RAFT_START;                                                          \
-	rv = transport__stream(&f->loop, f->server, &stream);                \
-	munit_assert_int(rv, ==, 0);                                         \
-	f->closed = false;                                                   \
-	f->conn.queue[0] = &f->closed;                                       \
-	rv = conn__start(&f->conn, &f->config, &f->loop, &f->registry,       \
-			 &f->raft, stream, &f->raft_transport, connCloseCb); \
+#define SETUP                                                          \
+	struct uv_stream_s *stream;                                    \
+	struct id_state seed = {{1}};                                  \
+	int rv;                                                        \
+	SETUP_HEAP;                                                    \
+	SETUP_SQLITE;                                                  \
+	SETUP_LOGGER;                                                  \
+	SETUP_VFS;                                                     \
+	SETUP_CONFIG;                                                  \
+	SETUP_REGISTRY;                                                \
+	SETUP_RAFT;                                                    \
+	SETUP_CLIENT;                                                  \
+	RAFT_BOOTSTRAP;                                                \
+	RAFT_START;                                                    \
+	rv = transport__stream(&f->loop, f->server, &stream);          \
+	munit_assert_int(rv, ==, 0);                                   \
+	f->closed = false;                                             \
+	f->conn.queue[0] = &f->closed;                                 \
+	rv = conn__start(&f->conn, &f->config, &f->loop, &f->registry, \
+			 &f->raft, stream, &f->raft_transport,         \
+			 seed, connCloseCb);                           \
 	munit_assert_int(rv, ==, 0)
 
 #define TEAR_DOWN                         \

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -52,10 +52,11 @@ struct connection
 	for (i = 0; i < N_SERVERS; i++) {                               \
 		struct connection *c = &f->connections[i];              \
 		struct config *config;                                  \
+		struct id_state seed = {{1}};                           \
 		config = CLUSTER_CONFIG(i);                             \
 		config->page_size = 512;                                \
 		gateway__init(&c->gateway, config, CLUSTER_REGISTRY(i), \
-			      CLUSTER_RAFT(i));                         \
+			      CLUSTER_RAFT(i), seed);                   \
 		c->handle.data = &c->context;                           \
 		rc = buffer__init(&c->buf1);                            \
 		munit_assert_int(rc, ==, 0);                            \

--- a/test/unit/test_replication.c
+++ b/test/unit/test_replication.c
@@ -90,6 +90,7 @@ TEST_MODULE(replication_v1);
 	{                                                       \
 		int rc2;                                        \
 		rc2 = leader__exec(LEADER(I), &f->req, f->stmt, \
+				   0,                           \
 				   fixture_exec_cb);            \
 		munit_assert_int(rc2, ==, 0);                   \
 	}
@@ -356,7 +357,7 @@ TEST(replication, exec, setUp, tearDown, 0, NULL)
 	CLUSTER_ELECT(0);
 
 	PREPARE(0, "BEGIN");
-	rv = leader__exec(LEADER(0), &f->req, f->stmt, execCb);
+	rv = leader__exec(LEADER(0), &f->req, f->stmt, 0, execCb);
 	CLUSTER_APPLIED(3);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_true(f->invoked);
@@ -365,7 +366,7 @@ TEST(replication, exec, setUp, tearDown, 0, NULL)
 	FINALIZE;
 
 	PREPARE(0, "CREATE TABLE test (a  INT)");
-	rv = leader__exec(LEADER(0), &f->req, f->stmt, execCb);
+	rv = leader__exec(LEADER(0), &f->req, f->stmt, 0, execCb);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_true(f->invoked);
 	munit_assert_int(f->status, ==, SQLITE_DONE);
@@ -373,7 +374,7 @@ TEST(replication, exec, setUp, tearDown, 0, NULL)
 	FINALIZE;
 
 	PREPARE(0, "COMMIT");
-	rv = leader__exec(LEADER(0), &f->req, f->stmt, execCb);
+	rv = leader__exec(LEADER(0), &f->req, f->stmt, 0, execCb);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_false(f->invoked);
 	FINALIZE;
@@ -406,14 +407,14 @@ TEST(replication, checkpoint, setUp, tearDown, 0, NULL)
 	CLUSTER_ELECT(0);
 
 	PREPARE(0, "CREATE TABLE test (n  INT)");
-	rv = leader__exec(LEADER(0), &f->req, f->stmt, execCb);
+	rv = leader__exec(LEADER(0), &f->req, f->stmt, 0, execCb);
 	munit_assert_int(rv, ==, 0);
 	CLUSTER_APPLIED(4);
 	FINALIZE;
 
 
 	PREPARE(0, "INSERT INTO test(n) VALUES(1)");
-	rv = leader__exec(LEADER(0), &f->req, f->stmt, execCb);
+	rv = leader__exec(LEADER(0), &f->req, f->stmt, 0, execCb);
 	munit_assert_int(rv, ==, 0);
 	CLUSTER_APPLIED(6);
 	FINALIZE;


### PR DESCRIPTION
Just a first pass at assigning request IDs in the dqlite layer that can be used in tracing. We only use the first 8 bytes of the new 16-byte req_id field from RAFT__REQUEST, and set the last byte of that field to -1 to indicate that the ID is set.

Signed-off-by: Cole Miller <cole.miller@canonical.com>