### PR TITLE
Revert tolerance for EAGAIN when probing async I/O

### DIFF
--- a/src/raft/uv_fs.c
+++ b/src/raft/uv_fs.c
@@ -840,14 +840,6 @@ static int probeAsyncIO(int fd, size_t size, bool *ok, char *errmsg)
 		 * errors, since we allocated the file with posix_fallocate and
 		 * the block size is supposed to be correct. */
 		*ok = false;
-		if (event.res == -EAGAIN) {
-			/* If EAGAIN is encountered we assume the functionality
-			 * is supported but this write would have blocked for
-			 * some reason. UvWriter has a fallback mechanism to
-			 * schedule writes on the thread pool in case the async
-			 * write fails with EAGAIN, so this is safe. */
-			*ok = true;
-		}
 	}
 
 	return 0;


### PR DESCRIPTION
This reverts canonical/raft#485, hopefully (not yet confirmed) fixing the regression canonical/lxd#13326.

Signed-off-by: Cole Miller <cole.miller@canonical.com>