### PR TITLE
replace monitor_cb by raft state_cb.

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -43,9 +43,8 @@ struct dqlite_node
 	struct uv_async_s handover;
 	int handover_status;
 	void (*handover_done_cb)(struct dqlite_node *, int);
-	struct uv_async_s stop;      /* Trigger UV loop stop */
-	struct uv_timer_s startup;   /* Unblock ready sem */
-	struct uv_prepare_s monitor; /* Raft state change monitor */
+	struct uv_async_s stop;    /* Trigger UV loop stop */
+	struct uv_timer_s startup; /* Unblock ready sem */
 	struct uv_timer_s timer;
 	int raft_state;     /* Previous raft state */
 	char *bind_address; /* Listen address */

--- a/test/integration/test_membership.c
+++ b/test/integration/test_membership.c
@@ -223,7 +223,8 @@ TEST(membership,
 
 	await_arg.f = f;
 	await_arg.id = 0;
-	await_arg.last_applied = last_applied + 1;
+	/* 2 barriers and 1 write tx. */
+	await_arg.last_applied = last_applied + 3;
 	AWAIT_TRUE(last_applied_cond, await_arg, 2);
 
 	return MUNIT_OK;
@@ -337,7 +338,8 @@ TEST(membership,
 
 	await_arg.f = f;
 	await_arg.id = 0;
-	await_arg.last_applied = last_applied + 1;
+	/* 2 barriers and 1 write tx. */
+	await_arg.last_applied = last_applied + 3;
 	AWAIT_TRUE(last_applied_cond, await_arg, 2);
 
 	/* Transfer leadership back to original node, reconnect the client and


### PR DESCRIPTION
The state_cb is called immediately after raft's state changes, while the
monitor_cb was polling every loop iteration. This led e.g. to bugs where
raft was assuming no longer being the leader while dqlite's state was not
properly reflecting that.

Fixes #541 , also please refer to that issue for the problem description. Issue observed was similar as in #355. 
Relies on functionality introduced by https://github.com/canonical/raft/pull/488.
