### PR TITLE
Include more debug info in debug builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,7 +111,7 @@ integration_test_LDFLAGS = $(AM_LDFLAGS) -no-install
 integration_test_LDADD = libtest.la libdqlite.la
 
 if DEBUG_ENABLED
-  AM_CFLAGS += -g
+  AM_CFLAGS += -g3
 else
   AM_CFLAGS += -O2
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ PKG_CHECK_MODULES(RAFT, [raft >= 0.17.1], [], [])
 
 CC_CHECK_FLAGS_APPEND([AM_CFLAGS],[CFLAGS],[ \
   -std=c11 \
-  -g \
+  -g3 \
   --mcet \
   -fcf-protection \
   --param=ssp-buffer-size=4 \


### PR DESCRIPTION
See [here](https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html#Options-for-Debugging-Your-Program) for the description of what `-g3` does. More debuginfo seems better to me!