### PR TITLE
Fix use-after-free in threadpool code

### DIFF
--- a/src/lib/threadpool.c
+++ b/src/lib/threadpool.c
@@ -525,8 +525,8 @@ int pool_init(pool_t *pool,
 
 	rc = uv_async_init(loop, &pi->outq_async, work_done);
 	if (rc != 0) {
-		free(pi);
 		uv_mutex_destroy(&pi->outq_mutex);
+		free(pi);
 		return rc;
 	}
 


### PR DESCRIPTION
Pointed out by GCC on one of the LP builders.

Signed-off-by: Cole Miller <cole.miller@canonical.com>