### PR TITLE
Refactor gateway.c

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -26,7 +26,6 @@ void gateway__init(struct gateway *g,
 	g->stmt = NULL;
 	g->stmt_finalize = false;
 	g->exec.data = g;
-	g->sql = NULL;
 	stmt__registry_init(&g->stmts);
 	g->barrier.data = g;
 	g->barrier.cb = NULL;
@@ -1354,6 +1353,7 @@ handle:
 	req->buffer = buffer;
 	req->db_id = 0;
 	req->stmt_id = 0;
+	req->sql = NULL;
 
 	switch (type) {
 #define DISPATCH(LOWER, UPPER, _)                 \

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -34,8 +34,6 @@ struct gateway
 	sqlite3_stmt *stmt;           /* Statement being processed */
 	bool stmt_finalize;           /* Whether to finalize the statement */
 	struct exec exec;             /* Low-level exec async request */
-	/* FIXME store this in the req */
-	const char *sql;              /* SQL query for exec_sql requests */
 	struct stmt__registry stmts;  /* Registry of prepared statements */
 	struct barrier barrier;       /* Barrier for query requests */
 	uint64_t protocol;            /* Protocol format version */

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -71,6 +71,7 @@ struct handle
 	size_t db_id;            /* For use by prepare callback */
 	size_t stmt_id;          /* For use by prepare callback */
 	const char *sql;
+	unsigned exec_count;
 	handle_cb cb;
 };
 

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -73,6 +73,7 @@ struct handle
 	struct cursor cursor;
 	size_t db_id;            /* For use by prepare callback */
 	size_t stmt_id;          /* For use by prepare callback */
+	const char *sql;
 	handle_cb cb;
 };
 

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -66,7 +66,6 @@ struct handle
 	void *data;              /* User data */
 	int type;                /* Request type */
 	int schema;              /* Request schema version */
-	struct gateway *gateway;
 	struct buffer *buffer;
 	struct cursor cursor;
 	size_t db_id;            /* For use by prepare callback */

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -31,8 +31,6 @@ struct gateway
 	struct raft *raft;            /* Raft instance */
 	struct leader *leader;        /* Leader connection to the database */
 	struct handle *req;           /* Asynchronous request being handled */
-	sqlite3_stmt *stmt;           /* Statement being processed */
-	bool stmt_finalize;           /* Whether to finalize the statement */
 	struct exec exec;             /* Low-level exec async request */
 	struct stmt__registry stmts;  /* Registry of prepared statements */
 	struct barrier barrier;       /* Barrier for query requests */
@@ -71,6 +69,7 @@ struct handle
 	size_t db_id;            /* For use by prepare callback */
 	size_t stmt_id;          /* For use by prepare callback */
 	const char *sql;
+	sqlite3_stmt *stmt;
 	unsigned exec_count;
 	handle_cb cb;
 };


### PR DESCRIPTION
This PR refactors gateway.c to store several pieces of request-scoped data in the request handle object instead of the gateway itself. In the process, I fixed (?) how we handle parameters to multi-statement EXEC_SQL requests.