### PR TITLE
client/protocol: Ensure 64 bits for nanosecond calculations

### DIFF
--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -126,7 +126,7 @@ static ssize_t doRead(int fd,
 	ssize_t total;
 	struct pollfd pfd;
 	struct timespec now;
-	long millis;
+	long long millis;
 	ssize_t n;
 	int rv;
 
@@ -206,7 +206,7 @@ static ssize_t doWrite(int fd,
 	ssize_t total;
 	struct pollfd pfd;
 	struct timespec now;
-	long millis;
+	long long millis;
 	ssize_t n;
 	int rv;
 


### PR DESCRIPTION
Fixes this Launchpad build failure on armhf: https://launchpad.net/~dqlite/+archive/ubuntu/dev/+build/27853399

```console
src/client/protocol.c: In function ‘doRead’:
src/client/protocol.c:143:29: error: conversion from ‘__time64_t’ {aka ‘long long int’} to ‘long int’ may change value [-Werror=conversion]
  143 |                             (context->deadline.tv_sec - now.tv_sec) * 1000 +
      |                             ^
src/client/protocol.c: In function ‘doWrite’:
src/client/protocol.c:223:29: error: conversion from ‘__time64_t’ {aka ‘long long int’} to ‘long int’ may change value [-Werror=conversion]
  223 |                             (context->deadline.tv_sec - now.tv_sec) * 1000 +
      |                             ^
```

(I don't know why these warnings didn't fire before -- either a GCC update or something to do with the time64 transition.)

Signed-off-by: Cole Miller <cole.miller@canonical.com>