### PR TITLE
gateway: accept interrupt when no query active

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -62,12 +62,12 @@ static void gateway_handle_cb(struct handle *req, int status, uint8_t type, uint
 	/* Ignore results firing after we started closing. TODO: instead, we
 	 * should make gateway__close() asynchronous. */
 	if (c->closed) {
-                tracef("gateway handle cb closed");
+		tracef("gateway handle cb closed");
 		return;
 	}
 
 	if (status != 0) {
-                tracef("gateway handle cb closed status %d", status);
+		tracef("gateway handle cb status %d", status);
 		goto abort;
 	}
 


### PR DESCRIPTION
The behavior of an interrupt request was recently changed, previously handling an interrupt when no request was active was basically a no-op, it was changed to a hard error [here](https://github.com/canonical/dqlite/commit/83c693e3754ccd9c1814ef652cf2e019a43622cd).

This breaks the package builds of `go-dqlite` on focal with `go 1.13.8`, however it doesn't seem to be caught in the go-dqlite CI tests on focal running `go 1.13.15`.

Decided to revert to previous behavior, unless there's a good reason to change it.

edit: Added a - currently failing - test that actually interrupts a `query_sql` instead of `query`. Apparently there's also an issue with the cleanup code that broke around the same time the other behavior broke.

edit2: So if a request comes in on the same connection, `req` and `g->req` can point to the same `struct handle`. This PR saves the current stmt on the interrupt req that's going to be handled instead of overwriting req->stmt (and thus g->req->stmt) with NULL.

edit3: I actually think it's impossible that the same connection object can handle a new request while another one is ongoing. A new request is only read (after the initial protocol message) in the [write_cb](https://github.com/canonical/dqlite/blob/a856e88d5c9a01e275dccbf5b788a5497ac50944/src/conn.c#L43).

The write_cb can be called during the handling of request in case of a query yielding multiple rows that it needs to send in multiple messages, in that case, gateway__resume will indicate the request is not finished and write_cb will not try to read the next message. write_cb can also be called in case of an exec that resulted in the replication of raft log entries, in that case the write_cb is called after replication is done and the request is finished, so a new request can't be handled during handling of an exec. Same for the other request types, that don't return immediately, we only read a new request after answering the current request.

So, my current understanding is that it's okay to `assert`  in gateway__handle when a request comes in during the handling of another request.

A consequence of this is also that `Interrupt` doesn't work today, the interrupt request will never be read while the query is yielding rows. The interrupt failure was hit in the `go-dqlite` tests because the previous implementation crashed when no request was active, and indeed that looks to be the only case that's possible in the current implementation, it works in the unit tests though, because we call `gateway__handle` directly.

Please correct me if my understanding is wrong.