### PR TITLE
Add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to dqlite
+
+The dqlite team welcomes external contributions via GitHub pull
+requests. To get your PR merged, you need to sign [Canonical's
+contributor license agreement (CLA)][cla]. This is straightforward to
+do once you have an account on [Launchpad][lp]; if you don't, you can
+create one [here][signup].
+
+[cla]: https://ubuntu.com/legal/contributors
+[lp]: https://launchpad.net
+[signup]: https://launchpad.net/+login

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ sudo apt update
 sudo apt install libdqlite-dev
 ```
 
+Contributing
+------------
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 Build
 -----
 


### PR DESCRIPTION
Immediate motivation: as @gibmat pointed out, right now we don't mention anywhere that signing the CLA is required to get your PR merged. There's other things that should go in CONTRIBUTING.md as well but we can add that in follow-up PRs.

Signed-off-by: Cole Miller <cole.miller@canonical.com>