### PR TITLE
Fix many cases of arithmetic on void pointers

### DIFF
--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -103,7 +103,8 @@ static int peekUint64(struct cursor cursor, uint64_t *val)
 	if (cursor.cap < 8) {
 		return DQLITE_CLIENT_PROTO_ERROR;
 	}
-	*val = ByteFlipLe64(*(uint64_t *)cursor.p);
+	memcpy(val, cursor.p, sizeof(*val));
+	*val = ByteFlipLe64(*val);
 	return 0;
 }
 

--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -371,7 +371,7 @@ static int writeMessage(struct client_proto *c,
 	struct message message = {0};
 	size_t n;
 	size_t words;
-	void *cursor;
+	char *cursor;
 	ssize_t rv;
 	n = buffer__offset(&c->write);
 	words = (n - message__sizeof(&message)) / 8;
@@ -395,7 +395,7 @@ static int writeMessage(struct client_proto *c,
 		struct message _message = {0};                   \
 		size_t _n1;                                      \
 		size_t _n2;                                      \
-		void *_cursor;                                   \
+		char *_cursor;                                   \
 		_n1 = message__sizeof(&_message);                \
 		_n2 = request_##LOWER##__sizeof(&request);       \
 		buffer__reset(&c->write);                        \

--- a/src/command.c
+++ b/src/command.c
@@ -29,7 +29,7 @@ static size_t frames__sizeof(const frames_t *frames)
 	return s;
 }
 
-static void frames__encode(const frames_t *frames, void **cursor)
+static void frames__encode(const frames_t *frames, char **cursor)
 {
 	const dqlite_vfs_frame *list;
 	unsigned i;
@@ -88,7 +88,7 @@ COMMAND__TYPES(COMMAND__IMPLEMENT, );
 int command__encode(int type, const void *command, struct raft_buffer *buf)
 {
 	struct header h = {0};
-	void *cursor;
+	char *cursor;
 	int rc = 0;
 	h.format = FORMAT;
 	switch (type) {

--- a/src/conn.c
+++ b/src/conn.c
@@ -56,7 +56,7 @@ static void gateway_handle_cb(struct handle *req,
 {
 	struct conn *c = req->data;
 	size_t n;
-	void *cursor;
+	char *cursor;
 	uv_buf_t buf;
 	int rv;
 

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -366,7 +366,7 @@ SERIALIZE__IMPLEMENT(snapshotDatabase, SNAPSHOT_DATABASE);
 static int encodeSnapshotHeader(unsigned n, struct raft_buffer *buf)
 {
 	struct snapshotHeader header;
-	void *cursor;
+	char *cursor;
 	header.format = SNAPSHOT_FORMAT;
 	header.n = n;
 	buf->len = snapshotHeader__sizeof(&header);
@@ -388,7 +388,7 @@ static int encodeDatabase(struct db *db,
 	sqlite3_vfs *vfs;
 	uint32_t database_size = 0;
 	uint8_t *page;
-	void *cursor;
+	char *cursor;
 	struct dqlite_buffer *bufs = (struct dqlite_buffer *)r_bufs;
 	int rv;
 
@@ -776,7 +776,7 @@ static int encodeDiskDatabaseAsync(struct db *db,
 {
 	struct snapshotDatabase header;
 	sqlite3_vfs *vfs;
-	void *cursor;
+	char *cursor;
 	struct dqlite_buffer *bufs = (struct dqlite_buffer *)r_bufs;
 	int rv;
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -121,7 +121,7 @@ void gateway__close(struct gateway *g)
 #define SUCCESS(LOWER, UPPER, RESP, SCHEMA)                                    \
 	{                                                                      \
 		size_t _n = response_##LOWER##__sizeof(&RESP);                 \
-		void *_cursor;                                                 \
+		char *_cursor;                                                 \
 		assert(_n % 8 == 0);                                           \
 		_cursor = buffer__advance(req->buffer, _n);                    \
 		/* Since responses are small and the buffer it's at least 4096 \
@@ -179,7 +179,7 @@ static void failure(struct handle *req, int code, const char *message)
 {
 	struct response_failure failure;
 	size_t n;
-	void *cursor;
+	char *cursor;
 	failure.code = (uint64_t)code;
 	failure.message = message;
 	n = response_failure__sizeof(&failure);
@@ -194,7 +194,7 @@ static void failure(struct handle *req, int code, const char *message)
 
 static void emptyRows(struct handle *req)
 {
-	void *cursor = buffer__advance(req->buffer, 8 + 8);
+	char *cursor = buffer__advance(req->buffer, 8 + 8);
 	uint64_t val;
 	assert(cursor != NULL);
 	val = 0;
@@ -1106,7 +1106,7 @@ static int dumpFile(const char *filename,
 		    size_t n,
 		    struct buffer *buffer)
 {
-	void *cur;
+	char *cur;
 	uint64_t len = n;
 
 	cur = buffer__advance(buffer, text__sizeof(&filename));
@@ -1145,7 +1145,7 @@ static int handle_dump(struct gateway *g, struct handle *req)
 	struct cursor *cursor = &req->cursor;
 	bool err = true;
 	sqlite3_vfs *vfs;
-	void *cur;
+	char *cur;
 	char filename[1024] = {0};
 	void *data;
 	size_t n;
@@ -1235,7 +1235,7 @@ static int encodeServer(struct gateway *g,
 			struct buffer *buffer,
 			int format)
 {
-	void *cur;
+	char *cur;
 	uint64_t id;
 	uint64_t role;
 	text_t address;
@@ -1278,7 +1278,7 @@ static int handle_cluster(struct gateway *g, struct handle *req)
 	tracef("handle cluster");
 	struct cursor *cursor = &req->cursor;
 	unsigned i;
-	void *cur;
+	char *cur;
 	int rv;
 	START_V0(cluster, servers);
 

--- a/src/lib/serialize.h
+++ b/src/lib/serialize.h
@@ -168,31 +168,36 @@ DQLITE_INLINE void uint8__encode(const uint8_t *value, char **cursor)
 
 DQLITE_INLINE void uint16__encode(const uint16_t *value, char **cursor)
 {
-	*(uint16_t *)(*cursor) = ByteFlipLe16(*value);
+	uint16_t x = ByteFlipLe16(*value);
+	memcpy(*cursor, &x, sizeof(uint16_t));
 	*cursor += sizeof(uint16_t);
 }
 
 DQLITE_INLINE void uint32__encode(const uint32_t *value, char **cursor)
 {
-	*(uint32_t *)(*cursor) = ByteFlipLe32(*value);
+	uint32_t x = ByteFlipLe32(*value);
+	memcpy(*cursor, &x, sizeof(uint32_t));
 	*cursor += sizeof(uint32_t);
 }
 
 DQLITE_INLINE void uint64__encode(const uint64_t *value, char **cursor)
 {
-	*(uint64_t *)(*cursor) = ByteFlipLe64(*value);
+	uint64_t x = ByteFlipLe64(*value);
+	memcpy(*cursor, &x, sizeof(uint64_t));
 	*cursor += sizeof(uint64_t);
 }
 
 DQLITE_INLINE void int64__encode(const int64_t *value, char **cursor)
 {
-	*(int64_t *)(*cursor) = (int64_t)ByteFlipLe64((uint64_t)*value);
+	int64_t x = (int64_t)ByteFlipLe64((uint64_t)*value);
+	memcpy(*cursor, &x, sizeof(int64_t));
 	*cursor += sizeof(int64_t);
 }
 
 DQLITE_INLINE void float__encode(const float_t *value, char **cursor)
 {
-	*(uint64_t *)(*cursor) = ByteFlipLe64(*(uint64_t *)value);
+	uint64_t x = ByteFlipLe64(*(uint64_t *)value);
+	memcpy(*cursor, &x, sizeof(uint64_t));
 	*cursor += sizeof(uint64_t);
 }
 
@@ -231,7 +236,8 @@ DQLITE_INLINE int uint16__decode(struct cursor *cursor, uint16_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = ByteFlipLe16(*(uint16_t *)cursor->p);
+	memcpy(value, cursor->p, sizeof(*value));
+	*value = ByteFlipLe16(*value);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -243,7 +249,8 @@ DQLITE_INLINE int uint32__decode(struct cursor *cursor, uint32_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = ByteFlipLe32(*(uint32_t *)cursor->p);
+	memcpy(value, cursor->p, sizeof(*value));
+	*value = ByteFlipLe32(*value);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -255,7 +262,8 @@ DQLITE_INLINE int uint64__decode(struct cursor *cursor, uint64_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = ByteFlipLe64(*(uint64_t *)cursor->p);
+	memcpy(value, cursor->p, sizeof(*value));
+	*value = ByteFlipLe64(*value);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -267,7 +275,8 @@ DQLITE_INLINE int int64__decode(struct cursor *cursor, int64_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*value = (int64_t)ByteFlipLe64((uint64_t) * (int64_t *)cursor->p);
+	memcpy(value, cursor->p, sizeof(*value));
+	*value = (int64_t)ByteFlipLe64((uint64_t)*value);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;
@@ -279,7 +288,9 @@ DQLITE_INLINE int float__decode(struct cursor *cursor, float_t *value)
 	if (n > cursor->cap) {
 		return DQLITE_PARSE;
 	}
-	*(uint64_t *)value = ByteFlipLe64(*(uint64_t *)cursor->p);
+	uint64_t x;
+	memcpy(&x, cursor->p, sizeof(x));
+	*(uint64_t *)value = ByteFlipLe64(x);
 	cursor->p += n;
 	cursor->cap -= n;
 	return 0;

--- a/src/lib/serialize.h
+++ b/src/lib/serialize.h
@@ -45,7 +45,7 @@ typedef uv_buf_t blob_t;
  */
 struct cursor
 {
-	const void *p; /* Next byte to read */
+	const char *p; /* Next byte to read */
 	size_t cap;    /* Number of bytes left in the buffer */
 };
 
@@ -71,7 +71,7 @@ struct cursor
 
 #define SERIALIZE__DEFINE_METHODS(NAME, FIELDS)                   \
 	size_t NAME##__sizeof(const struct NAME *p);              \
-	void NAME##__encode(const struct NAME *p, void **cursor); \
+	void NAME##__encode(const struct NAME *p, char **cursor); \
 	int NAME##__decode(struct cursor *cursor, struct NAME *p)
 
 /* Define a single field in serializable struct.
@@ -90,7 +90,7 @@ struct cursor
 		FIELDS(SERIALIZE__SIZEOF_FIELD, p);               \
 		return size;                                      \
 	}                                                         \
-	void NAME##__encode(const struct NAME *p, void **cursor)  \
+	void NAME##__encode(const struct NAME *p, char **cursor)  \
 	{                                                         \
 		FIELDS(SERIALIZE__ENCODE_FIELD, p, cursor);       \
 	}                                                         \
@@ -160,43 +160,43 @@ DQLITE_INLINE size_t blob__sizeof(const blob_t *value)
 	return sizeof(uint64_t) + BytePad64(value->len);
 }
 
-DQLITE_INLINE void uint8__encode(const uint8_t *value, void **cursor)
+DQLITE_INLINE void uint8__encode(const uint8_t *value, char **cursor)
 {
 	*(uint8_t *)(*cursor) = *value;
 	*cursor += sizeof(uint8_t);
 }
 
-DQLITE_INLINE void uint16__encode(const uint16_t *value, void **cursor)
+DQLITE_INLINE void uint16__encode(const uint16_t *value, char **cursor)
 {
 	*(uint16_t *)(*cursor) = ByteFlipLe16(*value);
 	*cursor += sizeof(uint16_t);
 }
 
-DQLITE_INLINE void uint32__encode(const uint32_t *value, void **cursor)
+DQLITE_INLINE void uint32__encode(const uint32_t *value, char **cursor)
 {
 	*(uint32_t *)(*cursor) = ByteFlipLe32(*value);
 	*cursor += sizeof(uint32_t);
 }
 
-DQLITE_INLINE void uint64__encode(const uint64_t *value, void **cursor)
+DQLITE_INLINE void uint64__encode(const uint64_t *value, char **cursor)
 {
 	*(uint64_t *)(*cursor) = ByteFlipLe64(*value);
 	*cursor += sizeof(uint64_t);
 }
 
-DQLITE_INLINE void int64__encode(const int64_t *value, void **cursor)
+DQLITE_INLINE void int64__encode(const int64_t *value, char **cursor)
 {
 	*(int64_t *)(*cursor) = (int64_t)ByteFlipLe64((uint64_t)*value);
 	*cursor += sizeof(int64_t);
 }
 
-DQLITE_INLINE void float__encode(const float_t *value, void **cursor)
+DQLITE_INLINE void float__encode(const float_t *value, char **cursor)
 {
 	*(uint64_t *)(*cursor) = ByteFlipLe64(*(uint64_t *)value);
 	*cursor += sizeof(uint64_t);
 }
 
-DQLITE_INLINE void text__encode(const text_t *value, void **cursor)
+DQLITE_INLINE void text__encode(const text_t *value, char **cursor)
 {
 	size_t len = BytePad64(strlen(*value) + 1);
 	memset(*cursor, 0, len);
@@ -204,7 +204,7 @@ DQLITE_INLINE void text__encode(const text_t *value, void **cursor)
 	*cursor += len;
 }
 
-DQLITE_INLINE void blob__encode(const blob_t *value, void **cursor)
+DQLITE_INLINE void blob__encode(const blob_t *value, char **cursor)
 {
 	size_t len = BytePad64(value->len);
 	uint64_t value_len = value->len;

--- a/src/query.c
+++ b/src/query.c
@@ -99,7 +99,7 @@ int query__batch(sqlite3_stmt *stmt, struct buffer *buffer)
 	int n; /* Column count */
 	int i;
 	uint64_t n64;
-	void *cursor;
+	char *cursor;
 	int rc;
 
 	n = sqlite3_column_count(stmt);

--- a/src/transport.c
+++ b/src/transport.c
@@ -67,7 +67,7 @@ static void connect_work_cb(uv_work_t *work)
 	struct request_connect request = {0};
 	uint64_t protocol;
 	void *buf;
-	void *cursor;
+	char *cursor;
 	size_t n;
 	size_t n1;
 	size_t n2;

--- a/src/tuple.c
+++ b/src/tuple.c
@@ -75,7 +75,7 @@ int tuple_decoder__init(struct tuple_decoder *d,
 
 	d->format = format;
 	d->i = 0;
-	d->header = cursor->p;
+	d->header = (const uint8_t *)cursor->p;
 
 	/* Check that there is enough room to hold n type code slots. */
 	header_size = calc_header_size(d->n, d->format);
@@ -168,7 +168,7 @@ int tuple_encoder__init(struct tuple_encoder *e,
 			int format,
 			struct buffer *buffer)
 {
-	void *cursor;
+	char *cursor;
 	size_t n_header;
 
 	e->n = n;
@@ -188,7 +188,7 @@ int tuple_encoder__init(struct tuple_encoder *e,
 	} else if (e->format == TUPLE__PARAMS32) {
 		uint32_t val = (uint32_t)n;
 		assert((unsigned long long)val == (unsigned long long)n);
-		void *header = buffer__advance(buffer, 4);
+		char *header = buffer__advance(buffer, 4);
 		if (header == NULL) {
 			return DQLITE_NOMEM;
 		}
@@ -232,7 +232,7 @@ static void set_type(struct tuple_encoder *e, unsigned long i, int type)
 
 int tuple_encoder__next(struct tuple_encoder *e, struct value *value)
 {
-	void *cursor;
+	char *cursor;
 	size_t size;
 
 	assert(e->i < e->n);

--- a/test/unit/lib/test_serialize.c
+++ b/test/unit/lib/test_serialize.c
@@ -265,13 +265,19 @@ TEST_CASE(encode, custom, NULL)
 	munit_assert_string_equal(cursor, "Victor Hugo");
 	cursor += 16;
 
-	munit_assert_int(ByteFlipLe64(*(uint64_t *)cursor), ==, 40);
+	uint64_t x;
+	memcpy(&x, cursor, sizeof(x));
+	munit_assert_uint64(ByteFlipLe64(x), ==, 40);
 	cursor += 8;
 
-	munit_assert_int(ByteFlipLe16(*(uint16_t *)cursor), ==, 2);
+	uint16_t y;
+	memcpy(&y, cursor, sizeof(y));
+	munit_assert_uint16(ByteFlipLe16(y), ==, 2);
 	cursor += 2;
 
-	munit_assert_int(ByteFlipLe16(*(uint16_t *)cursor), ==, 8);
+	uint16_t z;
+	memcpy(&z, cursor, sizeof(z));
+	munit_assert_uint16(ByteFlipLe16(z), ==, 8);
 	cursor += 2;
 
 	cursor += 4; /* Unused */

--- a/test/unit/lib/test_serialize.c
+++ b/test/unit/lib/test_serialize.c
@@ -62,7 +62,7 @@ static size_t pages__sizeof(const pages_t *pages)
 	       pages->size * pages->n /* bufs */;
 }
 
-static void pages__encode(const pages_t *pages, void **cursor)
+static void pages__encode(const pages_t *pages, char **cursor)
 {
 	unsigned i;
 	uint16__encode(&pages->n, cursor);
@@ -194,7 +194,7 @@ TEST_CASE(encode, padding, NULL)
 	struct fixture *f = data;
 	size_t size;
 	void *buf;
-	void *cursor;
+	char *cursor;
 	(void)params;
 	f->person.name = "John Doh";
 	f->person.age = 40;
@@ -214,7 +214,7 @@ TEST_CASE(encode, no_padding, NULL)
 	struct fixture *f = data;
 	size_t size;
 	void *buf;
-	void *cursor;
+	char *cursor;
 	(void)params;
 	f->person.name = "Joe Doh";
 	f->person.age = 40;
@@ -234,7 +234,7 @@ TEST_CASE(encode, custom, NULL)
 	struct fixture *f = data;
 	size_t size;
 	void *buf;
-	void *cursor;
+	char *cursor;
 	(void)params;
 	f->book.title = "Les miserables";
 	f->book.author.name = "Victor Hugo";

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -98,7 +98,7 @@ static void fixture_handle_cb(struct handle *req,
 #define ENCODE(C, REQUEST, LOWER)                               \
 	{                                                       \
 		size_t n2 = request_##LOWER##__sizeof(REQUEST); \
-		void *cursor;                                   \
+		char *cursor;                                   \
 		buffer__reset(&C->request);                     \
 		cursor = buffer__advance(&C->request, n2);      \
 		munit_assert_ptr_not_null(cursor);              \

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -110,7 +110,7 @@ static void handleCb(struct handle *req,
 #define ENCODE(REQUEST, LOWER)                                  \
 	{                                                       \
 		size_t n2 = request_##LOWER##__sizeof(REQUEST); \
-		void *cursor;                                   \
+		char *cursor;                                   \
 		buffer__reset(f->buf1);                         \
 		cursor = buffer__advance(f->buf1, n2);          \
 		munit_assert_ptr_not_null(cursor);              \

--- a/test/unit/test_request.c
+++ b/test/unit/test_request.c
@@ -55,7 +55,7 @@ TEST_CASE(serialize, leader, NULL)
 {
 	struct fixture *f = data;
 	struct request_leader request;
-	void *cursor1;
+	char *cursor1;
 	struct cursor cursor2;
 	size_t n = request_leader__sizeof(&request);
 	(void)params;

--- a/test/unit/test_tuple.c
+++ b/test/unit/test_tuple.c
@@ -122,11 +122,11 @@ TEST_GROUP(decoder, row);
 TEST_CASE(decoder, row, one_value, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] = {
+	char buf[][8] = {
 	    {SQLITE_INTEGER, 0, 0, 0, 0, 0, 0, 0},
 	    {7, 0, 0, 0, 0, 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -145,12 +145,12 @@ TEST_CASE(decoder, row, one_value, NULL)
 TEST_CASE(decoder, row, two_values, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] = {
+	char buf[][8] = {
 	    {SQLITE_INTEGER | SQLITE_TEXT << 4, 0, 0, 0, 0, 0, 0, 0},
 	    {7, 0, 0, 0, 0, 0, 0, 0},
 	    {'h', 'e', 'l', 'l', 'o', 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -176,11 +176,11 @@ TEST_GROUP(decoder, params);
 TEST_CASE(decoder, params, one_value, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] = {
+	char buf[][8] = {
 	    {1, SQLITE_INTEGER, 0, 0, 0, 0, 0, 0},
 	    {7, 0, 0, 0, 0, 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -199,12 +199,12 @@ TEST_CASE(decoder, params, one_value, NULL)
 TEST_CASE(decoder, params, two_values, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] = {
+	char buf[][8] = {
 	    {2, SQLITE_INTEGER, SQLITE_TEXT, 0, 0, 0, 0, 0},
 	    {7, 0, 0, 0, 0, 0, 0, 0},
 	    {'h', 'e', 'l', 'l', 'o', 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -230,11 +230,11 @@ TEST_GROUP(decoder, params32);
 TEST_CASE(decoder, params32, one_value, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] = {
+	char buf[][8] = {
 	    {1, 0, 0, 0, SQLITE_INTEGER, 0, 0, 0},
 	    {7, 0, 0, 0, 0, 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -253,12 +253,12 @@ TEST_CASE(decoder, params32, one_value, NULL)
 TEST_CASE(decoder, params32, two_values, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] = {
+	char buf[][8] = {
 	    {2, 0, 0, 0, SQLITE_INTEGER, SQLITE_TEXT, 0, 0},
 	    {7, 0, 0, 0, 0, 0, 0, 0},
 	    {'h', 'e', 'l', 'l', 'o', 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -288,7 +288,7 @@ TEST_CASE(decoder, type, float, NULL)
 	    {SQLITE_FLOAT, 0, 0, 0, 0, 0, 0, 0},
 	    {0, 0, 0, 0, 0, 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 	double pi = 3.1415;
 
@@ -313,11 +313,11 @@ TEST_CASE(decoder, type, float, NULL)
 TEST_CASE(decoder, type, null, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] __attribute__((aligned(sizeof(uint64_t)))) = {
+	char buf[][8] __attribute__((aligned(sizeof(uint64_t)))) = {
 	    {SQLITE_NULL, 0, 0, 0, 0, 0, 0, 0},
 	    {0, 0, 0, 0, 0, 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -335,10 +335,10 @@ TEST_CASE(decoder, type, null, NULL)
 TEST_CASE(decoder, type, iso8601, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[5][8] __attribute__((aligned(sizeof(uint64_t)))) = {
+	char buf[5][8] __attribute__((aligned(sizeof(uint64_t)))) = {
 	    {DQLITE_ISO8601, 0, 0, 0, 0, 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;
@@ -359,11 +359,11 @@ TEST_CASE(decoder, type, iso8601, NULL)
 TEST_CASE(decoder, type, boolean, NULL)
 {
 	struct tuple_decoder decoder;
-	uint8_t buf[][8] __attribute__((aligned(sizeof(uint64_t)))) = {
+	char buf[][8] __attribute__((aligned(sizeof(uint64_t)))) = {
 	    {DQLITE_BOOLEAN, 0, 0, 0, 0, 0, 0, 0},
 	    {1, 0, 0, 0, 0, 0, 0, 0},
 	};
-	struct cursor cursor = {buf, sizeof buf};
+	struct cursor cursor = {(const char *)buf, sizeof buf};
 	struct value value;
 
 	(void)data;


### PR DESCRIPTION
Currently we use `void *` as a cursor type when parsing and serializing, and this results in many cases of performing arithmetic on void pointers -- technically UB. Change these types to `char *` everywhere.

Signed-off-by: Cole Miller <cole.miller@canonical.com>