### PR TITLE
client/protocol: Return owned error message from clientRecvFailure

### DIFF
--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -967,7 +967,7 @@ int clientRecvEmpty(struct client_proto *c, struct client_context *context)
 
 int clientRecvFailure(struct client_proto *c,
 		      uint64_t *code,
-		      const char **msg,
+		      char **msg,
 		      struct client_context *context)
 {
 	tracef("client recv failure");
@@ -975,7 +975,7 @@ int clientRecvFailure(struct client_proto *c,
 	struct response_failure response;
 	RESPONSE(failure, FAILURE);
 	*code = response.code;
-	*msg = response.message;
+	*msg = strdupChecked(response.message);
 	return 0;
 }
 

--- a/src/client/protocol.h
+++ b/src/client/protocol.h
@@ -237,7 +237,7 @@ int clientRecvEmpty(struct client_proto *c, struct client_context *context);
 /* Receive a failure response. */
 int clientRecvFailure(struct client_proto *c,
 		      uint64_t *code,
-		      const char **msg,
+		      char **msg,
 		      struct client_context *context);
 
 /* Receive a list of nodes in the cluster. */

--- a/test/integration/test_fsm.c
+++ b/test/integration/test_fsm.c
@@ -684,7 +684,7 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, snapshot_params)
 	uint64_t rows_affected;
 	struct rows rows;
 	uint64_t code;
-	const char *msg;
+	char *msg;
 	int rv;
 
 	bool disk_mode = false;
@@ -748,6 +748,7 @@ TEST(fsm, snapshotRestoreMultipleDBs, setUp, tearDown, 0, snapshot_params)
 	PREPARE_FAIL("SELECT * from test2b", &stmt_id, &code, &msg);
 	munit_assert_uint64(code, ==, DQLITE_ERROR);
 	munit_assert_string_equal(msg, "no such table: test2b");
+	free(msg);
 
 	/* Table is there on first DB */
 	test_server_client_reconnect(&f->servers[0], &f->servers[0].client);


### PR DESCRIPTION
This matches how other functions in client/protocol.c work and is less error-prone.

Signed-off-by: Cole Miller <cole.miller@canonical.com>