### PR TITLE
Use --enable-build-raft for Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,9 +21,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository -y ppa:dqlite/dev
           sudo apt-get update -qq
-          sudo apt-get install -qq gcc libsqlite3-dev liblz4-dev libuv1-dev libraft-dev
+          sudo apt-get install -qq gcc libsqlite3-dev liblz4-dev libuv1-dev
 
       - name: Run coverity
         run: |
@@ -33,7 +32,7 @@ jobs:
           autoreconf -i
           mkdir build
           cd build
-          ../configure
+          ../configure --enable-build-raft
 
           # Build
           cov-build --dir cov-int make -j4


### PR DESCRIPTION
Closes #611

Signed-off-by: Cole Miller <cole.miller@canonical.com>