### PR TITLE
raft: Close fd used for fallocate probing

### DIFF
--- a/src/raft/uv_fs.c
+++ b/src/raft/uv_fs.c
@@ -874,6 +874,7 @@ static void probeFallocate(const char *dir, bool *fallocate)
 	if (rv == 0) {
 		*fallocate = true;
 	}
+	close(fd);
 
 out:
 	UvFsRemoveFile(dir, UV__FS_PROBE_FALLOCATE_FILE, ignored);


### PR DESCRIPTION
The file descriptor leak here was noted by the LXD folks: https://github.com/canonical/lxd/issues/12808#issuecomment-1969219953

cc @tomponline @simondeziel

Signed-off-by: Cole Miller <cole.miller@canonical.com>