### PR TITLE
uv_writer: Don't skip later KAIO events when one is EAGAIN

### DIFF
--- a/src/raft/uv_writer.c
+++ b/src/raft/uv_writer.c
@@ -207,7 +207,7 @@ static void uvWriterPollCb(uv_poll_t *poller, int status, int events)
 				req->status = RAFT_IOERR;
 				goto finish;
 			}
-			return;
+			continue;
 		}
 
 		uvWriterReqSetStatus(req, (int)event->res);


### PR DESCRIPTION
@marco6 pointed out this `return` that should be a `continue`, which causes us to skip processing some KAIO write results if we get several of them in a batch and one of them has status code EAGAIN.

In practice, when running our test suite, it seems that io_getevents never returns more than one event in this context, which together with the dependence on getting EAGAIN explains why we never noticed this while developing dqlite or raft. But in production we could certainly encounter `n_events > 1`.

Signed-off-by: Cole Miller <cole.miller@canonical.com>