### PR TITLE
Fix build on alpha and x32 architectures

### DIFF
--- a/src/raft/uv_fs.c
+++ b/src/raft/uv_fs.c
@@ -704,7 +704,11 @@ static int probeDirectIO(int fd, size_t *size, char *errmsg)
 			default:
 				/* UNTESTED: this is an unsupported file system.
 				 */
-#if defined(__s390x__)
+#if defined(__alpha__)
+				ErrMsgPrintf(errmsg,
+					     "unsupported file system: %x",
+					     fs_info.f_type);
+#elif defined(__s390x__)
 				ErrMsgPrintf(errmsg,
 					     "unsupported file system: %ux",
 					     fs_info.f_type);

--- a/src/raft/uv_fs.c
+++ b/src/raft/uv_fs.c
@@ -712,6 +712,10 @@ static int probeDirectIO(int fd, size_t *size, char *errmsg)
 				ErrMsgPrintf(errmsg,
 					     "unsupported file system: %ux",
 					     fs_info.f_type);
+#elif defined(__x86_64__) && defined(__ILP32__)
+				ErrMsgPrintf(errmsg,
+					     "unsupported file system: %llx",
+					     fs_info.f_type);
 #else
 				ErrMsgPrintf(errmsg,
 					     "unsupported file system: %zx",

--- a/src/raft/uv_os.c
+++ b/src/raft/uv_os.c
@@ -52,7 +52,7 @@ int UvOsFallocateEmulation(int fd, off_t offset, off_t len)
 	if (f.f_bsize == 0) {
 		increment = 512;
 	} else if (f.f_bsize < 4096) {
-		increment = f.f_bsize;
+		increment = (ssize_t)f.f_bsize;
 	} else {
 		increment = 4096;
 	}

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -79,7 +79,7 @@ static inline void tracerEmit(const char *file,
 		tracerPidCached,
 
 		tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour,
-		tm.tm_min, tm.tm_sec, ts.tv_nsec,
+		tm.tm_min, tm.tm_sec, (unsigned long)ts.tv_nsec,
 
 		(unsigned)tid, tracerTraceLevelName(level), func,
 		tracerShortFileName(file), line, message);


### PR DESCRIPTION
Fix compile errors on alpha and x32 architectures, as seen on the [Debian builders](https://buildd.debian.org/status/package.php?p=dqlite).