### PR TITLE
Refactor vfs2

### DIFF
--- a/src/lib/byte.h
+++ b/src/lib/byte.h
@@ -115,6 +115,18 @@ DQLITE_INLINE uint32_t ByteGetBe32(const uint8_t *buf)
 	return w | x | y | z;
 }
 
+DQLITE_INLINE uint32_t ByteGetLe32(const uint8_t *buf)
+{
+	uint32_t w = buf[0];
+	uint32_t x = buf[1];
+	uint32_t y = buf[2];
+	uint32_t z = buf[3];
+	z <<= 24;
+	y <<= 16;
+	x <<= 8;
+	return w | x | y | z;
+}
+
 DQLITE_INLINE void BytePutBe32(uint32_t v, uint8_t *buf)
 {
 	buf[0] = (uint8_t)(v >> 24);

--- a/src/lib/sm.c
+++ b/src/lib/sm.c
@@ -42,7 +42,7 @@ void sm_move(struct sm *m, int next_state)
 {
 	int prev = sm_state(m);
 
-	tracef("SM_MOVE %d => %d", prev, next_state);
+	tracef("SM_MOVE %s => %s", m->conf[prev].name, m->conf[next_state].name);
 
 	PRE(sm_is_locked(m));
 	PRE(m->conf[sm_state(m)].allowed & BITS(next_state));

--- a/src/lib/sm.h
+++ b/src/lib/sm.h
@@ -6,7 +6,7 @@
 
 #define BITS(state) (1ULL << (state))
 
-#define CHECK(cond) if (!sm_check((cond), __FILE__, __LINE__, #cond)) return false
+#define CHECK(cond) sm_check((cond), __FILE__, __LINE__, #cond)
 
 enum {
 	SM_PREV_NONE = -1,

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,6 +2,7 @@
 #define DQLITE_UTILS_H_
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 /* Various utility functions and macros */
@@ -20,5 +21,9 @@
 #define PRE(cond) assert((cond))
 #define POST(cond) assert((cond))
 #define ERGO(a, b) (!(a) || (b))
+
+static inline bool is_po2(unsigned long n) {
+	return n > 0 && (n & (n - 1)) == 0;
+}
 
 #endif /* DQLITE_UTILS_H_ */

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -61,7 +61,7 @@ static const struct sm_conf wtx_states[SM_STATES_MAX] = {
 	[WTX_EMPTY] = {
 		.flags = 0,
 		.name = "empty",
-		.allowed = BITS(WTX_FOLLOWING)|BITS(WTX_FLUSH)|BITS(WTX_BASE)|BITS(WTX_CLOSED),
+		.allowed = BITS(WTX_FOLLOWING)|BITS(WTX_FLUSH)|BITS(WTX_ACTIVE)|BITS(WTX_CLOSED),
 	},
 	[WTX_FOLLOWING] = {
 		.flags = 0,
@@ -690,7 +690,7 @@ static int vfs2_write(sqlite3_file *file,
 		if (rv != SQLITE_OK) {
 			return rv;
 		}
-		sm_move(&e->wtx_sm, WTX_BASE);
+		sm_move(&e->wtx_sm, WTX_ACTIVE);
 		return SQLITE_OK;
 	}
 
@@ -954,10 +954,9 @@ static int vfs2_shm_lock(sqlite3_file *file, int ofst, int n, int flags)
 			if (ihdr->nBackfill == ihdr->basic[0].mxFrame) {
 				sm_move(&e->wtx_sm, WTX_EMPTY);
 			}
-		} else if (ofst <= WAL_RECOVER_LOCK && WAL_RECOVER_LOCK < ofst + n) {
-			/* End of recovery: move to BASE. */
+		} /* else if (ofst <= WAL_RECOVER_LOCK && WAL_RECOVER_LOCK < ofst + n) {
 			sm_move(&e->wtx_sm, WTX_BASE);
-		}
+		} */
 	} else {
 		assert(0);
 	}
@@ -1740,7 +1739,7 @@ int vfs2_apply_uncommitted(sqlite3_file *file, uint32_t page_size, const struct 
 		if (rv != SQLITE_OK) {
 			return 1;
 		}
-		sm_move(&e->wtx_sm, WTX_FLUSH);
+		/* sm_move(&e->wtx_sm, WTX_FLUSH); */
 	}
 
 	uint32_t start = e->wal_cursor;

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -76,7 +76,7 @@ static const struct sm_conf wtx_states[SM_STATES_MAX] = {
 	[WTX_BASE] = {
 		.flags = 0,
 		.name = "base",
-		.allowed = BITS(WTX_FOLLOWING)|BITS(WTX_BASE)|BITS(WTX_ACTIVE)|BITS(WTX_CLOSED),
+		.allowed = BITS(WTX_FOLLOWING)|BITS(WTX_BASE)|BITS(WTX_ACTIVE)|BITS(WTX_EMPTY)|BITS(WTX_CLOSED),
 	},
 	[WTX_ACTIVE] = {
 		.flags = 0,

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -445,6 +445,7 @@ static bool wtx_invariant(const struct sm *sm, int prev)
 		CHECK(no_pending_txn(e));
 		CHECK(!write_lock_held(e));
 		CHECK(backfill < mx);
+		tracef("mx=%u cursor=%u", mx, cursor);
 		CHECK(mx == cursor);
 		CHECK(wal_index_recovered(e));
 		return true;
@@ -1611,6 +1612,7 @@ int vfs2_abort(sqlite3_file *file)
 	hdr->basic[1] = e->prev_txn_hdr;
 	e->pending_txn_hdr = (struct wal_index_basic_hdr){};
 
+	e->wal_cursor = e->pending_txn_start;
 	free_pending_txn(e);
 
 	sm_move(&xfile->entry->wtx_sm, WTX_BASE);

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1695,6 +1695,9 @@ int vfs2_read_wal(sqlite3_file *file,
 				return 1;
 			}
 			rv = wal->pMethods->xRead(wal, p, page_size, off);
+			if (rv != SQLITE_OK) {
+				return 1;
+			}
 			txns[i].frames[j].page_number = ByteGetBe32(fhdr.page_number);
 			txns[i].frames[j].commit = ByteGetBe32(fhdr.commit);
 			txns[i].frames[j].page = p;

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -538,7 +538,6 @@ static int vfs2_close(sqlite3_file *file)
 		rv = xfile->orig->pMethods->xClose(xfile->orig);
 		sqlite3_free(xfile->orig);
 	}
-	sqlite3_free(file);
 	return rv;
 }
 

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -450,8 +450,6 @@ static bool wtx_invariant(const struct sm *sm, int prev)
 		return true;
 	}
 
-	CHECK(mx < cursor);
-
 	if (sm_state(sm) == WTX_ACTIVE) {
 		CHECK(wal_index_basic_hdr_equal(get_full_hdr(e)->basic[0], e->prev_txn_hdr));
 		CHECK(wal_index_basic_hdr_zeroed(e->pending_txn_hdr));
@@ -459,6 +457,8 @@ static bool wtx_invariant(const struct sm *sm, int prev)
 		CHECK(have_pending_txn(e));
 		return true;
 	}
+
+	CHECK(mx < cursor);
 
 	if (sm_state(sm) == WTX_HIDDEN) {
 		CHECK(wal_index_basic_hdr_equal(get_full_hdr(e)->basic[0], e->prev_txn_hdr));

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -520,6 +520,13 @@ static void maybe_close_entry(struct entry *e)
 	}
 	sqlite3_free(e->wal_prev);
 
+	free_pending_txn(e);
+
+	pthread_rwlock_wrlock(&e->common->rwlock);
+	queue_remove(&e->link);
+	pthread_rwlock_unlock(&e->common->rwlock);
+	sqlite3_free(e);
+
 }
 
 static int vfs2_close(sqlite3_file *file)

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -109,32 +109,16 @@ static const struct sm_conf wtx_states[SM_STATES_MAX] = {
 /**
  * Userdata owned by the VFS.
  */
-struct vfs2_data {
+struct common {
 	sqlite3_vfs *orig;       /* underlying VFS */
 	pthread_rwlock_t rwlock; /* protects the queue */
-	atomic_uint page_size;
-	queue queue; /* queue of vfs2_db_entry */
-};
-
-/**
- * Linked list element representing a single database/WAL pair.
- */
-struct vfs2_db_entry {
-	struct vfs2_file *db;
-	struct vfs2_file *wal;
-
-	struct sm wtx_sm;
-
-	char *db_name;
-	struct vfs2_wal_slice wal_limit;
-
-	queue link;
+	queue queue; /* queue of entry */
 };
 
 /**
  * Layout-compatible with the first part of the WAL index header.
  */
-struct vfs2_wal_index_basic_hdr {
+struct wal_index_basic_hdr {
 	uint32_t iVersion;
 	uint8_t unused[4];
 	uint32_t iChange;
@@ -148,7 +132,7 @@ struct vfs2_wal_index_basic_hdr {
 	uint32_t aCksum[2];
 };
 
-struct vfs2_wal_hdr {
+struct wal_hdr {
 	uint8_t magic[4];
 	uint8_t version[4];
 	uint8_t page_size[4];
@@ -158,8 +142,8 @@ struct vfs2_wal_hdr {
 	uint8_t cksum2[4];
 };
 
-struct vfs2_wal_index_full_hdr {
-	struct vfs2_wal_index_basic_hdr basic[2];
+struct wal_index_full_hdr {
+	struct wal_index_basic_hdr basic[2];
 	uint32_t nBackfill;
 	uint32_t marks[5];
 	uint8_t locks[SQLITE_SHM_NLOCK];
@@ -171,73 +155,54 @@ struct vfs2_wal_index_full_hdr {
  * View of the zeroth shm region, which contains the WAL index header.
  */
 union vfs2_shm_region0 {
-	struct vfs2_wal_index_full_hdr hdr;
+	struct wal_index_full_hdr hdr;
 	char bytes[VFS2_WAL_INDEX_REGION_SIZE];
 };
 
-struct vfs2_wal {
-	const char *moving_name;   /* e.g. /path/to/my.db-wal */
-	char *wal_cur_fixed_name;  /* e.g. /path/to/my.db-xwal1 */
-	sqlite3_file *wal_prev;    /* underlying file object for WAL-prev */
-	char *wal_prev_fixed_name; /* e.g. /path/to/my.db-xwal2 */
+struct entry {
+	struct common *common;
 
-	uint32_t commit_end; /* frame index, zero-based, should be in sync with mxFrame */
+	uint32_t page_size;
 
-	/* All pending_txn fields pertain to a transaction that has at least one
-	 * frame in the WAL and is the last transaction represented in the WAL.
-	 * Writing a frame either updates the pending transaction or starts a
-	 * new transaction. A frame starts a new transaction if it is written at
-	 * the end of the WAL and the physically preceding frame has a nonzero
-	 * commit marker. */
-	dqlite_vfs_frame *pending_txn_frames; /* for vfs2_poll */
+	char *main_db_name;
+
+	char *wal_moving_name;
+	char *wal_cur_fixed_name;
+	sqlite3_file *wal_cur;
+	char *wal_prev_fixed_name;
+	sqlite3_file *wal_prev;
+
+	unsigned refcount_main_db;
+	unsigned refcount_wal;
+
+	struct wal_index_basic_hdr prev_txn_hdr;
+	struct wal_index_basic_hdr pending_txn_hdr;
+
+	void **shm_regions;
+	int shm_regions_len;
+	unsigned shm_refcount;
+	unsigned shm_locks[SQLITE_SHM_NLOCK];
+
+	dqlite_vfs_frame *pending_txn_frames;
+	uint32_t pending_txn_start;
 	uint32_t pending_txn_len;
-	uint32_t pending_txn_last_frame_commit; /* commit marker for the
-						   physical last frame */
-};
+	uint32_t pending_txn_last_frame_commit;
 
-struct vfs2_db {
-	const char *name; /* e.g. /path/to/my.db */
+	uint32_t wal_cursor;
 
-	/* Copy of the WAL index header that reflects the last really-committed
-	 * (i.e. in Raft too) transaction, or the initial state of the WAL if
-	 * no transactions have been committed yet. */
-	struct vfs2_wal_index_basic_hdr prev_txn_hdr;
-	/* Copy of the WAL index header that reflects a sorta-committed
-	 * transaction that has not yet been through Raft, or all zeros
-	 * if no transaction fits this description. */
-	struct vfs2_wal_index_basic_hdr pending_txn_hdr;
-	/* When the WAL is restarted (or started for the first time), we capture
-	 * the initial WAL index header in prev_txn_hdr.
-	 *
-	 * When we get SQLITE_FCNTL_COMMIT_PHASETWO, we copy the WAL index
-	 * header from shm into pending_txn_hdr, then overwrite the shm with
-	 * prev_txn_hdr to hide the transaction.
-	 *
-	 * When we get vfs2_apply, we overwrite both prev_txn_hdr and the shm
-	 * with pending_txn_hdr. */
+	struct sm wtx_sm;
 
-	void **regions;
-	int regions_len;
-	unsigned refcount;
-
-	unsigned locks[SQLITE_SHM_NLOCK];
+	queue link;
 };
 
 /**
  * VFS-specific file object, upcastable to sqlite3_file.
  */
-struct vfs2_file {
-	struct sqlite3_file base; /* vtable, must be first */
-	sqlite3_file *orig;       /* underlying file object */
-	struct vfs2_data *vfs_data;
-	struct vfs2_db_entry *entry;
-	int flags; /* from xOpen */
-	union {
-		/* if this file object is a WAL */
-		struct vfs2_wal wal;
-		/* if this file object is a main file */
-		struct vfs2_db db_shm;
-	};
+struct file {
+	struct sqlite3_file base;
+	int flags;
+	sqlite3_file *orig; /* NULL for WAL */
+	struct entry *entry; /* NULL for non-main non-WAL */
 };
 
 static uint32_t get_salt1(struct vfs2_salts s)
@@ -255,48 +220,48 @@ static bool salts_equal(struct vfs2_salts a, struct vfs2_salts b)
 	return get_salt1(a) == get_salt1(b) && get_salt2(a) == get_salt2(b);
 }
 
-static struct vfs2_wal_index_full_hdr *get_full_hdr(struct vfs2_db *db)
+static struct wal_index_full_hdr *get_full_hdr(struct entry *e)
 {
-	PRE(db->regions_len > 0);
-	PRE(db->regions != NULL);
-	return db->regions[0];
+	PRE(e->shm_regions_len > 0);
+	PRE(e->shm_regions != NULL);
+	return e->shm_regions[0];
 }
 
-static bool region0_mapped(struct vfs2_db *db)
+static bool region0_mapped(struct entry *e)
 {
-	return db->regions_len > 0 && db->regions != NULL &&
-	       db->regions[0] != NULL;
+	return e->shm_regions_len > 0 && e->shm_regions != NULL &&
+	       e->shm_regions[0] != NULL;
 }
 
-static bool no_pending_txn(struct vfs2_wal *wal)
+static bool no_pending_txn(struct entry *e)
 {
-	return wal->pending_txn_len == 0 && wal->pending_txn_frames == NULL && wal->pending_txn_last_frame_commit == 0;
+	return e->pending_txn_len == 0 && e->pending_txn_frames == NULL && e->pending_txn_last_frame_commit == 0;
 }
 
-static bool have_pending_txn(struct vfs2_wal *wal)
+static bool have_pending_txn(struct entry *e)
 {
-	return wal->pending_txn_len > 0 && wal->pending_txn_frames != NULL;
+	return e->pending_txn_len > 0 && e->pending_txn_frames != NULL;
 }
 
-static bool write_lock_held(struct vfs2_db *db)
+static bool write_lock_held(struct entry *e)
 {
-	return db->locks[VFS2_SHM_WRITE_LOCK] == VFS2_EXCLUSIVE;
+	return e->shm_locks[VFS2_SHM_WRITE_LOCK] == VFS2_EXCLUSIVE;
 }
 
-static bool wal_index_hdr_fresh(const struct vfs2_wal_index_full_hdr *hdr)
+static bool wal_index_hdr_fresh(const struct wal_index_full_hdr *hdr)
 {
 	/* TODO check other things here? */
 	return hdr->basic[0].mxFrame == 0;
 }
 
-static bool wal_index_basic_hdr_equal(struct vfs2_wal_index_basic_hdr a,
-				      struct vfs2_wal_index_basic_hdr b)
+static bool wal_index_basic_hdr_equal(struct wal_index_basic_hdr a,
+				      struct wal_index_basic_hdr b)
 {
-	return memcmp(&a, &b, sizeof(struct vfs2_wal_index_basic_hdr)) == 0;
+	return memcmp(&a, &b, sizeof(struct wal_index_basic_hdr)) == 0;
 }
 
-static bool wal_index_basic_hdr_advanced(struct vfs2_wal_index_basic_hdr new,
-					 struct vfs2_wal_index_basic_hdr old)
+static bool wal_index_basic_hdr_advanced(struct wal_index_basic_hdr new,
+					 struct wal_index_basic_hdr old)
 {
 	return new.iChange == old.iChange + 1 &&
 	       new.nPage >= old.nPage /* no vacuums here */
@@ -308,93 +273,99 @@ static bool wal_index_basic_hdr_advanced(struct vfs2_wal_index_basic_hdr new,
 	       && new.mxFrame > old.mxFrame;
 }
 
+static bool is_valid_page_size(unsigned long n)
+{
+	return n >= 1 << 9 && n <= 1 << 16 && (n & (n - 1)) == 0;
+}
+
 static bool wtx_invariant(const struct sm *sm, int prev)
 {
-	struct vfs2_db_entry *entry =
-	    CONTAINER_OF(sm, struct vfs2_db_entry, wtx_sm);
-	struct vfs2_wal *wal = (entry->wal == NULL) ? NULL : &entry->wal->wal;
-	struct vfs2_db *db_shm =
-	    (entry->db == NULL) ? NULL : &entry->db->db_shm;
+	(void)sm;
+	(void)prev;
+	(void)wal_index_basic_hdr_advanced;
+	(void)is_valid_page_size;
+	(void)wal_index_basic_hdr_equal;
+	(void)wal_index_hdr_fresh;
+	(void)write_lock_held;
+	(void)have_pending_txn;
+	(void)no_pending_txn;
+	(void)region0_mapped;
+	// struct entry *e = CONTAINER_OF(sm, struct entry, wtx_sm);
 
 	/* TODO go over these checks again and strengthen them */
 	/* TODO rewrite in expression-oriented style? */
 
-	if (sm_state(sm) == WTX_NOT_OPEN) {
-		CHECK(wal == NULL);
-	}
+	// if (sm_state(sm) == WTX_NOT_OPEN) {
+	// 	CHECK(wal == NULL);
+	// }
 
-	if (sm_state(sm) == WTX_EMPTY) {
-		CHECK(wal != NULL);
-	}
+	// if (sm_state(sm) == WTX_EMPTY) {
+	// 	CHECK(wal != NULL);
+	// }
 
-	if (sm_state(sm) == WTX_BASE) {
-		CHECK(db_shm != NULL);
-		CHECK(wal != NULL);
-		CHECK(no_pending_txn(wal));
-		CHECK(wal_index_basic_hdr_equal(db_shm->pending_txn_hdr, (struct vfs2_wal_index_basic_hdr){}));
+	// if (sm_state(sm) == WTX_BASE) {
+	// 	CHECK(db_shm != NULL);
+	// 	CHECK(wal != NULL);
+	// 	CHECK(no_pending_txn(wal));
+	// 	CHECK(wal_index_basic_hdr_equal(db_shm->pending_txn_hdr, (struct wal_index_basic_hdr){}));
 
-		if (prev == WTX_BASE) {
-			/* just after a WAL swap */
-			CHECK(write_lock_held(db_shm));
-			CHECK(region0_mapped(db_shm));
-			CHECK(wal_index_hdr_fresh(get_full_hdr(db_shm)));
-		}
-	}
+	// 	if (prev == WTX_BASE) {
+	// 		/* just after a WAL swap */
+	// 		CHECK(write_lock_held(db_shm));
+	// 		CHECK(region0_mapped(db_shm));
+	// 		CHECK(wal_index_hdr_fresh(get_full_hdr(db_shm)));
+	// 	}
+	// }
 
-	if (sm_state(sm) == WTX_ACTIVE) {
-		CHECK(db_shm != NULL);
-		CHECK(wal != NULL);
-		CHECK(have_pending_txn(wal));
-		CHECK(region0_mapped(db_shm));
-		CHECK(write_lock_held(db_shm));
+	// if (sm_state(sm) == WTX_ACTIVE) {
+	// 	CHECK(db_shm != NULL);
+	// 	CHECK(wal != NULL);
+	// 	CHECK(have_pending_txn(wal));
+	// 	CHECK(region0_mapped(db_shm));
+	// 	CHECK(write_lock_held(db_shm));
 
-		struct vfs2_wal_index_full_hdr *hdr = get_full_hdr(db_shm);
-		CHECK(wal_index_basic_hdr_equal(hdr->basic[0],
-						db_shm->prev_txn_hdr) ||
-		      wal_index_basic_hdr_advanced(hdr->basic[0],
-						   db_shm->prev_txn_hdr));
-		CHECK(wal_index_basic_hdr_equal(db_shm->pending_txn_hdr, (struct vfs2_wal_index_basic_hdr){}));
+	// 	struct wal_index_full_hdr *hdr = get_full_hdr(db_shm);
+	// 	CHECK(wal_index_basic_hdr_equal(hdr->basic[0],
+	// 					db_shm->prev_txn_hdr) ||
+	// 	      wal_index_basic_hdr_advanced(hdr->basic[0],
+	// 					   db_shm->prev_txn_hdr));
+	// 	CHECK(wal_index_basic_hdr_equal(db_shm->pending_txn_hdr, (struct wal_index_basic_hdr){}));
 
-		if (prev == WTX_BASE) {
-			/* first frame in a txn */
-			CHECK(wal->pending_txn_len == 1);
-		}
-	}
+	// 	if (prev == WTX_BASE) {
+	// 		/* first frame in a txn */
+	// 		CHECK(wal->pending_txn_len == 1);
+	// 	}
+	// }
 
-	if (sm_state(sm) == WTX_HIDDEN) {
-		CHECK(db_shm != NULL);
-		CHECK(wal != NULL);
-		CHECK(have_pending_txn(wal));
-		CHECK(region0_mapped(db_shm));
-		CHECK(!write_lock_held(db_shm));
+	// if (sm_state(sm) == WTX_HIDDEN) {
+	// 	CHECK(db_shm != NULL);
+	// 	CHECK(wal != NULL);
+	// 	CHECK(have_pending_txn(wal));
+	// 	CHECK(region0_mapped(db_shm));
+	// 	CHECK(!write_lock_held(db_shm));
 
-		struct vfs2_wal_index_full_hdr *hdr = get_full_hdr(db_shm);
-		CHECK(wal_index_basic_hdr_equal(hdr->basic[0],
-						db_shm->prev_txn_hdr));
-		CHECK(wal_index_basic_hdr_advanced(db_shm->pending_txn_hdr,
-						   hdr->basic[0]));
-	}
+	// 	struct wal_index_full_hdr *hdr = get_full_hdr(db_shm);
+	// 	CHECK(wal_index_basic_hdr_equal(hdr->basic[0],
+	// 					db_shm->prev_txn_hdr));
+	// 	CHECK(wal_index_basic_hdr_advanced(db_shm->pending_txn_hdr,
+	// 					   hdr->basic[0]));
+	// }
 
-	if (sm_state(sm) == WTX_POLLED) {
-		CHECK(db_shm != NULL);
-		CHECK(wal != NULL);
-		CHECK(!have_pending_txn(wal));
-		CHECK(region0_mapped(db_shm));
-		CHECK(write_lock_held(db_shm));
+	// if (sm_state(sm) == WTX_POLLED) {
+	// 	CHECK(db_shm != NULL);
+	// 	CHECK(wal != NULL);
+	// 	CHECK(!have_pending_txn(wal));
+	// 	CHECK(region0_mapped(db_shm));
+	// 	CHECK(write_lock_held(db_shm));
 
-		struct vfs2_wal_index_full_hdr *hdr = get_full_hdr(db_shm);
-		CHECK(wal_index_basic_hdr_equal(hdr->basic[0],
-						db_shm->prev_txn_hdr));
-		CHECK(wal_index_basic_hdr_advanced(db_shm->pending_txn_hdr,
-						   hdr->basic[0]));
-	}
+	// 	struct wal_index_full_hdr *hdr = get_full_hdr(db_shm);
+	// 	CHECK(wal_index_basic_hdr_equal(hdr->basic[0],
+	// 					db_shm->prev_txn_hdr));
+	// 	CHECK(wal_index_basic_hdr_advanced(db_shm->pending_txn_hdr,
+	// 					   hdr->basic[0]));
+	// }
 
 	return true;
-}
-
-static bool is_valid_page_size(unsigned long n)
-{
-	return n >= 1 << 9 && n <= 1 << 16 && (n & (n - 1)) == 0;
 }
 
 static int check_wal_integrity(sqlite3_file *f)
@@ -404,71 +375,53 @@ static int check_wal_integrity(sqlite3_file *f)
 	return SQLITE_OK;
 }
 
-static void unregister_file(struct vfs2_file *file)
-{
-	pthread_rwlock_wrlock(&file->vfs_data->rwlock);
-	queue *q = queue_head(&file->vfs_data->queue);
-	while (q != &file->vfs_data->queue) {
-		queue *next = q->next;
-		struct vfs2_db_entry *entry =
-		    QUEUE_DATA(q, struct vfs2_db_entry, link);
-		if (entry->db == file) {
-			entry->db = NULL;
-		} else if (entry->wal == file) {
-			entry->wal = NULL;
-		}
-		if (entry->wal == NULL) {
-			sm_move(&entry->wtx_sm, WTX_NOT_OPEN);
-		}
-		if (entry->db == NULL && entry->wal == NULL) {
-			q->prev->next = q->next;
-			q->next->prev = q->prev;
-			sm_fini(&entry->wtx_sm);
-			sqlite3_free(entry->db_name);
-			sqlite3_free(entry);
-		}
-		q = next;
-	}
-	pthread_rwlock_unlock(&file->vfs_data->rwlock);
-}
-
 /* sqlite3_io_methods implementations begin here */
+
+static sqlite3_file *get_orig(struct file *f)
+{
+	if (f->flags & SQLITE_OPEN_WAL) {
+		return f->entry->wal_cur;
+	} else {
+		return f->orig;
+	}
+}
 
 static int vfs2_close(sqlite3_file *file)
 {
-	int rv, rvprev;
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
+	struct file *xfile = (struct file *)file;
+	struct entry *e = xfile->entry;
+	int rv;
 
-	unregister_file(xfile);
+	/* TODO unregister */
 
-	rvprev = SQLITE_OK;
+	int rvprev = SQLITE_OK;
 	if (xfile->flags & SQLITE_OPEN_WAL) {
-		sqlite3_free(xfile->wal.wal_cur_fixed_name);
-		sqlite3_free(xfile->wal.wal_prev_fixed_name);
-		if (xfile->wal.wal_prev->pMethods != NULL) {
-			rvprev = xfile->wal.wal_prev->pMethods->xClose(
-			    xfile->wal.wal_prev);
+		sqlite3_free(e->wal_cur_fixed_name);
+		sqlite3_free(e->wal_prev_fixed_name);
+		if (e->wal_prev->pMethods != NULL) {
+			rvprev = e->wal_prev->pMethods->xClose(e->wal_prev);
 		}
-		if (xfile->wal.pending_txn_frames != NULL) {
-			for (uint32_t i = 0; i < xfile->wal.pending_txn_len;
-			     i++) {
-				sqlite3_free(
-				    xfile->wal.pending_txn_frames[i].data);
+		dqlite_vfs_frame *frames = e->pending_txn_frames;
+		uint32_t len = e->pending_txn_len;
+		if (frames != NULL) {
+			for (uint32_t i = 0; i < len; i++) {
+				sqlite3_free(frames[i].data);
 			}
 		}
-		sqlite3_free(xfile->wal.pending_txn_frames);
-		sqlite3_free(xfile->wal.wal_prev);
+		sqlite3_free(frames);
+		sqlite3_free(e->wal_prev);
 	} else if (xfile->flags & SQLITE_OPEN_MAIN_DB) {
-		for (int i = 0; i < xfile->db_shm.regions_len; i++) {
-			sqlite3_free(xfile->db_shm.regions[i]);
+		for (int i = 0; i < e->shm_regions_len; i++) {
+			sqlite3_free(e->shm_regions[i]);
 		}
-		sqlite3_free(xfile->db_shm.regions);
+		sqlite3_free(e->shm_regions);
 	}
 	rv = SQLITE_OK;
-	if (xfile->orig->pMethods != NULL) {
-		rv = xfile->orig->pMethods->xClose(xfile->orig);
+	sqlite3_file *orig = get_orig(xfile);
+	if (orig->pMethods != NULL) {
+		rv = orig->pMethods->xClose(orig);
 	}
-	sqlite3_free(xfile->orig);
+	sqlite3_free(orig);
 	if (rv != SQLITE_OK) {
 		return rv;
 	}
@@ -477,54 +430,46 @@ static int vfs2_close(sqlite3_file *file)
 
 static int vfs2_read(sqlite3_file *file, void *buf, int amt, sqlite3_int64 ofst)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xRead(xfile->orig, buf, amt, ofst);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xRead(orig, buf, amt, ofst);
 }
 
-static int vfs2_wal_swap(struct vfs2_file *wal,
-			 const struct vfs2_wal_hdr *wal_hdr)
+static int vfs2_wal_swap(struct entry *e,
+			 const struct wal_hdr *wal_hdr)
 {
-	PRE(wal->wal.pending_txn_len == 0);
-	PRE(wal->wal.pending_txn_frames == NULL);
+	PRE(e->pending_txn_len == 0);
+	PRE(e->pending_txn_frames == NULL);
 	int rv;
 
-	atomic_uint *p = &wal->vfs_data->page_size;
-	unsigned expected = 0;
-	uint32_t z = ByteGetBe32(wal_hdr->page_size);
-	if (!atomic_compare_exchange_strong(p, &expected, z)) {
-		assert(expected == z);
-	}
-
-	sqlite3_file *phys_outgoing = wal->orig;
-	char *name_outgoing = wal->wal.wal_cur_fixed_name;
-	sqlite3_file *phys_incoming = wal->wal.wal_prev;
-	char *name_incoming = wal->wal.wal_prev_fixed_name;
+	sqlite3_file *phys_outgoing = e->wal_cur;
+	char *name_outgoing = e->wal_cur_fixed_name;
+	sqlite3_file *phys_incoming = e->wal_prev;
+	char *name_incoming = e->wal_prev_fixed_name;
 
 	tracef("wal swap outgoing=%s incoming=%s", name_outgoing, name_incoming);
 
 	/* Write the new header of the incoming WAL. */
 	rv = phys_incoming->pMethods->xWrite(phys_incoming, wal_hdr,
-					     sizeof(struct vfs2_wal_hdr), 0);
+					     sizeof(struct wal_hdr), 0);
 	if (rv != SQLITE_OK) {
 		return rv;
 	}
 
 	/* In-memory WAL swap. */
-	struct vfs2_file *db = wal->entry->db;
-	assert(db != NULL);
-	wal->orig = phys_incoming;
-	wal->wal.wal_cur_fixed_name = name_incoming;
-	wal->wal.wal_prev = phys_outgoing;
-	wal->wal.wal_prev_fixed_name = name_outgoing;
-	wal->wal.commit_end = 0;
-	sm_move(&wal->entry->wtx_sm, WTX_BASE);
+	e->wal_cur = phys_incoming;
+	e->wal_cur_fixed_name = name_incoming;
+	e->wal_prev = phys_outgoing;
+	e->wal_prev_fixed_name = name_outgoing;
+	e->wal_cursor = 0;
+	sm_move(&e->wtx_sm, WTX_BASE);
 
 	/* Move the moving name. */
-	rv = unlink(wal->wal.moving_name);
+	rv = unlink(e->wal_moving_name);
 	if (rv != 0) {
 		return SQLITE_IOERR;
 	}
-	rv = link(name_incoming, wal->wal.moving_name);
+	rv = link(name_incoming, e->wal_moving_name);
 	if (rv != 0) {
 		return SQLITE_IOERR;
 	}
@@ -538,80 +483,73 @@ static int vfs2_wal_swap(struct vfs2_file *wal,
 	return SQLITE_OK;
 }
 
-static int vfs2_wal_write_frame_hdr(struct vfs2_file *wal,
+static int vfs2_wal_write_frame_hdr(struct entry *e,
 				    const void *buf,
 				    uint32_t x)
 {
-	x -= wal->wal.commit_end;
-
-	assert(x <= wal->wal.pending_txn_len);
-	uint32_t n = wal->wal.pending_txn_len;
-	dqlite_vfs_frame *frames = wal->wal.pending_txn_frames;
-	if (wal->wal.pending_txn_len == 0 && x == 0) {
+	dqlite_vfs_frame *frames = e->pending_txn_frames;
+	uint32_t n = e->pending_txn_len;
+	x -= e->pending_txn_start;
+	assert(x <= n);
+	if (e->pending_txn_len == 0 && x == 0) {
 		/* check that the WAL-index hdr makes sense and save it */
-		struct vfs2_db *db_shm = &wal->entry->db->db_shm;
-		struct vfs2_wal_index_basic_hdr hdr =
-		    get_full_hdr(db_shm)->basic[0];
+		struct wal_index_basic_hdr hdr = get_full_hdr(e)->basic[0];
 		assert(hdr.isInit != 0);
-		assert(hdr.mxFrame == wal->wal.commit_end);
-		db_shm->prev_txn_hdr = hdr;
+		assert(hdr.mxFrame == e->pending_txn_start);
+		e->prev_txn_hdr = hdr;
 	}
 	if (x == n) {
 		/* FIXME reallocating every time seems bad */
-		wal->wal.pending_txn_frames =
-		    sqlite3_realloc64(frames, (sqlite_uint64)sizeof(*frames) *
-						  (sqlite3_uint64)(n + 1));
-		if (wal->wal.pending_txn_frames == NULL) {
+		sqlite3_uint64 z = (sqlite3_uint64)sizeof(*frames) * (sqlite3_uint64)(n + 1);
+		e->pending_txn_frames = sqlite3_realloc64(frames, z);
+		if (e->pending_txn_frames == NULL) {
 			return SQLITE_NOMEM;
 		}
-		dqlite_vfs_frame *frame = &wal->wal.pending_txn_frames[n];
+		dqlite_vfs_frame *frame = &e->pending_txn_frames[n];
 		frame->page_number = ByteGetBe32(buf);
 		frame->data = NULL;
-		wal->wal.pending_txn_last_frame_commit =
+		e->pending_txn_last_frame_commit =
 		    ByteGetBe32((const uint8_t *)buf + 4);
-		wal->wal.pending_txn_len++;
+		e->pending_txn_len++;
 	} else {
 		/* Overwriting a previously-written frame in the current
 		 * transaction. */
-		dqlite_vfs_frame *frame = &wal->wal.pending_txn_frames[x];
+		dqlite_vfs_frame *frame = &e->pending_txn_frames[x];
 		frame->page_number = ByteGetBe32(buf);
 		sqlite3_free(frame->data);
 		frame->data = NULL;
 	}
-	sm_move(&wal->entry->wtx_sm, WTX_ACTIVE);
+	sm_move(&e->wtx_sm, WTX_ACTIVE);
 	return SQLITE_OK;
 }
 
-static int vfs2_wal_post_write(struct vfs2_file *wal,
+static int vfs2_wal_post_write(struct entry *e,
 			       const void *buf,
 			       int amt,
 			       sqlite3_int64 ofst)
 {
-
-	unsigned page_size = atomic_load(&wal->vfs_data->page_size);
-	uint32_t frame_size = VFS2_WAL_FRAME_HDR_SIZE + page_size;
+	uint32_t frame_size = VFS2_WAL_FRAME_HDR_SIZE + e->page_size;
 	if (amt == VFS2_WAL_FRAME_HDR_SIZE) {
 		sqlite3_int64 x =
-		    ofst - (sqlite3_int64)sizeof(struct vfs2_wal_hdr);
+		    ofst - (sqlite3_int64)sizeof(struct wal_hdr);
 		assert(x % frame_size == 0);
 		x /= frame_size;
-		return vfs2_wal_write_frame_hdr(wal, buf, (uint32_t)x);
-	} else if (amt == (int)page_size) {
+		return vfs2_wal_write_frame_hdr(e, buf, (uint32_t)x);
+	} else if (amt == (int)e->page_size) {
 		sqlite3_int64 x = ofst - VFS2_WAL_FRAME_HDR_SIZE -
-				  (sqlite3_int64)sizeof(struct vfs2_wal_hdr);
+				  (sqlite3_int64)sizeof(struct wal_hdr);
 		assert(x % frame_size == 0);
 		x /= frame_size;
-		x -= wal->wal.commit_end;
-		assert(0 <= x && x < wal->wal.pending_txn_len);
-		dqlite_vfs_frame *frame = &wal->wal.pending_txn_frames[x];
+		x -= e->pending_txn_start;
+		assert(0 <= x && x < e->pending_txn_len);
+		dqlite_vfs_frame *frame = &e->pending_txn_frames[x];
 		assert(frame->data == NULL);
 		frame->data = sqlite3_malloc(amt);
 		if (frame->data == NULL) {
 			return SQLITE_NOMEM;
 		}
 		memcpy(frame->data, buf, (size_t)amt);
-
-		sm_move(&wal->entry->wtx_sm, WTX_ACTIVE);
+		sm_move(&e->wtx_sm, WTX_ACTIVE);
 		return SQLITE_OK;
 	} else {
 		assert(0);
@@ -623,22 +561,27 @@ static int vfs2_write(sqlite3_file *file,
 		      int amt,
 		      sqlite3_int64 ofst)
 {
+	struct file *xfile = (struct file *)file;
 	int rv;
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
 
 	if ((xfile->flags & SQLITE_OPEN_WAL) && ofst == 0) {
-		assert(amt == sizeof(struct vfs2_wal_hdr));
-		return vfs2_wal_swap(xfile, buf);
+		assert(amt == sizeof(struct wal_hdr));
+		const struct wal_hdr *hdr = buf;
+		struct entry *e = xfile->entry;
+		e->page_size = ByteGetBe32(hdr->page_size);
+		return vfs2_wal_swap(e, hdr);
 	}
 
-	rv = xfile->orig->pMethods->xWrite(xfile->orig, buf, amt, ofst);
+	sqlite3_file *orig = get_orig(xfile);
+	rv = orig->pMethods->xWrite(orig, buf, amt, ofst);
 	if (rv != SQLITE_OK) {
 		return rv;
 	}
 
 	if (xfile->flags & SQLITE_OPEN_WAL) {
-		tracef("wrote to WAL name=%s amt=%d ofst=%lld", xfile->wal.wal_cur_fixed_name, amt, ofst);
-		return vfs2_wal_post_write(xfile, buf, amt, ofst);
+		struct entry *e = xfile->entry;
+		tracef("wrote to WAL name=%s amt=%d ofst=%lld", e->wal_cur_fixed_name, amt, ofst);
+		return vfs2_wal_post_write(e, buf, amt, ofst);
 	}
 
 	return SQLITE_OK;
@@ -646,59 +589,54 @@ static int vfs2_write(sqlite3_file *file,
 
 static int vfs2_truncate(sqlite3_file *file, sqlite3_int64 size)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xTruncate(xfile->orig, size);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xTruncate(orig, size);
 }
 
 static int vfs2_sync(sqlite3_file *file, int flags)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xSync(xfile->orig, flags);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xSync(orig, flags);
 }
 
 static int vfs2_file_size(sqlite3_file *file, sqlite3_int64 *size)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xFileSize(xfile->orig, size);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xFileSize(orig, size);
 }
 
 static int vfs2_lock(sqlite3_file *file, int mode)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xLock(xfile->orig, mode);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xLock(orig, mode);
 }
 
 static int vfs2_unlock(sqlite3_file *file, int mode)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xUnlock(xfile->orig, mode);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xUnlock(orig, mode);
 }
 
 static int vfs2_check_reserved_lock(sqlite3_file *file, int *out)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xCheckReservedLock(xfile->orig, out);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xCheckReservedLock(orig, out);
 }
 
-static int interpret_pragma(struct vfs2_file *f, char **args)
+static int interpret_pragma(char **args)
 {
 	char **e = &args[0];
 	char *left = args[1];
 	PRE(left != NULL);
 	char *right = args[2];
 
-	if (strcmp(left, "page_size") == 0 && right != NULL) {
-		char *end;
-		unsigned long z = strtoul(right, &end, 10);
-		if (*end == '\0' && is_valid_page_size(z)) {
-			unsigned expected = 0;
-			atomic_uint *page_size = &f->vfs_data->page_size;
-			if (!atomic_compare_exchange_strong(page_size, &expected, (unsigned)z) && expected != z) {
-				*e = sqlite3_mprintf("can't modify page size once set");
-				return SQLITE_ERROR;
-			}
-		}
-	} else if (strcmp(left, "journal_mode") == 0 && right != NULL && strcasecmp(right, "wal") != 0) {
+	if (strcmp(left, "journal_mode") == 0 && right != NULL && strcasecmp(right, "wal") != 0) {
 		*e = sqlite3_mprintf("dqlite requires WAL mode");
 		return SQLITE_ERROR;
 	}
@@ -708,46 +646,49 @@ static int interpret_pragma(struct vfs2_file *f, char **args)
 
 static int vfs2_file_control(sqlite3_file *file, int op, void *arg)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
+	struct file *xfile = (struct file *)file;
 	PRE(xfile->flags & SQLITE_OPEN_MAIN_DB);
+	struct entry *e = xfile->entry;
 	int rv;
 
-	if (op == SQLITE_FCNTL_COMMIT_PHASETWO && xfile->entry->wal != NULL && xfile->entry->wal->wal.pending_txn_len != 0) {
+	if (op == SQLITE_FCNTL_COMMIT_PHASETWO && e->pending_txn_len != 0) {
 		/* Hide the transaction that was just written by resetting
 		 * the WAL index header. */
-		struct vfs2_wal_index_full_hdr *hdr =
-		    get_full_hdr(&xfile->db_shm);
-		xfile->db_shm.pending_txn_hdr = hdr->basic[0];
-		hdr->basic[0] = xfile->db_shm.prev_txn_hdr;
+		struct wal_index_full_hdr *hdr = get_full_hdr(e);
+		e->pending_txn_hdr = hdr->basic[0];
+		hdr->basic[0] = e->prev_txn_hdr;
 		hdr->basic[1] = hdr->basic[0];
 		sm_move(&xfile->entry->wtx_sm, WTX_HIDDEN);
 	} else if (op == SQLITE_FCNTL_PRAGMA) {
-		rv = interpret_pragma(xfile, arg);
+		rv = interpret_pragma(arg);
 		if (rv != SQLITE_NOTFOUND) {
 			return rv;
 		}
 	} else if (op == SQLITE_FCNTL_PERSIST_WAL) {
-		// XXX handle setting as well as getting?
+		/* TODO handle setting as well as getting (?) */
 		int *out = arg;
 		*out = 1;
 		return SQLITE_OK;
 	}
 
-	rv = xfile->orig->pMethods->xFileControl(xfile->orig, op, arg);
+	sqlite3_file *orig = get_orig(xfile);
+	rv = orig->pMethods->xFileControl(orig, op, arg);
 	assert(ERGO(op == SQLITE_FCNTL_PRAGMA, rv == SQLITE_NOTFOUND));
 	return rv;
 }
 
 static int vfs2_sector_size(sqlite3_file *file)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xSectorSize(xfile->orig);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xSectorSize(orig);
 }
 
 static int vfs2_device_characteristics(sqlite3_file *file)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xDeviceCharacteristics(xfile->orig);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xDeviceCharacteristics(orig);
 }
 
 static int vfs2_fetch(sqlite3_file *file,
@@ -755,67 +696,58 @@ static int vfs2_fetch(sqlite3_file *file,
 		      int amt,
 		      void **out)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xFetch(xfile->orig, ofst, amt, out);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xFetch(orig, ofst, amt, out);
 }
 
 static int vfs2_unfetch(sqlite3_file *file, sqlite3_int64 ofst, void *buf)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	return xfile->orig->pMethods->xUnfetch(xfile->orig, ofst, buf);
+	struct file *xfile = (struct file *)file;
+	sqlite3_file *orig = get_orig(xfile);
+	return orig->pMethods->xUnfetch(orig, ofst, buf);
 }
 
 static int vfs2_shm_map(sqlite3_file *file,
-			int pgno,
-			int pgsz,
+			int regno,
+			int regsz,
 			int extend,
 			void volatile **out)
 {
-	tracef("vfs2_shm_map(%p, %d, %d, %d, %p)", file, pgno, pgsz, extend,
-	       out);
-	int rv;
+	struct file *xfile = (struct file *)file;
+	struct entry *e = xfile->entry;
 	void *region;
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
+	int rv;
 
-	if (xfile->db_shm.regions != NULL && pgno < xfile->db_shm.regions_len) {
-		region = xfile->db_shm.regions[pgno];
+	if (e->shm_regions != NULL && regno < e->shm_regions_len) {
+		region = e->shm_regions[regno];
 		assert(region != NULL);
-	} else if (extend) {
-		void **regions;
-
-		assert(pgsz == VFS2_WAL_INDEX_REGION_SIZE);
-		assert(pgno == xfile->db_shm.regions_len);
-		region = sqlite3_malloc(pgsz);
+	} else if (extend != 0) {
+		assert(regno == e->shm_regions_len);
+		region = sqlite3_malloc(regsz);
 		if (region == NULL) {
 			rv = SQLITE_NOMEM;
 			goto err;
 		}
-
-		memset(region, 0, (size_t)pgsz);
-
+		memset(region, 0, (size_t)regsz);
 		/* FIXME reallocating every time seems bad */
-		regions = sqlite3_realloc64(
-		    xfile->db_shm.regions,
-		    (sqlite3_uint64)sizeof(*xfile->db_shm.regions) *
-			(sqlite3_uint64)(xfile->db_shm.regions_len + 1));
+		sqlite3_uint64 z = (sqlite3_uint64)sizeof(*e->shm_regions) * (sqlite3_uint64)(e->shm_regions_len + 1);
+		void **regions = sqlite3_realloc64(e->shm_regions, z);
 		if (regions == NULL) {
 			rv = SQLITE_NOMEM;
 			goto err_after_region_malloc;
 		}
-
-		xfile->db_shm.regions = regions;
-		xfile->db_shm.regions[pgno] = region;
-		xfile->db_shm.regions_len++;
+		e->shm_regions = regions;
+		e->shm_regions[regno] = region;
+		e->shm_regions_len++;
 	} else {
 		region = NULL;
 	}
 
 	*out = region;
-
-	if (pgno == 0 && region != NULL) {
-		xfile->db_shm.refcount++;
+	if (regno == 0 && region != NULL) {
+		e->shm_refcount++;
 	}
-
 	return SQLITE_OK;
 
 err_after_region_malloc:
@@ -828,7 +760,8 @@ err:
 
 static int vfs2_shm_lock(sqlite3_file *file, int ofst, int n, int flags)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
+	struct file *xfile = (struct file *)file;
+	struct entry *e = xfile->entry;
 
 	assert(file != NULL);
 	assert(ofst >= 0);
@@ -845,64 +778,58 @@ static int vfs2_shm_lock(sqlite3_file *file, int ofst, int n, int flags)
 
 	assert(xfile->flags & SQLITE_OPEN_MAIN_DB);
 
-	unsigned *locks = xfile->db_shm.locks;
 	if (flags == (SQLITE_SHM_LOCK | SQLITE_SHM_SHARED)) {
 		for (int i = ofst; i < ofst + n; i++) {
-			if (locks[i] == VFS2_EXCLUSIVE) {
+			if (e->shm_locks[i] == VFS2_EXCLUSIVE) {
 				return SQLITE_BUSY;
 			}
 		}
 
 		for (int i = ofst; i < ofst + n; i++) {
-			locks[i]++;
+			e->shm_locks[i]++;
 		}
 	} else if (flags == (SQLITE_SHM_LOCK | SQLITE_SHM_EXCLUSIVE)) {
 		for (int i = ofst; i < ofst + n; i++) {
-			if (locks[i] > 0) {
+			if (e->shm_locks[i] > 0) {
 				return SQLITE_BUSY;
 			}
 		}
 
 		for (int i = ofst; i < ofst + n; i++) {
-			locks[i] = VFS2_EXCLUSIVE;
+			e->shm_locks[i] = VFS2_EXCLUSIVE;
 		}
 
 		/* XXX maybe this shouldn't be an assertion */
 		if (ofst == VFS2_SHM_WRITE_LOCK) {
 			assert(n == 1);
-			struct vfs2_file *wal = xfile->entry->wal;
-			assert(wal->wal.pending_txn_len == 0);
+			assert(e->pending_txn_len == 0);
 		}
 	} else if (flags == (SQLITE_SHM_UNLOCK | SQLITE_SHM_SHARED)) {
 		for (int i = ofst; i < ofst + n; i++) {
-			assert(locks[i] > 0);
-			locks[i]--;
+			assert(e->shm_locks[i] > 0);
+			e->shm_locks[i]--;
 		}
 	} else if (flags == (SQLITE_SHM_UNLOCK | SQLITE_SHM_EXCLUSIVE)) {
 		for (int i = ofst; i < ofst + n; i++) {
-			assert(locks[i] == VFS2_EXCLUSIVE);
-			locks[i] = 0;
+			assert(e->shm_locks[i] == VFS2_EXCLUSIVE);
+			e->shm_locks[i] = 0;
 		}
 
 		/* Unlocking the write lock: roll back any uncommitted
 		 * transaction. */
 		if (ofst == VFS2_SHM_WRITE_LOCK) {
 			assert(n == 1);
-			struct vfs2_file *wal = xfile->entry->wal;
-
-			if (wal->wal.pending_txn_len > 0 &&
-			    wal->wal.pending_txn_last_frame_commit == 0) {
-				for (uint32_t i = 0;
-				     i < wal->wal.pending_txn_len; i++) {
-					sqlite3_free(
-					    wal->wal.pending_txn_frames[i]
-						.data);
+			dqlite_vfs_frame *frames = e->pending_txn_frames;
+			uint32_t len = e->pending_txn_len;
+			if (len > 0 && e->pending_txn_last_frame_commit == 0) {
+				for (uint32_t i = 0; i < len; i++) {
+					sqlite3_free(frames[i].data);
 				}
-				sqlite3_free(wal->wal.pending_txn_frames);
-				wal->wal.pending_txn_frames = NULL;
-				wal->wal.pending_txn_len = 0;
-				wal->wal.pending_txn_last_frame_commit = 0;
-				sm_move(&wal->entry->wtx_sm, WTX_BASE);
+				sqlite3_free(frames);
+				e->pending_txn_frames = NULL;
+				e->pending_txn_len = 0;
+				e->pending_txn_last_frame_commit = 0;
+				sm_move(&e->wtx_sm, WTX_BASE);
 			}
 		}
 	} else {
@@ -920,24 +847,23 @@ static void vfs2_shm_barrier(sqlite3_file *file)
 static int vfs2_shm_unmap(sqlite3_file *file, int delete)
 {
 	(void)delete;
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	xfile->db_shm.refcount--;
-	if (xfile->db_shm.refcount == 0) {
-		for (int i = 0; i < xfile->db_shm.regions_len; i++) {
-			void *region = xfile->db_shm.regions[i];
+	struct file *xfile = (struct file *)file;
+	struct entry *e = xfile->entry;
+	e->shm_refcount--;
+	if (e->shm_refcount == 0) {
+		for (int i = 0; i < e->shm_regions_len; i++) {
+			void *region = e->shm_regions[i];
 			assert(region != NULL);
 			sqlite3_free(region);
 		}
-		sqlite3_free(xfile->db_shm.regions);
+		sqlite3_free(e->shm_regions);
 
-		xfile->db_shm.regions = NULL;
-		xfile->db_shm.regions_len = 0;
-		memset(xfile->db_shm.locks, 0, sizeof(xfile->db_shm.locks));
+		e->shm_regions = NULL;
+		e->shm_regions_len = 0;
+		memset(e->shm_locks, 0, sizeof(e->shm_locks));
 	}
 	return SQLITE_OK;
 }
-
-/* sqlite3_io_methods implementations end here */
 
 static struct sqlite3_io_methods vfs2_io_methods = {
 	.iVersion = 3,
@@ -961,10 +887,8 @@ static struct sqlite3_io_methods vfs2_io_methods = {
 	.xUnfetch = vfs2_unfetch
 };
 
-/* sqlite3_vfs implementations begin here */
-
-static int compare_wal_headers(struct vfs2_wal_hdr a,
-			       struct vfs2_wal_hdr b,
+static int compare_wal_headers(struct wal_hdr a,
+			       struct wal_hdr b,
 			       bool *ordered)
 {
 	if (get_salt1(a.salts) == get_salt1(b.salts) + 1) {
@@ -977,104 +901,100 @@ static int compare_wal_headers(struct vfs2_wal_hdr a,
 	return SQLITE_OK;
 }
 
-static int vfs2_open_wal(sqlite3_vfs *vfs,
-			 const char *name,
-			 struct vfs2_file *xout,
-			 int flags,
-			 int *out_flags)
+static int read_wal_hdr(sqlite3_file *wal, sqlite3_int64 *size, struct wal_hdr *hdr)
 {
 	int rv;
-	struct vfs2_data *data = vfs->pAppData;
 
-	const char *dash = strrchr(name, '-');
-	assert(dash != NULL);
-	static_assert(
-	    sizeof(VFS2_WAL_FIXED_SUFFIX1) == sizeof(VFS2_WAL_FIXED_SUFFIX2),
-	    "uneven WAL suffixes");
-	if ((size_t)(dash - name) + strlen(VFS2_WAL_FIXED_SUFFIX1) >
-	    (size_t)data->orig->mxPathname) {
-		return SQLITE_ERROR;
+	rv = wal->pMethods->xFileSize(wal, size);
+	if (rv != SQLITE_OK) {
+		return rv;
 	}
+	if (*size >= (sqlite3_int64)sizeof(struct wal_hdr)) {
+		rv = wal->pMethods->xRead(wal, hdr, sizeof(*hdr), 0);
+		if (rv != SQLITE_OK) {
+			return rv;
+		}
+	}
+	return SQLITE_OK;
+}
 
-	/* Collect memory allocations in one place to simplify the control
-	 * flow. A small amount of memory will be leaked if one of the later
-	 * allocations fails. */
-	char *fixed1 = sqlite3_malloc(data->orig->mxPathname + 1);
-	char *fixed2 = sqlite3_malloc(data->orig->mxPathname + 1);
-	sqlite3_file *phys1 = sqlite3_malloc(data->orig->szOsFile);
-	sqlite3_file *phys2 = sqlite3_malloc(data->orig->szOsFile);
-	if (fixed1 == NULL || fixed2 == NULL || phys1 == NULL ||
-	    phys2 == NULL) {
+static int open_entry(struct common *common, const char *name, struct entry *e)
+{
+	sqlite3_vfs *v = common->orig;
+	int path_cap = v->mxPathname + 1;
+	int file_cap = v->szOsFile;
+	int rv;
+
+	*e = (struct entry){};
+	e->common = common;
+	e->main_db_name = sqlite3_malloc(path_cap);
+	if (e->main_db_name == NULL) {
 		return SQLITE_NOMEM;
 	}
-	xout->wal.wal_cur_fixed_name = fixed1;
-	xout->wal.wal_prev_fixed_name = fixed2;
-	memset(phys1, 0, (size_t)data->orig->szOsFile);
-	xout->orig = phys1;
-	memset(phys2, 0, (size_t)data->orig->szOsFile);
-	xout->wal.wal_prev = phys2;
-	xout->wal.moving_name = name;
+	strcpy(e->main_db_name, name);
 
-	/* Open the two physical WALs. */
-	strncpy(fixed1, name, (size_t)(dash - name));
-	fixed1[dash - name] = '\0';
-	strcat(fixed1, VFS2_WAL_FIXED_SUFFIX1);
-	int out_flags1;
-	rv = data->orig->xOpen(data->orig, fixed1, phys1, flags, &out_flags1);
+	e->wal_moving_name = sqlite3_malloc(path_cap);
+	if (e->wal_moving_name == NULL) {
+		return SQLITE_NOMEM;
+	}
+	strcpy(e->wal_moving_name, name);
+	strcat(e->wal_moving_name, "-wal");
+
+	e->wal_cur_fixed_name = sqlite3_malloc(path_cap);
+	if (e->wal_cur_fixed_name == NULL) {
+		return SQLITE_NOMEM;
+	}
+	strcpy(e->wal_cur_fixed_name, name);
+	strcat(e->wal_cur_fixed_name, "-xwal1");
+
+	e->wal_prev_fixed_name = sqlite3_malloc(path_cap);
+	if (e->wal_prev_fixed_name == NULL) {
+		return SQLITE_NOMEM;
+	}
+	strcpy(e->wal_prev_fixed_name, name);
+	strcat(e->wal_prev_fixed_name, "-xwal2");
+
+	/* TODO more flags here? */
+	int phys_wal_flags = SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_WAL|SQLITE_OPEN_NOFOLLOW|SQLITE_OPEN_EXRESCODE;
+
+	e->wal_cur = sqlite3_malloc(file_cap);
+	if (e->wal_cur == NULL) {
+		return SQLITE_NOMEM;
+	}
+	rv = v->xOpen(v, e->wal_cur_fixed_name, e->wal_cur, phys_wal_flags, NULL);
 	if (rv != SQLITE_OK) {
 		return rv;
 	}
-	strncpy(fixed2, name, (size_t)(dash - name));
-	fixed2[dash - name] = '\0';
-	strcat(fixed2, VFS2_WAL_FIXED_SUFFIX2);
-	int out_flags2;
-	rv = data->orig->xOpen(data->orig, fixed2, phys2, flags, &out_flags2);
+
+	e->wal_prev = sqlite3_malloc(file_cap);
+	if (e->wal_prev == NULL) {
+		return SQLITE_NOMEM;
+	}
+	rv = v->xOpen(v, e->wal_prev_fixed_name, e->wal_prev, phys_wal_flags, NULL);
 	if (rv != SQLITE_OK) {
 		return rv;
 	}
 
-	/* Determine the relationship between the two physical WALs. */
 	sqlite3_int64 size1;
-	rv = phys1->pMethods->xFileSize(phys1, &size1);
+	struct wal_hdr hdr1;
+	rv = read_wal_hdr(e->wal_cur, &size1, &hdr1);
 	if (rv != SQLITE_OK) {
 		return rv;
-	}
-	if (size1 < (sqlite3_int64)sizeof(struct vfs2_wal_hdr)) {
-		size1 = 0;
 	}
 	sqlite3_int64 size2;
-	rv = phys2->pMethods->xFileSize(phys2, &size2);
+	struct wal_hdr hdr2;
+	rv = read_wal_hdr(e->wal_prev, &size2, &hdr2);
 	if (rv != SQLITE_OK) {
 		return rv;
 	}
-	if (size2 < (sqlite3_int64)sizeof(struct vfs2_wal_hdr)) {
-		size2 = 0;
-	}
 
-	struct vfs2_wal_hdr hdr1 = { 0 };
-	if (size1 > 0) {
-		rv = phys1->pMethods->xRead(phys1, &hdr1, sizeof(hdr1), 0);
-		if (rv != SQLITE_OK) {
-			return rv;
-		}
-	}
-	struct vfs2_wal_hdr hdr2 = { 0 };
-	if (size2 > 0) {
-		rv = phys2->pMethods->xRead(phys2, &hdr2, sizeof(hdr2), 0);
-		if (rv != SQLITE_OK) {
-			return rv;
-		}
-	}
-
-	struct vfs2_wal_hdr hdr_cur = { 0 };
-	struct vfs2_wal_hdr hdr_prev = { 0 };
-	sqlite3_int64 size_cur = 0;
-	sqlite3_int64 size_prev = 0;
+	struct wal_hdr hdr_cur = hdr1;
+	sqlite3_int64 size_cur = size1;
 
 	bool wal1_is_fresh;
-	if (size2 == 0) {
+	if (size2 < (sqlite3_int64)sizeof(struct wal_hdr)) {
 		wal1_is_fresh = true;
-	} else if (size1 == 0) {
+	} else if (size1 < (sqlite3_int64)sizeof(struct wal_hdr)) {
 		wal1_is_fresh = false;
 	} else {
 		rv = compare_wal_headers(hdr1, hdr2, &wal1_is_fresh);
@@ -1082,172 +1002,80 @@ static int vfs2_open_wal(sqlite3_vfs *vfs,
 			return rv;
 		}
 	}
-	if (wal1_is_fresh) {
-		rv = unlink(name);
-		(void)rv;
-		rv = link(fixed1, name);
-		(void)rv;
+	if (!wal1_is_fresh) {
+		void *temp;
 
-		hdr_prev = hdr2;
-		size_prev = size2;
-		hdr_cur = hdr1;
-		size_cur = size1;
+		temp = e->wal_cur;
+		e->wal_cur = e->wal_prev;
+		e->wal_prev = temp;
 
-		if (out_flags != NULL) {
-			*out_flags = out_flags1;
-		}
-	} else {
-		rv = unlink(name);
-		(void)rv;
-		rv = link(fixed2, name);
-		(void)rv;
+		temp = e->wal_cur_fixed_name;
+		e->wal_cur_fixed_name = e->wal_prev_fixed_name;
+		e->wal_prev_fixed_name = temp;
 
-		xout->orig = phys2;
-		xout->wal.moving_name = name;
-		xout->wal.wal_cur_fixed_name = fixed2;
-		xout->wal.wal_prev = phys1;
-		xout->wal.wal_prev_fixed_name = fixed1;
-
-		hdr_prev = hdr1;
-		size_prev = size1;
 		hdr_cur = hdr2;
 		size_cur = size2;
-
-		if (out_flags != NULL) {
-			*out_flags = out_flags2;
-		}
 	}
 
-	rv = check_wal_integrity(xout->wal.wal_prev);
-	if (rv != SQLITE_OK) {
-		return rv;
-	}
+	rv = unlink(e->wal_moving_name);
+	(void)rv;
+	rv = link(e->wal_cur_fixed_name, e->wal_moving_name);
+	(void)rv;
 
-	struct vfs2_wal_slice limit = xout->entry->wal_limit;
-	if (size1 > 0 && size2 > 0 && limit.len > 0) {
-		uint32_t page_size = ByteGetBe32(hdr_cur.page_size);
-		assert(ByteGetBe32(hdr_prev.page_size) == page_size);
-		sqlite3_int64 implied_size =
-		    (sqlite3_int64)sizeof(struct vfs2_wal_hdr) +
-		    (sqlite3_int64)(VFS2_WAL_FRAME_HDR_SIZE + page_size) *
-			(sqlite3_int64)(limit.start + limit.len);
-
-		if (salts_equal(limit.salts, hdr_prev.salts)) {
-			if (size_prev != implied_size) {
-				return SQLITE_ERROR;
-			}
-			rv = xout->orig->pMethods->xTruncate(
-			    xout->orig, sizeof(struct vfs2_wal_hdr));
-			if (rv != SQLITE_OK) {
-				return rv;
-			}
-			xout->wal.commit_end = 0;
-		} else if (salts_equal(limit.salts, hdr_cur.salts)) {
-			if (size_cur < implied_size) {
-				return SQLITE_ERROR;
-			}
-			rv = xout->orig->pMethods->xTruncate(xout->orig,
-							     implied_size);
-			if (rv != SQLITE_OK) {
-				return rv;
-			}
-			xout->wal.commit_end = limit.start + limit.len;
-		} else {
-			return SQLITE_ERROR;
-		}
-	} else {
-		xout->wal.commit_end = 0;
+	if (size_cur >= (sqlite3_int64)sizeof(struct wal_hdr)) {
+		e->page_size = ByteGetBe32(hdr_cur.page_size);
 	}
+	
+	/* TODO sm_init with the appropriate state */
+	(void)wtx_states;
+	(void)wtx_invariant;
 
-	xout->entry->wal = xout;
-	if (size_cur > 0) {
-		uint32_t z = ByteGetBe32(hdr_cur.page_size);
-		assert(z > 0);
-		atomic_store(&data->page_size, z);
-		sm_move(&xout->entry->wtx_sm, WTX_BASE);
-	} else {
-		sm_move(&xout->entry->wtx_sm, WTX_EMPTY);
-	}
-	tracef("opened WAL cur=%s prev=%s", xout->wal.wal_cur_fixed_name, xout->wal.wal_prev_fixed_name);
 	return SQLITE_OK;
 }
 
-static int vfs2_open_db(sqlite3_vfs *vfs,
-			const char *name,
-			struct vfs2_file *xout,
-			int flags,
-			int *out_flags)
-{
-	int rv;
-	struct vfs2_data *data = vfs->pAppData;
-
-	xout->orig = sqlite3_malloc(data->orig->szOsFile);
-	if (xout->orig == NULL) {
-		return SQLITE_NOMEM;
-	}
-	memset(xout->orig, 0, (size_t)data->orig->szOsFile);
-	rv = data->orig->xOpen(data->orig, name, xout->orig, flags, out_flags);
-	if (rv != SQLITE_OK) {
-		return rv;
-	}
-
-	xout->db_shm.name = name;
-	xout->db_shm.regions = NULL;
-	xout->db_shm.regions_len = 0;
-	xout->db_shm.refcount = 0;
-	memset(xout->db_shm.locks, 0, sizeof(xout->db_shm.locks));
-	xout->entry->db = xout;
-	return SQLITE_OK;
-}
-
-static struct vfs2_db_entry *get_or_create_entry(struct vfs2_data *data,
-						 const char *name,
-						 int flags)
+static int set_up_entry(struct common *common, const char *name, int flags, int *out_flags, struct entry **e)
 {
 	bool name_is_db = (flags & SQLITE_OPEN_MAIN_DB) != 0;
 	bool name_is_wal = (flags & SQLITE_OPEN_WAL) != 0;
 	assert(name_is_db ^ name_is_wal);
-	const char *dash = strrchr(name, '-');
-	assert(ERGO(name_is_wal, dash != NULL));
+	int rv;
 
-	struct vfs2_db_entry *res = NULL;
-	pthread_rwlock_rdlock(&data->rwlock);
+	struct entry *res = NULL;
+	pthread_rwlock_rdlock(&common->rwlock);
 	queue *q;
-	QUEUE_FOREACH(q, &data->queue)
+	QUEUE_FOREACH(q, &common->queue)
 	{
-		struct vfs2_db_entry *cur =
-		    QUEUE_DATA(q, struct vfs2_db_entry, link);
-		if ((name_is_db && strcmp(cur->db_name, name) == 0) ||
-		    (name_is_wal && strncmp(cur->db_name, name, (size_t)(dash - name)) == 0)) {
+		struct entry *cur = QUEUE_DATA(q, struct entry, link);
+		if ((name_is_db && strcmp(cur->main_db_name, name) == 0) ||
+		    (name_is_wal && strcmp(cur->wal_moving_name, name) == 0)) {
 			res = cur;
 			break;
 		}
 	}
-	pthread_rwlock_unlock(&data->rwlock);
+	pthread_rwlock_unlock(&common->rwlock);
 	if (res != NULL) {
-		return res;
+		unsigned *count = name_is_db ? &res->refcount_main_db : &res->refcount_wal;
+		*count += 1;
+		sqlite3_free(*e);
+		*e = res;
+		/* TODO set out_flags if this is a WAL */
+		(void)out_flags;
+		return SQLITE_OK;
 	}
 
-	res = sqlite3_malloc(sizeof(*res));
-	if (res == NULL) {
-		return NULL;
-	}
-	memset(res, 0, sizeof(*res));
-	size_t len = name_is_db ? strlen(name) : (size_t)(dash - name);
-	res->db_name = sqlite3_malloc((int)len + 1);
-	if (res->db_name == NULL) {
+	assert(name_is_db);
+	res = *e;
+	rv = open_entry(common, name, res);
+	if (rv != SQLITE_OK) {
 		sqlite3_free(res);
-		return NULL;
+		*e = NULL;
+		return rv;
 	}
-	memcpy(res->db_name, name, len);
-	res->db_name[len] = '\0';
-
-	sm_init(&res->wtx_sm, wtx_invariant, NULL, wtx_states, WTX_NOT_OPEN);
-
-	pthread_rwlock_wrlock(&data->rwlock);
-	queue_insert_tail(&data->queue, &res->link);
-	pthread_rwlock_unlock(&data->rwlock);
-	return res;
+	res->refcount_main_db = 1;
+	pthread_rwlock_wrlock(&common->rwlock);
+	queue_insert_tail(&common->queue, &res->link);
+	pthread_rwlock_unlock(&common->rwlock);
+	return SQLITE_OK;
 }
 
 static int vfs2_open(sqlite3_vfs *vfs,
@@ -1256,53 +1084,51 @@ static int vfs2_open(sqlite3_vfs *vfs,
 		     int flags,
 		     int *out_flags)
 {
-	struct vfs2_file *xout = (struct vfs2_file *)out;
-	struct vfs2_data *data = vfs->pAppData;
-	memset(xout, 0, sizeof(*xout));
+	struct file *xout = (struct file *)out;
+	struct common *common = vfs->pAppData;
+	int rv;
+
+	*xout = (struct file){};
 	xout->base.pMethods = &vfs2_io_methods;
 	xout->flags = flags;
-	xout->vfs_data = data;
 
-	if (flags & SQLITE_OPEN_WAL) {
-		struct vfs2_db_entry *entry =
-		    get_or_create_entry(data, name, flags);
-		if (entry == NULL) {
-			return SQLITE_NOMEM;
-		}
-		assert(entry->wal == NULL);
-		xout->entry = entry;
-		int rv = vfs2_open_wal(vfs, name, xout, flags, out_flags);
-		return rv;
-	} else if (flags & SQLITE_OPEN_MAIN_DB) {
-		struct vfs2_db_entry *entry =
-		    get_or_create_entry(data, name, flags);
-		if (entry == NULL) {
-			return SQLITE_NOMEM;
-		}
-		assert(entry->db == NULL);
-		xout->entry = entry;
-		return vfs2_open_db(vfs, name, xout, flags, out_flags);
-	} else {
-		xout->orig = sqlite3_malloc(data->orig->szOsFile);
+	if ((flags & SQLITE_OPEN_WAL) == 0) {
+		sqlite3_vfs *v = common->orig;
+		xout->orig = sqlite3_malloc(v->szOsFile);
 		if (xout->orig == NULL) {
 			return SQLITE_NOMEM;
 		}
-		return data->orig->xOpen(data->orig, name, xout->orig, flags,
-					 out_flags);
+		rv = v->xOpen(v, name, xout->orig, flags, out_flags);
+		if (rv != SQLITE_OK) {
+			return rv;
+		}
 	}
+
+	if (flags & (SQLITE_OPEN_MAIN_DB|SQLITE_OPEN_WAL)) {
+		xout->entry = sqlite3_malloc(sizeof(*xout->entry));
+		if (xout->entry == NULL) {
+			return SQLITE_NOMEM;
+		}
+		rv = set_up_entry(common, name, flags, out_flags, &xout->entry);
+		if (rv != SQLITE_OK) {
+			return rv;
+		}
+	}
+
+	return SQLITE_OK;
 }
 
 /* TODO does this need to be customized? */
 static int vfs2_delete(sqlite3_vfs *vfs, const char *name, int sync_dir)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xDelete(data->orig, name, sync_dir);
 }
 
 /* TODO does this need to be customized? */
 static int vfs2_access(sqlite3_vfs *vfs, const char *name, int flags, int *out)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xAccess(data->orig, name, flags, out);
 }
 
@@ -1311,50 +1137,50 @@ static int vfs2_full_pathname(sqlite3_vfs *vfs,
 			      int n,
 			      char *out)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xFullPathname(data->orig, name, n, out);
 }
 
 static void *vfs2_dl_open(sqlite3_vfs *vfs, const char *filename)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xDlOpen(data->orig, filename);
 }
 
 static void vfs2_dl_error(sqlite3_vfs *vfs, int n, char *msg)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xDlError(data->orig, n, msg);
 }
 
 typedef void (*vfs2_sym)(void);
 static vfs2_sym vfs2_dl_sym(sqlite3_vfs *vfs, void *dl, const char *symbol)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xDlSym(data->orig, dl, symbol);
 }
 
 static void vfs2_dl_close(sqlite3_vfs *vfs, void *dl)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xDlClose(data->orig, dl);
 }
 
 static int vfs2_randomness(sqlite3_vfs *vfs, int n, char *out)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xRandomness(data->orig, n, out);
 }
 
 static int vfs2_sleep(sqlite3_vfs *vfs, int microseconds)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xSleep(data->orig, microseconds);
 }
 
 static int vfs2_current_time(sqlite3_vfs *vfs, double *out)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xCurrentTime(data->orig, out);
 }
 
@@ -1362,13 +1188,13 @@ static int vfs2_current_time(sqlite3_vfs *vfs, double *out)
  * base VFS) */
 static int vfs2_get_last_error(sqlite3_vfs *vfs, int n, char *out)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	return data->orig->xGetLastError(data->orig, n, out);
 }
 
 static int vfs2_current_time_int64(sqlite3_vfs *vfs, sqlite3_int64 *out)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	if (data->orig->iVersion < 2) {
 		return SQLITE_ERROR;
 	}
@@ -1377,25 +1203,21 @@ static int vfs2_current_time_int64(sqlite3_vfs *vfs, sqlite3_int64 *out)
 
 /* sqlite3_vfs implementations end here */
 
-sqlite3_vfs *vfs2_make(sqlite3_vfs *orig, const char *name, unsigned page_size)
+sqlite3_vfs *vfs2_make(sqlite3_vfs *orig, const char *name)
 {
-	if (page_size != 0 && !is_valid_page_size(page_size)) {
-		return NULL;
-	}
-	struct vfs2_data *data = sqlite3_malloc(sizeof(*data));
+	struct common *common = sqlite3_malloc(sizeof(*common));
 	struct sqlite3_vfs *vfs = sqlite3_malloc(sizeof(*vfs));
-	if (data == NULL || vfs == NULL) {
+	if (common == NULL || vfs == NULL) {
 		return NULL;
 	}
-	data->orig = orig;
-	pthread_rwlock_init(&data->rwlock, NULL);
-	atomic_init(&data->page_size, page_size);
-	queue_init(&data->queue);
+	common->orig = orig;
+	pthread_rwlock_init(&common->rwlock, NULL);
+	queue_init(&common->queue);
 	vfs->iVersion = 2;
-	vfs->szOsFile = sizeof(struct vfs2_file);
+	vfs->szOsFile = sizeof(struct file);
 	vfs->mxPathname = orig->mxPathname;
 	vfs->zName = name;
-	vfs->pAppData = data;
+	vfs->pAppData = common;
 	vfs->xOpen = vfs2_open;
 	vfs->xDelete = vfs2_delete;
 	vfs->xAccess = vfs2_access;
@@ -1412,99 +1234,129 @@ sqlite3_vfs *vfs2_make(sqlite3_vfs *orig, const char *name, unsigned page_size)
 	return vfs;
 }
 
-/* XXX return codes */
-int vfs2_set_wal_limit(sqlite3_vfs *vfs,
-		       const char *name,
-		       struct vfs2_wal_slice sl)
+int vfs2_unapply_after(sqlite3_file *file, struct vfs2_wal_slice stop)
 {
-	struct vfs2_data *data = vfs->pAppData;
-	struct vfs2_db_entry *entry =
-	    get_or_create_entry(data, name, SQLITE_OPEN_MAIN_DB);
-	if (entry == NULL) {
+	/* TODO write lock stuff */
+	/* TODO ensure we're in the right state? */
+	/* TODO keep the wal-index header up to date (don't worry about the rest of the wal-index) */
+	PRE(stop.len > 0);
+	struct file *xfile = (struct file *)file;
+	PRE(xfile->flags & SQLITE_OPEN_MAIN_DB);
+	struct entry *e = xfile->entry;
+	int rv;
+
+	sqlite3_int64 size_cur;
+	struct wal_hdr hdr_cur;
+	rv = read_wal_hdr(e->wal_cur, &size_cur, &hdr_cur);
+	if (rv != SQLITE_OK) {
 		return 1;
 	}
-	/* If the WAL is already open then all is lost */
-	if (entry->wal != NULL) {
+	if (size_cur < (sqlite3_int64)sizeof(struct wal_hdr)) {
 		return 1;
 	}
-	entry->wal_limit = sl;
+
+	sqlite3_int64 size_prev;
+	struct wal_hdr hdr_prev;
+	rv = read_wal_hdr(e->wal_prev, &size_prev, &hdr_prev);
+	if (rv != SQLITE_OK) {
+		return 1;
+	}
+
+	sqlite3_int64 implied_size =
+	    (sqlite3_int64)sizeof(struct wal_hdr) +
+	    (sqlite3_int64)(VFS2_WAL_FRAME_HDR_SIZE + e->page_size) *
+	    (sqlite3_int64)(stop.start + stop.len);
+	if (salts_equal(stop.salts, hdr_cur.salts)) {
+		if (size_cur < implied_size) {
+			return 1;
+		}
+		e->wal_cursor = stop.start + stop.len;
+	} else if (size_prev < (sqlite3_int64)sizeof(struct wal_hdr)) {
+		return 1;
+	} else if (salts_equal(stop.salts, hdr_prev.salts)) {
+		if (size_prev != implied_size) {
+			return 1;
+		}
+	} else {
+		return 1;
+	}
+
 	return 0;
 }
 
-/* FIXME what return codes should this use? */
-int vfs2_commit(sqlite3_file *file, struct vfs2_wal_slice sl)
+int vfs2_commit(sqlite3_file *file, struct vfs2_wal_slice stop)
 {
-	(void)sl; /* XXX */
+	(void)stop; // XXX
+	/* TODO get this to support the follower side as well */
+	/* TODO (follower) if everything has been committed then release the write lock */
+	/* TODO (follower) keep the wal-index header up to date (don't worry about the rest of the wal-index) */
+	struct file *xfile = (struct file *)file;
+	PRE(xfile->flags & SQLITE_OPEN_MAIN_DB);
+	struct entry *e = xfile->entry;
+	if (e->shm_regions_len == 0) {
+		return 1;
+	}
+	if (e->shm_locks[VFS2_SHM_WRITE_LOCK] != VFS2_EXCLUSIVE) {
+		return 1;
+	}
+	e->shm_locks[VFS2_SHM_WRITE_LOCK] = 0;
 
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	if (!(xfile->flags & SQLITE_OPEN_MAIN_DB)) {
-		return 1;
-	}
-	struct vfs2_file *wal = xfile->entry->wal;
-	if (wal == NULL) {
-		return 1;
-	}
-	if (xfile->db_shm.regions_len == 0) {
-		return 1;
-	}
-	unsigned *locks = xfile->db_shm.locks;
-	if (locks[VFS2_SHM_WRITE_LOCK] != VFS2_EXCLUSIVE) {
-		return 1;
-	}
-	locks[VFS2_SHM_WRITE_LOCK] = 0;
-
-	union vfs2_shm_region0 *region0 = xfile->db_shm.regions[0];
-	region0->hdr.basic[0] = xfile->db_shm.pending_txn_hdr;
-	region0->hdr.basic[1] = xfile->db_shm.pending_txn_hdr;
-	xfile->db_shm.prev_txn_hdr = xfile->db_shm.pending_txn_hdr;
-	xfile->db_shm.pending_txn_hdr = (struct vfs2_wal_index_basic_hdr){};
-	wal->wal.commit_end += wal->wal.pending_txn_len;
-	wal->wal.pending_txn_len = 0;
-	wal->wal.pending_txn_last_frame_commit = 0;
+	struct wal_index_full_hdr *hdr = get_full_hdr(e);
+	hdr->basic[0] = e->pending_txn_hdr;
+	hdr->basic[1] = e->pending_txn_hdr;
+	e->prev_txn_hdr = e->pending_txn_hdr;
+	e->pending_txn_hdr = (struct wal_index_basic_hdr){};
+	/* XXX */
+	// commit_end += pending_txn_len;
+	e->pending_txn_len = 0;
+	e->pending_txn_last_frame_commit = 0;
 
 	sm_move(&xfile->entry->wtx_sm, WTX_BASE);
 
 	return 0;
 }
 
+int vfs2_commit_barrier(sqlite3_file *file)
+{
+	(void)file;
+	return 0;
+	/* TODO implement */
+	/* TODO release write lock */
+	/* TODO invalidate wal-index header to trigger a rebuild */
+}
+
 int vfs2_poll(sqlite3_file *file, dqlite_vfs_frame **frames, unsigned *n, struct vfs2_wal_slice *sl)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	if (!(xfile->flags & SQLITE_OPEN_MAIN_DB)) {
-		return 1;
-	}
-	struct vfs2_file *wal = xfile->entry->wal;
-	if (wal == NULL) {
-		return 1;
-	}
+	struct file *xfile = (struct file *)file;
+	PRE(xfile->flags & SQLITE_OPEN_WAL);
+	struct entry *e = xfile->entry;
 
-	uint32_t len = wal->wal.pending_txn_len;
+	uint32_t len = e->pending_txn_len;
 	if (len > 0) {
 		/* Don't go through vfs2_shm_lock here since that has additional
 		 * checks that assume the context of being called from inside
 		 * SQLite. */
-		unsigned *locks = xfile->db_shm.locks;
-		if (locks[VFS2_SHM_WRITE_LOCK] > 0) {
+		if (e->shm_locks[VFS2_SHM_WRITE_LOCK] > 0) {
 			return 1;
 		}
-		locks[VFS2_SHM_WRITE_LOCK] = VFS2_EXCLUSIVE;
+		e->shm_locks[VFS2_SHM_WRITE_LOCK] = VFS2_EXCLUSIVE;
 	}
 
 	if (n != NULL && frames != NULL) {
 		*n = len;
-		*frames = wal->wal.pending_txn_frames;
-	} else if (wal->wal.pending_txn_frames != NULL) {
+		*frames = e->pending_txn_frames;
+	} else if (e->pending_txn_frames != NULL) {
 		for (uint32_t i = 0; i < len; i++) {
-			sqlite3_free(wal->wal.pending_txn_frames[i].data);
+			sqlite3_free(e->pending_txn_frames[i].data);
 		}
-		sqlite3_free(wal->wal.pending_txn_frames);
+		sqlite3_free(e->pending_txn_frames);
 	}
-	wal->wal.pending_txn_frames = NULL;
+	e->pending_txn_frames = NULL;
 
 	if (sl != NULL) {
 		sl->len = len;
-		sl->salts = xfile->db_shm.pending_txn_hdr.salts;
-		sl->start = xfile->db_shm.prev_txn_hdr.mxFrame;
+		sl->salts = e->pending_txn_hdr.salts;
+		sl->start = e->prev_txn_hdr.mxFrame;
 		sl->len = len;
 	}
 
@@ -1515,43 +1367,37 @@ int vfs2_poll(sqlite3_file *file, dqlite_vfs_frame **frames, unsigned *n, struct
 
 void vfs2_destroy(sqlite3_vfs *vfs)
 {
-	struct vfs2_data *data = vfs->pAppData;
+	struct common *data = vfs->pAppData;
 	pthread_rwlock_destroy(&data->rwlock);
 	sqlite3_free(data);
 	sqlite3_free(vfs);
 }
 
-/* TODO maybe this should prophylactically truncate the WAL? */
 int vfs2_abort(sqlite3_file *file)
 {
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
-	if (!(xfile->flags & SQLITE_OPEN_MAIN_DB)) {
-		return 1;
-	}
-	struct vfs2_file *wal = xfile->entry->wal;
-	if (wal == NULL) {
-		return 1;
-	}
+	/* TODO maybe can "followerize" this and get rid of vfs2_unapply_after? */
+	struct file *xfile = (struct file *)file;
+	PRE(xfile->flags & SQLITE_OPEN_MAIN_DB);
+	struct entry *e = xfile->entry;
 
-	unsigned *locks = xfile->db_shm.locks;
-	locks[VFS2_SHM_WRITE_LOCK] = 0;
+	e->shm_locks[VFS2_SHM_WRITE_LOCK] = 0;
 
-	struct vfs2_wal_index_full_hdr *hdr = get_full_hdr(&xfile->db_shm);
-	hdr->basic[0] = xfile->db_shm.prev_txn_hdr;
-	hdr->basic[1] = xfile->db_shm.prev_txn_hdr;
-	xfile->db_shm.pending_txn_hdr = (struct vfs2_wal_index_basic_hdr){};
+	struct wal_index_full_hdr *hdr = get_full_hdr(e);
+	hdr->basic[0] = e->prev_txn_hdr;
+	hdr->basic[1] = e->prev_txn_hdr;
+	e->pending_txn_hdr = (struct wal_index_basic_hdr){};
 
-	dqlite_vfs_frame *frames = wal->wal.pending_txn_frames;
+	dqlite_vfs_frame *frames = e->pending_txn_frames;
 	if (frames != NULL) {
-		uint32_t n = wal->wal.pending_txn_len;
+		uint32_t n = e->pending_txn_len;
 		for (uint32_t i = 0; i < n; i++) {
 			sqlite3_free(frames[i].data);
 		}
 	}
 	sqlite3_free(frames);
-	wal->wal.pending_txn_frames = NULL;
-	wal->wal.pending_txn_len = 0;
-	wal->wal.pending_txn_last_frame_commit = 0;
+	e->pending_txn_frames = NULL;
+	e->pending_txn_len = 0;
+	e->pending_txn_last_frame_commit = 0;
 
 	sm_move(&xfile->entry->wtx_sm, WTX_BASE);
 	return 0;
@@ -1561,7 +1407,10 @@ int vfs2_read_wal(sqlite3_file *file,
 		  struct vfs2_wal_txn *txns,
 		  size_t txns_len)
 {
-	/* TODO */
+	/* TODO implement this */
+	/* TODO check_wal_integrity if this is the first time we're reading from
+	 * this (physical) WAL */
+	(void)check_wal_integrity;
 	(void)file;
 	(void)txns;
 	(void)txns_len;
@@ -1570,29 +1419,32 @@ int vfs2_read_wal(sqlite3_file *file,
 
 int vfs2_apply_uncommitted(sqlite3_file *file, const dqlite_vfs_frame *frames, unsigned len, struct vfs2_wal_slice *out)
 {
+	/* TODO implement this */
+	/* TODO acquire write lock if not held */
+	/* TODO keep the wal-index header up to date (don't worry about the rest of the wal-index) */
 	(void)file;
 	(void)frames;
 	(void)len;
 	(void)out;
 	/*
-	struct vfs2_file *xfile = (struct vfs2_file *)file;
+	struct file *xfile = (struct file *)file;
 	if (!(xfile->flags & SQLITE_OPEN_MAIN_DB)) {
 		return 1;
 	}
 	int rv;
 
-	unsigned *locks = xfile->db_shm.locks;
-	if (locks[VFS2_SHM_WRITE_LOCK] > 0) {
+	unsigned *shm_locks = xfile->db_shm.shm_locks;
+	if (shm_locks[VFS2_SHM_WRITE_LOCK] > 0) {
 		return 1;
 	}
-	locks[VFS2_SHM_WRITE_LOCK] = VFS2_EXCLUSIVE;
+	shm_locks[VFS2_SHM_WRITE_LOCK] = VFS2_EXCLUSIVE;
 
 	struct vfs2_salts salts;
 	rv = maybe_setup_or_swap_wal(xfile, len, &salts);
 	if (rv != SQLITE_OK) {
 		return 1;
 	}
-	struct vfs2_file *wal = xfile->entry->wal;
+	struct file *wal = xfile->entry->wal;
 
 	// TODO assert that nothing is mapped => don't need to invalidate the WAL index
 

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1659,6 +1659,8 @@ int vfs2_read_wal(sqlite3_file *file,
 	/* TODO check wal integrity before reading it */
 	(void)check_wal_integrity;
 
+	/* TODO don't leak memory on error */
+
 	for (size_t i = 0; i < txns_len; i++) {
 		sqlite3_file *wal;
 		unsigned read_lock;

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -87,7 +87,7 @@ int vfs2_read_wal(sqlite3_file *file,
  */
 int vfs2_abort(sqlite3_file *file);
 
-int vfs2_pseudo_read_begin(sqlite3_file *file, struct vfs2_wal_slice first_not_to_read, unsigned *out);
+int vfs2_pseudo_read_begin(sqlite3_file *file, uint32_t target, unsigned *out);
 
 int vfs2_pseudo_read_end(sqlite3_file *file, unsigned i);
 

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -17,12 +17,8 @@
  * be used on the thread that opened it. The functions below that operate on
  * sqlite3_file objects created by this VFS should also only be used on that
  * thread.
- *
- * page_size can be zero to defer setting the page size to runtime (PRAGMA
- * page_size=) or use SQLite's default.
- *
  */
-sqlite3_vfs *vfs2_make(sqlite3_vfs *orig, const char *name, unsigned page_size);
+sqlite3_vfs *vfs2_make(sqlite3_vfs *orig, const char *name);
 
 struct vfs2_salts {
 	uint8_t salt1[4];
@@ -38,10 +34,6 @@ struct vfs2_wal_slice {
 	uint32_t len;
 };
 
-int vfs2_set_wal_limit(sqlite3_vfs *vfs,
-		       const char *name,
-		       struct vfs2_wal_slice sl);
-
 /**
  * Retrieve frames that were appended to the WAL by the last write transaction,
  * and reacquire the write lock.
@@ -52,9 +44,13 @@ int vfs2_set_wal_limit(sqlite3_vfs *vfs,
  */
 int vfs2_poll(sqlite3_file *file, dqlite_vfs_frame **frames, unsigned *n, struct vfs2_wal_slice *sl);
 
-int vfs2_commit(sqlite3_file *file, struct vfs2_wal_slice sl);
+int vfs2_commit(sqlite3_file *file, struct vfs2_wal_slice stop);
+
+int vfs2_commit_barrier(sqlite3_file *file);
 
 int vfs2_apply_uncommitted(sqlite3_file *file, const dqlite_vfs_frame *frames, unsigned n, struct vfs2_wal_slice *out);
+
+int vfs2_unapply_after(sqlite3_file *file, struct vfs2_wal_slice stop);
 
 struct vfs2_wal_txn {
 	struct vfs2_wal_slice meta;
@@ -63,8 +59,6 @@ struct vfs2_wal_txn {
 
 /**
  * Synchronously read some transaction data directly from the WAL.
- *
- * Call this on the WAL file object (SQLITE_FCNTL_JOURNAL_POINTER).
  *
  * Fill the `meta` field of each vfs2_wal_txn with a slice that was previously
  * returned by vfs2_shallow_poll. On return, this function will set the `frames`
@@ -94,7 +88,7 @@ int vfs2_abort(sqlite3_file *file);
  */
 void vfs2_destroy(sqlite3_vfs *vfs);
 
-// TODO access read marks and locks
+// TODO access read marks and shm_locks
 // TODO access information about checkpoints
 
 #endif

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -1,10 +1,9 @@
 #ifndef DQLITE_VFS2_H
 #define DQLITE_VFS2_H
 
-#include "../include/dqlite.h"
-
 #include <sqlite3.h>
 
+#include <stddef.h>
 #include <stdint.h>
 
 /**
@@ -34,6 +33,12 @@ struct vfs2_wal_slice {
 	uint32_t len;
 };
 
+struct vfs2_wal_frame {
+	uint32_t page_number;
+	uint32_t commit;
+	void *page;
+};
+
 /**
  * Retrieve frames that were appended to the WAL by the last write transaction,
  * and reacquire the write lock.
@@ -42,19 +47,21 @@ struct vfs2_wal_slice {
  *
  * Polling the same transaction more than once is an error.
  */
-int vfs2_poll(sqlite3_file *file, dqlite_vfs_frame **frames, unsigned *n, struct vfs2_wal_slice *sl);
+int vfs2_poll(sqlite3_file *file, struct vfs2_wal_frame **frames, unsigned *n, struct vfs2_wal_slice *sl);
+
+int vfs2_unhide(sqlite3_file *file);
 
 int vfs2_commit(sqlite3_file *file, struct vfs2_wal_slice stop);
 
 int vfs2_commit_barrier(sqlite3_file *file);
 
-int vfs2_apply_uncommitted(sqlite3_file *file, const dqlite_vfs_frame *frames, unsigned n, struct vfs2_wal_slice *out);
+int vfs2_apply_uncommitted(sqlite3_file *file, uint32_t page_size, const struct vfs2_wal_frame *frames, unsigned n, struct vfs2_wal_slice *out);
 
-int vfs2_unapply_after(sqlite3_file *file, struct vfs2_wal_slice stop);
+int vfs2_unapply(sqlite3_file *file, struct vfs2_wal_slice stop);
 
 struct vfs2_wal_txn {
 	struct vfs2_wal_slice meta;
-	dqlite_vfs_frame *frames;
+	struct vfs2_wal_frame *frames;
 };
 
 /**

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -87,6 +87,10 @@ int vfs2_read_wal(sqlite3_file *file,
  */
 int vfs2_abort(sqlite3_file *file);
 
+int vfs2_pseudo_read_begin(sqlite3_file *file, struct vfs2_wal_slice first_not_to_read, unsigned *out);
+
+int vfs2_pseudo_read_end(sqlite3_file *file, unsigned i);
+
 /**
  * Destroy the VFS object.
  *

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -4,6 +4,9 @@
 #define TEST_RUNNER_H
 
 #include <signal.h>
+#include <execinfo.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "munit.h"
 

--- a/test/lib/runner.h
+++ b/test/lib/runner.h
@@ -24,6 +24,12 @@ extern int _main_suites_n;
 #define SUITE__CAP 128
 #define TEST__CAP SUITE__CAP
 
+static inline void log_sqlite_error(void *arg, int e, const char *msg)
+{
+	(void)arg;
+	fprintf(stderr, "SQLITE %d %s\n", e, msg);
+}
+
 /* Define the top-level suites array and the main() function of the test. */
 #define RUNNER(NAME)                                                       \
 	MunitSuite _main_suites[SUITE__CAP];                               \
@@ -33,6 +39,7 @@ extern int _main_suites_n;
 	{                                                                  \
 		signal(SIGPIPE, SIG_IGN);                                  \
 		dqliteTracingMaybeEnable(true);                            \
+		sqlite3_config(SQLITE_CONFIG_LOG, log_sqlite_error, NULL); \
 		MunitSuite suite = {(char *)"", NULL, _main_suites, 1, 0}; \
 		return munit_suite_main(&suite, (void *)NAME, argc, argv); \
 	}

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -126,7 +126,7 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	struct vfs2_wal_slice sl;
 	rv = vfs2_poll(fp, NULL, NULL, &sl);
 	munit_assert_int(rv, ==, 0);
-	rv = vfs2_commit(fp, sl);
+	rv = vfs2_unhide(fp);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_uint32(sl.start, ==, 0);
 	munit_assert_uint32(sl.len, ==, 2);
@@ -144,7 +144,7 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	munit_assert_int(rv, ==, 0);
 	munit_assert_uint32(sl.start, ==, 2);
 	munit_assert_uint32(sl.len, ==, 1);
-	rv = vfs2_commit(fp, sl);
+	rv = vfs2_unhide(fp);
 	munit_assert_int(rv, ==, 0);
 
 	sqlite3_stmt *stmt;
@@ -189,7 +189,7 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	sqlite3_free(frames[0].page);
 	sqlite3_free(frames);
 
-	rv = vfs2_commit(fp, sl);
+	rv = vfs2_unhide(fp);
 	munit_assert_int(rv, ==, 0);
 
 	rv = sqlite3_reset(stmt);
@@ -339,7 +339,7 @@ TEST(vfs2, rollback, set_up, tear_down, 0, NULL)
 	struct vfs2_wal_slice sl;
 	rv = vfs2_poll(fp, NULL, NULL, &sl);
 	munit_assert_int(rv, ==, 0);
-	rv = vfs2_commit(fp, sl);
+	rv = vfs2_unhide(fp);
 	rv = sqlite3_exec(db, "BEGIN", NULL, NULL, NULL);
 	munit_assert_int(rv, ==, SQLITE_OK);
 	char sql[100];

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -115,13 +115,14 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 
 	char *args[] = {NULL, "page_size", NULL};
 	rv = sqlite3_file_control(db, "main", SQLITE_FCNTL_PRAGMA, args);
-
+	sqlite3_file *fp;
+	sqlite3_file_control(db, "main", SQLITE_FCNTL_FILE_POINTER, &fp);
+	rv = vfs2_commit_barrier(fp);
+	munit_assert_int(rv, ==, 0);
 	rv = sqlite3_exec(db, "CREATE TABLE foo (bar INTEGER)", NULL, NULL,
 			  NULL);
 	munit_assert_int(rv, ==, SQLITE_OK);
 
-	sqlite3_file *fp;
-	sqlite3_file_control(db, "main", SQLITE_FCNTL_FILE_POINTER, &fp);
 	struct vfs2_wal_slice sl;
 	rv = vfs2_poll(fp, NULL, NULL, &sl);
 	munit_assert_int(rv, ==, 0);

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -134,6 +134,7 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	rv = sqlite3_exec(db, "INSERT INTO foo (bar) VALUES (17)", NULL, NULL,
 			  NULL);
 	munit_assert_int(rv, ==, SQLITE_OK);
+	tracef("aborting...");
 	rv = vfs2_abort(fp);
 	munit_assert_int(rv, ==, 0);
 

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -30,7 +30,7 @@ static void *set_up(const MunitParameter params[], void *user_data)
 	(void)user_data;
 	struct fixture *f = munit_malloc(sizeof(*f));
 	f->dir = test_dir_setup();
-	f->vfs = vfs2_make(sqlite3_vfs_find("unix"), "dqlite-vfs2", 0);
+	f->vfs = vfs2_make(sqlite3_vfs_find("unix"), "dqlite-vfs2");
 	munit_assert_ptr_not_null(f->vfs);
 	sqlite3_vfs_register(f->vfs, 1 /* make default */);
 	return f;
@@ -178,14 +178,14 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	rv = sqlite3_step(stmt);
 	munit_assert_int(rv, ==, SQLITE_DONE);
 
-	dqlite_vfs_frame *frames;
+	struct vfs2_wal_frame *frames;
 	unsigned n;
 	rv = vfs2_poll(fp, &frames, &n, &sl);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_uint(n, ==, 1);
 	munit_assert_not_null(frames);
-	munit_assert_not_null(frames[0].data);
-	sqlite3_free(frames[0].data);
+	munit_assert_not_null(frames[0].page);
+	sqlite3_free(frames[0].page);
 	sqlite3_free(frames);
 
 	rv = vfs2_commit(fp, sl);


### PR DESCRIPTION
The headline change is that almost everything now lives in the linked-list entry, but various other changes were swept up in this as well.

Still incomplete, the state machine needs to be updated along with the implementations of the vfs2.h functions and quite a few smaller TODOs that I've tried to note in the code for my own benefit.

The big refactor was motivated by thinking in more detail about how the WAL-index is going to be managed throughout the node's whole lifetime, including the "follower" part that I'd previously neglected. I think I now have a good mental model for this, which I intend to write down as a doc comment on the state machine stuff once that is brought up to date/stabilized.

Signed-off-by: Cole Miller <cole.miller@canonical.com>