### PR TITLE
server: Expose uv block_size setting.

### DIFF
--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -200,6 +200,14 @@ int dqlite_node_set_snapshot_params(dqlite_node *n,
 				    unsigned snapshot_trailing);
 
 /**
+ * Set the block size used for performing disk IO when writing raft log segments
+ * to disk. @size is limited to a list of preset values.
+ *
+ * This function must be called before calling dqlite_node_start().
+ */
+int dqlite_node_set_block_size(dqlite_node *n, size_t size);
+
+/**
  * WARNING: This is an experimental API.
  *
  * By default dqlite holds the SQLite database file and WAL in memory. By

--- a/src/server.c
+++ b/src/server.c
@@ -367,6 +367,32 @@ int dqlite_node_set_snapshot_params(dqlite_node *n,
 	return 0;
 }
 
+#define KB(N) (1024 * N)
+int dqlite_node_set_block_size(dqlite_node *n, size_t size)
+{
+	if (n->running) {
+		return DQLITE_MISUSE;
+	}
+
+	switch (size) {
+		case 512:      // fallthrough
+		case KB(1):    // fallthrough
+		case KB(2):    // fallthrough
+		case KB(4):    // fallthrough
+		case KB(8):    // fallthrough
+		case KB(16):   // fallthrough
+		case KB(32):   // fallthrough
+		case KB(64):   // fallthrough
+		case KB(128):  // fallthrough
+		case KB(256):
+			break;
+		default:
+			return DQLITE_ERROR;
+	}
+
+	raft_uv_set_block_size(&n->raft_io, size);
+	return 0;
+}
 int dqlite_node_enable_disk_mode(dqlite_node *n)
 {
 	int rv;

--- a/test/integration/test_node.c
+++ b/test/integration/test_node.c
@@ -316,6 +316,43 @@ TEST(node, networkLatencyMsTooLarge, setUp, tearDown, 0, node_params)
 	return MUNIT_OK;
 }
 
+TEST(node, blockSize, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	int rv;
+
+	rv = dqlite_node_set_block_size(f->node, 0);
+	munit_assert_int(rv, ==, DQLITE_ERROR);
+	rv = dqlite_node_set_block_size(f->node, 1);
+	munit_assert_int(rv, ==, DQLITE_ERROR);
+	rv = dqlite_node_set_block_size(f->node, 511);
+	munit_assert_int(rv, ==, DQLITE_ERROR);
+	rv = dqlite_node_set_block_size(f->node, 1024 * 512);
+	munit_assert_int(rv, ==, DQLITE_ERROR);
+	rv = dqlite_node_set_block_size(f->node, 64 * 1024);
+	munit_assert_int(rv, ==, 0);
+
+	startStopNode(f);
+	return MUNIT_OK;
+}
+
+TEST(node, blockSizeRunning, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	int rv;
+
+	rv = dqlite_node_start(f->node);
+	munit_assert_int(rv, ==, 0);
+
+	rv = dqlite_node_set_block_size(f->node, 64 * 1024);
+	munit_assert_int(rv, ==, DQLITE_MISUSE);
+
+	rv = dqlite_node_stop(f->node);
+	munit_assert_int(rv, ==, 0);
+
+	return MUNIT_OK;
+}
+
 /******************************************************************************
  *
  * dqlite_node_recover


### PR DESCRIPTION
Exposes the raft setting to set the `uv->block_size`. I started digging a bit because I had horrible results with the `dqlite-benchmark` tool on my laptop. I noticed that +- 99.5% of the async writes failed with `EAGAIN` on my laptop with 4KB block size. Changing the block size to 64KB increase success rate of the async writes to +- 80% and doubles the write throughput (or halves the average time a default write by the benchmark tool takes) on my 2 machines.

I think it's worth exposing this setting so that users can experiment with it. A lot will depend on the kind of workload I think.