### PR TITLE
raft/uv: Drop AI_V4MAPPED | AI_ADDRCONFIG from getaddrinfo

### DIFF
--- a/src/raft/uv_ip.c
+++ b/src/raft/uv_ip.c
@@ -58,7 +58,7 @@ int uvIpAddrSplit(const char *address,
 int uvIpResolveBindAddresses(const char *address, struct addrinfo **ai_result)
 {
 	static struct addrinfo hints = {
-	    .ai_flags = AI_ADDRCONFIG | AI_PASSIVE | AI_NUMERICSERV,
+	    .ai_flags = AI_PASSIVE | AI_NUMERICSERV,
 	    .ai_family = AF_INET,
 	    .ai_socktype = SOCK_STREAM,
 	    .ai_protocol = 0};

--- a/src/raft/uv_tcp_connect.c
+++ b/src/raft/uv_tcp_connect.c
@@ -261,7 +261,7 @@ static void uvGetAddrInfoCb(uv_getaddrinfo_t *req,
 /* Create a new TCP handle and submit a connection request to the event loop. */
 static int uvTcpConnectStart(struct uvTcpConnect *r, const char *address)
 {
-	static struct addrinfo hints = {.ai_flags = AI_V4MAPPED | AI_ADDRCONFIG,
+	static struct addrinfo hints = {.ai_flags = 0,
 					.ai_family = AF_INET,
 					.ai_socktype = SOCK_STREAM,
 					.ai_protocol = 0};


### PR DESCRIPTION
This is cherry-picked from https://github.com/cowsql/raft/commit/1a00ebf0482000d8b62ea1932bb88122a951aaba -- thanks @freeekanayaka for pointing out the fix.

Closes #574

Signed-off-by: Cole Miller <cole.miller@canonical.com>