### PR TITLE
packages: Add mantic.

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -13,6 +13,7 @@ jobs:
           - focal
           - jammy
           - lunar
+          - mantic
     runs-on: ubuntu-20.04
     environment:
       name: ppa


### PR DESCRIPTION
Add mantic packages.
Best to wait for raft packages to be published before starting to build dqlite ppa packages.