### PR TITLE
More revamp work: preparing to send requests to the DB thread

### DIFF
--- a/src/revamp.c
+++ b/src/revamp.c
@@ -3,16 +3,47 @@
 int dbContextInit(struct db_context *ctx, struct config *config)
 {
 	int rv;
-	rv = sem_init(&ctx->sem, 0, 0);
-	if (rv != 0) {
-		return DQLITE_ERROR;
-	}
+	rv = pthread_mutex_init(&ctx->mutex, NULL);
+	assert(rv == 0);
+	rv = pthread_cond_init(&ctx->cond, NULL);
+	assert(rv == 0);
 	registry__init(&ctx->registry, config);
+	ctx->shutdown = false;
+	return 0;
+}
+
+int postExecSqlReq(struct db_context *ctx,
+		struct exec_sql_req req,
+		void *data,
+		void (*cb)(struct exec_sql_req, int, void *))
+{
+	(void)ctx;
+	(void)req;
+	(void)data;
+	(void)cb;
 	return 0;
 }
 
 void dbContextClose(struct db_context *ctx)
 {
 	registry__close(&ctx->registry);
-	sem_destroy(&ctx->sem);
+	pthread_cond_destroy(&ctx->cond);
+	pthread_mutex_destroy(&ctx->mutex);
+}
+
+void *dbTask(void *arg)
+{
+	struct db_context *ctx = arg;
+	int rv;
+
+	rv = pthread_mutex_lock(&ctx->mutex);
+	assert(rv == 0);
+	for (;;) {
+		rv = pthread_cond_wait(&ctx->cond, &ctx->mutex);
+		assert(rv == 0);
+		if (ctx->shutdown) {
+			break;
+		}
+	}
+	return NULL;
 }

--- a/src/revamp.c
+++ b/src/revamp.c
@@ -1,1 +1,18 @@
 #include "revamp.h"
+
+int dbContextInit(struct db_context *ctx, struct config *config)
+{
+	int rv;
+	rv = sem_init(&ctx->sem, 0, 0);
+	if (rv != 0) {
+		return DQLITE_ERROR;
+	}
+	registry__init(&ctx->registry, config);
+	return 0;
+}
+
+void dbContextClose(struct db_context *ctx)
+{
+	registry__close(&ctx->registry);
+	sem_destroy(&ctx->sem);
+}

--- a/src/revamp.h
+++ b/src/revamp.h
@@ -1,17 +1,39 @@
 #ifndef DQLITE_REVAMP_H_
 #define DQLITE_REVAMP_H_
 
+#include "lib/queue.h"
 #include "registry.h"
+#include "tuple.h"
 
-#include <semaphore.h>
+#include <pthread.h>
+#include <stdbool.h>
 
 struct db_context
 {
-	sem_t sem;
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
 	struct registry registry;
+	queue exec_sql_reqs;
+	bool shutdown;
+};
+
+struct exec_sql_req
+{
+	char *db_name;
+	char *sql;
+	struct value *params;
+	queue queue;
 };
 
 int dbContextInit(struct db_context *ctx, struct config *config);
+
+int postExecSqlReq(struct db_context *ctx,
+		struct exec_sql_req req,
+		void *data,
+		void (*cb)(struct exec_sql_req, int, void *));
+
 void dbContextClose(struct db_context *ctx);
+
+void *dbTask(void *arg);
 
 #endif

--- a/src/revamp.h
+++ b/src/revamp.h
@@ -1,11 +1,17 @@
-#ifndef DQLITE_REVAMP_H
-#define DQLITE_REVAMP_H
+#ifndef DQLITE_REVAMP_H_
+#define DQLITE_REVAMP_H_
+
+#include "registry.h"
 
 #include <semaphore.h>
 
 struct db_context
 {
 	sem_t sem;
+	struct registry registry;
 };
+
+int dbContextInit(struct db_context *ctx, struct config *config);
+void dbContextClose(struct db_context *ctx);
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -15,6 +15,7 @@
 #include "lib/fs.h"
 #include "logger.h"
 #include "protocol.h"
+#include "revamp.h"
 #include "roles.h"
 #include "tracing.h"
 #include "translate.h"
@@ -529,7 +530,10 @@ static void stopCb(uv_async_t *stop)
 	}
 	raft_close(&d->raft, raftCloseCb);
 
-	sem_post(&d->db_ctx->sem);
+	pthread_mutex_lock(&d->db_ctx->mutex);
+	d->db_ctx->shutdown = true;
+	pthread_cond_signal(&d->db_ctx->cond);
+	pthread_mutex_unlock(&d->db_ctx->mutex);
 	pthread_join(d->db_thread, NULL);
 }
 
@@ -676,13 +680,6 @@ static void roleManagementTimerCb(uv_timer_t *handle)
 	RolesAdjust(d);
 }
 
-static void *dbTask(void *arg)
-{
-	struct db_context *ctx = arg;
-	sem_wait(&ctx->sem);
-	return NULL;
-}
-
 static int taskRun(struct dqlite_node *d)
 {
 	int rv;
@@ -697,6 +694,8 @@ static int taskRun(struct dqlite_node *d)
 		return rv;
 	}
 
+	rv = pthread_mutex_lock(&d->db_ctx->mutex);
+	assert(rv == 0);
 	rv = pthread_create(&d->db_thread, NULL, dbTask, d->db_ctx);
 	assert(rv == 0);
 
@@ -753,6 +752,9 @@ static int taskRun(struct dqlite_node *d)
 		sem_post(&d->ready);
 		return rv;
 	}
+
+	rv = pthread_mutex_unlock(&d->db_ctx->mutex);
+	assert(rv == 0);
 
 	rv = uv_run(&d->loop, UV_RUN_DEFAULT);
 	assert(rv == 0);


### PR DESCRIPTION
Next steps:

- There is a deadlock in the new mutex/condvar interaction that needs fixing.
- Sending the EXEC_SQL request to the DB thread at the appropriate place in gateway.c, and waiting for the DB thread to respond before the end of the request's lifecycle (by receiving an acknowledgement on another queue/channel). The DB thread doesn't have to do anything with the request yet.
- Having the DB thread open databases in response to the received requests, prepare statements, and execute them, using the normal VFS for now. (We should probably make up a subdirectory of the data directory for those files to live in.)

Signed-off-by: Cole Miller <cole.miller@canonical.com>