### PR TITLE
dqlite.h: Support switching off the auto-bootstrap configuration

### DIFF
--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -2,6 +2,7 @@
 #define DQLITE_H
 
 #include <sqlite3.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -80,7 +81,7 @@ DQLITE_API int dqlite_server_set_address(dqlite_server *server,
 					 const char *address);
 
 /**
- * Indicate that this server will be the "bootstrap" server for its cluster.
+ * Turn on or off automatic bootstrap for this server.
  *
  * The bootstrap server should be the first to start up. It automatically
  * becomes the leader in the first term, and is responsible for adding all other
@@ -88,7 +89,7 @@ DQLITE_API int dqlite_server_set_address(dqlite_server *server,
  * server in each cluster. After the first startup, the bootstrap server is no
  * longer special and this function is a no-op.
  */
-DQLITE_API int dqlite_server_set_auto_bootstrap(dqlite_server *server);
+DQLITE_API int dqlite_server_set_auto_bootstrap(dqlite_server *server, bool on);
 
 /**
  * Declare the addresses of existing servers in the cluster, which should

--- a/src/server.c
+++ b/src/server.c
@@ -1302,9 +1302,9 @@ int dqlite_server_set_address(dqlite_server *server, const char *address)
 	return 0;
 }
 
-int dqlite_server_set_auto_bootstrap(dqlite_server *server)
+int dqlite_server_set_auto_bootstrap(dqlite_server *server, bool on)
 {
-	server->bootstrap = true;
+	server->bootstrap = on;
 	return 0;
 }
 

--- a/test/integration/test_server.c
+++ b/test/integration/test_server.c
@@ -66,7 +66,7 @@ void start_each_server(struct fixture *f)
 
 	rv = dqlite_server_set_address(f->servers[0], "127.0.0.1:8880");
 	munit_assert_int(rv, ==, 0);
-	rv = dqlite_server_set_auto_bootstrap(f->servers[0]);
+	rv = dqlite_server_set_auto_bootstrap(f->servers[0], true);
 	munit_assert_int(rv, ==, 0);
 	f->servers[0]->refresh_period = 100;
 	rv = dqlite_server_start(f->servers[0]);
@@ -170,7 +170,7 @@ TEST(server, bad_info_file, setup, teardown, 0, NULL)
 
 	rv = dqlite_server_set_address(f->servers[0], "127.0.0.1:8880");
 	munit_assert_int(rv, ==, 0);
-	rv = dqlite_server_set_auto_bootstrap(f->servers[0]);
+	rv = dqlite_server_set_auto_bootstrap(f->servers[0], true);
 	munit_assert_int(rv, ==, 0);
 	rv = dqlite_server_start(f->servers[0]);
 	munit_assert_int(rv, !=, 0);
@@ -189,7 +189,7 @@ TEST(server, bad_node_store, setup, teardown, 0, NULL)
 
 	rv = dqlite_server_set_address(f->servers[0], "127.0.0.1:8880");
 	munit_assert_int(rv, ==, 0);
-	rv = dqlite_server_set_auto_bootstrap(f->servers[0]);
+	rv = dqlite_server_set_auto_bootstrap(f->servers[0], true);
 	munit_assert_int(rv, ==, 0);
 	rv = dqlite_server_start(f->servers[0]);
 	munit_assert_int(rv, !=, 0);
@@ -207,7 +207,7 @@ TEST(server, node_store_but_no_info, setup, teardown, 0, NULL)
 
 	rv = dqlite_server_set_address(f->servers[0], "127.0.0.1:8880");
 	munit_assert_int(rv, ==, 0);
-	rv = dqlite_server_set_auto_bootstrap(f->servers[0]);
+	rv = dqlite_server_set_auto_bootstrap(f->servers[0], true);
 	munit_assert_int(rv, ==, 0);
 	rv = dqlite_server_start(f->servers[0]);
 	munit_assert_int(rv, !=, 0);
@@ -238,7 +238,7 @@ TEST(server, start_twice, setup, teardown, 0, NULL)
 
 	rv = dqlite_server_set_address(f->servers[0], "127.0.0.1:8880");
 	munit_assert_int(rv, ==, 0);
-	rv = dqlite_server_set_auto_bootstrap(f->servers[0]);
+	rv = dqlite_server_set_auto_bootstrap(f->servers[0], true);
 	munit_assert_int(rv, ==, 0);
 	rv = dqlite_server_start(f->servers[0]);
 	munit_assert_int(rv, ==, 0);
@@ -257,7 +257,7 @@ TEST(server, stop_twice, setup, teardown, 0, NULL)
 
 	rv = dqlite_server_set_address(f->servers[0], "127.0.0.1:8880");
 	munit_assert_int(rv, ==, 0);
-	rv = dqlite_server_set_auto_bootstrap(f->servers[0]);
+	rv = dqlite_server_set_auto_bootstrap(f->servers[0], true);
 	munit_assert_int(rv, ==, 0);
 	rv = dqlite_server_start(f->servers[0]);
 	munit_assert_int(rv, ==, 0);


### PR DESCRIPTION
Add the ability to also turn off the automatic bootstrap behavior.

This makes `dqlite_server_set_auto_bootstrap` a bit more complete and consistent with the other `dqlite_server_set_xxx` APIs which allow to override/reset previous calls.

Since this code hasn't been part of a release yet and hasn't any consumer that we know of, I think it's safe to merge the change if desired.