### PR TITLE
client/protocol: Explicitly include limits.h for INT_MAX

### DIFF
--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <limits.h>
 #include <poll.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
Signed-off-by: Cole Miller <cole.miller@canonical.com>