### PR TITLE
test_conn: Fix changed alignment requirements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ dqlite.pc
 libtool
 stamp-h*
 sqlite3.c
+raft-core-fuzzy-test
+raft-core-integration-test
+raft-core-unit-test
+raft-uv-integration-test
+raft-uv-unit-test


### PR DESCRIPTION
On armhf casting to uint64_t* produces the following warning
"cast increases required alignment of target type". Remove
the hack of saving a pointer to bool in a field that's not
meant to hold it.

Fixes launchpad builds.