### PR TITLE
Add dependabot to manage dependencies updates of github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+# for more info see: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # checks for workflow files in .github/workflows
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What is dependabot
- dependabot periodically checks for outdated dependencies and raises PRs to update if there are any
- maintained and supported by GitHub
- configured in a `dependabot.yml` file 
- having the `dependabot.yml` file automatically activates dependabot
- further options can be found under _Settings_ -> _Code security and analysis_ -> _Dependabot_
- more information [here](https://docs.github.com/en/code-security/dependabot)

## What does this PR do
- adds the `dependabot.yml` file to the `.github` folder
- the added `dependabot.yml` is already configured to check all _github-actions_ once every week for dependencies updates