### PR TITLE
client/protocol.c: Various improvements

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -29,6 +29,7 @@ void gateway__init(struct gateway *g,
 	g->barrier.cb = NULL;
 	g->barrier.leader = NULL;
 	g->protocol = DQLITE_PROTOCOL_VERSION;
+	g->client_id = 0;
 	g->random_state = seed;
 }
 
@@ -248,6 +249,7 @@ static int handle_client(struct gateway *g, struct handle *req)
         tracef("handle client");
 	struct cursor *cursor = &req->cursor;
 	START_V0(client, welcome);
+	g->client_id = request.id;
 	response.heartbeat_timeout = g->config->heartbeat_timeout;
 	SUCCESS_V0(welcome, WELCOME);
 	return 0;

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -35,6 +35,7 @@ struct gateway
 	struct stmt__registry stmts;  /* Registry of prepared statements */
 	struct barrier barrier;       /* Barrier for query requests */
 	uint64_t protocol;            /* Protocol format version */
+	uint64_t client_id;
 	struct id_state random_state; /* For generating IDs */
 };
 

--- a/src/server.c
+++ b/src/server.c
@@ -391,7 +391,7 @@ static int maybeBootstrap(dqlite_node *d,
 		return 0;
 	}
 	raft_configuration_init(&configuration);
-	rv = raft_configuration_add(&configuration, id, address, true);
+	rv = raft_configuration_add(&configuration, id, address, RAFT_VOTER);
 	if (rv != 0) {
 		assert(rv == RAFT_NOMEM);
 		rv = DQLITE_NOMEM;

--- a/test/lib/client.h
+++ b/test/lib/client.h
@@ -18,7 +18,10 @@
 		_rv = listen(f->endpoint.fd, 16);                       \
 		munit_assert_int(_rv, ==, 0);                           \
 		test_endpoint_pair(&f->endpoint, &f->server, &_client); \
-		clientInit(&f->client, _client);                        \
+		memset(&f->client, 0, sizeof f->client);                \
+		buffer__init(&f->client.read);                          \
+		buffer__init(&f->client.write);                         \
+		f->client.fd = _client;                                 \
 	}
 
 #define TEAR_DOWN_CLIENT         \
@@ -108,13 +111,13 @@
 	}
 
 /* Prepare a statement. */
-#define PREPARE(SQL, STMT_ID)                                         \
-	{                                                             \
-		int rv_;                                              \
-		rv_ = clientSendPrepare(f->client, SQL, NULL);        \
-		munit_assert_int(rv_, ==, 0);                         \
-		rv_ = clientRecvStmt(f->client, STMT_ID, NULL, NULL); \
-		munit_assert_int(rv_, ==, 0);                         \
+#define PREPARE(SQL, STMT_ID)                                               \
+	{                                                                   \
+		int rv_;                                                    \
+		rv_ = clientSendPrepare(f->client, SQL, NULL);              \
+		munit_assert_int(rv_, ==, 0);                               \
+		rv_ = clientRecvStmt(f->client, STMT_ID, NULL, NULL, NULL); \
+		munit_assert_int(rv_, ==, 0);                               \
 	}
 
 #define PREPARE_FAIL(SQL, STMT_ID, RV, MSG)                        \
@@ -153,7 +156,7 @@
 		int rv_;                                                  \
 		rv_ = clientSendQuery(f->client, STMT_ID, NULL, 0, NULL); \
 		munit_assert_int(rv_, ==, 0);                             \
-		rv_ = clientRecvRows(f->client, ROWS, NULL);              \
+		rv_ = clientRecvRows(f->client, ROWS, NULL, NULL);        \
 		munit_assert_int(rv_, ==, 0);                             \
 	}
 
@@ -162,7 +165,7 @@
 		int rv_;                                                 \
 		rv_ = clientSendQuerySQL(f->client, SQL, NULL, 0, NULL); \
 		munit_assert_int(rv_, ==, 0);                            \
-		rv_ = clientRecvRows(f->client, ROWS, NULL);             \
+		rv_ = clientRecvRows(f->client, ROWS, NULL, NULL);       \
 		munit_assert_int(rv_, ==, 0);                            \
 	}
 

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -108,8 +108,10 @@ void test_server_client_connect(struct test_server *s, struct client_proto *c)
 	rv = endpointConnect(NULL, s->address, &fd);
 	munit_assert_int(rv, ==, 0);
 
-	rv = clientInit(c, fd);
-	munit_assert_int(rv, ==, 0);
+	memset(c, 0, sizeof *c);
+	buffer__init(&c->read);
+	buffer__init(&c->write);
+	c->fd = fd;
 }
 
 void test_server_client_close(struct test_server *s, struct client_proto *c)

--- a/test/unit/test_conn.c
+++ b/test/unit/test_conn.c
@@ -107,14 +107,14 @@ static void connCloseCb(struct conn *conn)
 	}
 
 /* Prepare a statement. */
-#define PREPARE_CONN(SQL, STMT_ID)                                     \
-	{                                                              \
-		int rv2;                                               \
-		rv2 = clientSendPrepare(&f->client, SQL, NULL);        \
-		munit_assert_int(rv2, ==, 0);                          \
-		test_uv_run(&f->loop, 1);                              \
-		rv2 = clientRecvStmt(&f->client, STMT_ID, NULL, NULL); \
-		munit_assert_int(rv2, ==, 0);                          \
+#define PREPARE_CONN(SQL, STMT_ID)                                           \
+	{                                                                    \
+		int rv2;                                                     \
+		rv2 = clientSendPrepare(&f->client, SQL, NULL);              \
+		munit_assert_int(rv2, ==, 0);                                \
+		test_uv_run(&f->loop, 1);                                    \
+		rv2 = clientRecvStmt(&f->client, STMT_ID, NULL, NULL, NULL); \
+		munit_assert_int(rv2, ==, 0);                                \
 	}
 
 /* Execute a statement. */
@@ -148,7 +148,7 @@ static void connCloseCb(struct conn *conn)
 		rv2 = clientSendQuery(&f->client, STMT_ID, NULL, 0, NULL); \
 		munit_assert_int(rv2, ==, 0);                              \
 		test_uv_run(&f->loop, 2);                                  \
-		rv2 = clientRecvRows(&f->client, ROWS, NULL);              \
+		rv2 = clientRecvRows(&f->client, ROWS, NULL, NULL);        \
 		munit_assert_int(rv2, ==, 0);                              \
 	}
 


### PR DESCRIPTION
This is in preparation for the C client. One or two bug fixes (like making sure to return early in RESPONSE), some changes to integer types, refactoring the "strdup or OOM" pattern into a function, and adding support for custom connect functions.

Signed-off-by: Cole Miller <cole.miller@canonical.com>