### PR TITLE
gateway: Appease Coverity

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -413,6 +413,7 @@ static void leader_exec_cb(struct exec *exec, int status)
 	struct gateway *g = exec->data;
 	struct handle *req = g->req;
 	struct stmt *stmt = stmt__registry_get(&g->stmts, req->stmt_id);
+	assert(stmt != NULL);
 	struct response_result response;
 
 	g->req = NULL;


### PR DESCRIPTION
The statement lookup in leader_exec_cb is infallible, because we've already looked up the same stmt_id in order to sqlite3_step the registered statement.

Signed-off-by: Cole Miller <cole.miller@canonical.com>