### PR TITLE
vfs: Fix buggy database filename comparison

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -722,7 +722,8 @@ static struct vfsDatabase *vfsDatabaseLookup(struct vfs *v,
 
 	for (i = 0; i < v->n_databases; i++) {
 		struct vfsDatabase *database = v->databases[i];
-		if (strncmp(database->name, filename, n) == 0) {
+		if (strlen(database->name) == n &&
+		    strncmp(database->name, filename, n) == 0) {
 			// Found matching file.
 			return database;
 		}


### PR DESCRIPTION
Before this change, a call to vfsDatabaseLookup with filename "blah" could end up opening a database named "blahblah" (n = strlen("blah") = 4, strncmp("blah", "blahblah", 4) = 0).

Signed-off-by: Cole Miller <cole.miller@canonical.com>