### PR TITLE
Polyfill __builtin_assume_aligned for tcc

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -8,6 +8,12 @@
 
 #include "format.h"
 
+/* tinycc doesn't have this builtin, nor the warning that it's meant to silence.
+ */
+#ifdef __TINYC__
+#define __builtin_assume_aligned(x, y) x
+#endif
+
 /* WAL magic value. Either this value, or the same value with the least
  * significant bit also set (FORMAT__WAL_MAGIC | 0x00000001) is stored in 32-bit
  * big-endian format in the first 4 bytes of a WAL file.

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -22,6 +22,12 @@
 #include "tracing.h"
 #include "vfs.h"
 
+/* tinycc doesn't have this builtin, nor the warning that it's meant to silence.
+ */
+#ifdef __TINYC__
+#define __builtin_assume_aligned(x, y) x
+#endif
+
 /* Byte order */
 #if defined(DQLITE_LITTLE_ENDIAN)
 #define VFS__BIGENDIAN 0

--- a/test/unit/test_tuple.c
+++ b/test/unit/test_tuple.c
@@ -4,6 +4,12 @@
 
 #include "../lib/runner.h"
 
+/* tinycc doesn't have this builtin, nor the warning that it's meant to silence.
+ */
+#ifdef __TINYC__
+#define __builtin_assume_aligned(x, y) x
+#endif
+
 TEST_MODULE(tuple);
 
 /******************************************************************************


### PR DESCRIPTION
I've been messing around with using Fabrice Bellard's tcc for local builds; this is the only change that's really required for libdqlite to build successfully (have not tried the test suite yet).

The only reason we call __builtin_assume_aligned is to silence a warning from GCC/Clang about unaligned accesses; tcc doesn't have that warning.

Signed-off-by: Cole Miller <cole.miller@canonical.com>