### PR TITLE
State cb

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -43,9 +43,8 @@ struct dqlite_node
 	struct uv_async_s handover;
 	int handover_status;
 	void (*handover_done_cb)(struct dqlite_node *, int);
-	struct uv_async_s stop;      /* Trigger UV loop stop */
-	struct uv_timer_s startup;   /* Unblock ready sem */
-	struct uv_prepare_s monitor; /* Raft state change monitor */
+	struct uv_async_s stop;    /* Trigger UV loop stop */
+	struct uv_timer_s startup; /* Unblock ready sem */
 	struct uv_timer_s timer;
 	int raft_state;     /* Previous raft state */
 	char *bind_address; /* Listen address */


### PR DESCRIPTION
The state_cb is triggered immediately when the raft state changes,
instead of the monitor_cb, that is only polling for the state change at
the start of a loop iteration. This avoids some bugs where dqlite has to
perform cleanups on leadership loss, but wasn't informed yet of the
leadership loss.

fixes #541 

Note: When we release a new dqlite version, we will also need an 
accompanying new raft version that supports registering the state_cb.