### PR TITLE
Add file locking to prevent two dqlite instances from using the same directory concurrently

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -31,7 +31,8 @@ static unsigned serial = 1;
 int config__init(struct config *c,
 		 dqlite_node_id id,
 		 const char *address,
-		 const char *dir)
+		 const char *raft_dir,
+		 const char *database_dir)
 {
 	int rv;
 	c->id = id;
@@ -49,8 +50,10 @@ int config__init(struct config *c,
 	c->logger.emit = loggerDefaultEmit;
 	c->failure_domain = 0;
 	c->weight = 0;
-	strncpy(c->dir, dir, sizeof(c->dir) - 1);
-	c->dir[sizeof(c->dir) - 1] = '\0';
+
+	snprintf(c->raft_dir, sizeof(c->raft_dir), "%s", (raft_dir != NULL) ? raft_dir : "");
+	snprintf(c->database_dir, sizeof(c->database_dir), "%s", database_dir);
+
 	c->disk = false;
 	c->voters = 3;
 	c->standbys = 0;

--- a/src/config.h
+++ b/src/config.h
@@ -16,7 +16,8 @@ struct config {
 	char name[256];                /* VFS/replication registriatio name */
 	unsigned long long failure_domain; /* User-provided failure domain */
 	unsigned long long int weight;     /* User-provided node weight */
-	char dir[1024];                    /* Data dir for on-disk database */
+	char raft_dir[1024];               /* Directory used by raft */
+	char database_dir[1024];           /* Data dir for on-disk database */
 	bool disk;                         /* Disk-mode or not */
 	int voters;                        /* Target number of voters */
 	int standbys;                      /* Target number of standbys */
@@ -30,7 +31,8 @@ struct config {
 int config__init(struct config *c,
 		 dqlite_node_id id,
 		 const char *address,
-		 const char *dir);
+		 const char *raft_dir,
+		 const char *database_dir);
 
 /**
  * Release any memory held by the config object.

--- a/src/db.c
+++ b/src/db.c
@@ -49,7 +49,7 @@ int db__init(struct db *db, struct config *config, const char *filename)
 	}
 	if (db->config->disk) {
 		rv = snprintf(db->path, MAX_PATHNAME + 1, "%s/%s",
-			      db->config->dir, db->filename);
+			      db->config->database_dir, db->filename);
 	} else {
 		rv = snprintf(db->path, MAX_PATHNAME + 1, "%s", db->filename);
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -72,7 +72,7 @@ int dqlite__init(struct dqlite_node *d,
 		goto err;
 	}
 
-	rv = config__init(&d->config, id, address, db_dir_path);
+	rv = config__init(&d->config, id, address, dir, db_dir_path);
 	if (rv != 0) {
 		snprintf(d->errmsg, DQLITE_ERRMSG_BUF_SIZE,
 			 "config__init(rv:%d)", rv);
@@ -837,14 +837,14 @@ static int dqliteDatabaseDirSetup(dqlite_node *t)
 		return 0;
 	}
 
-	rv = FsEnsureDir(t->config.dir);
+	rv = FsEnsureDir(t->config.database_dir);
 	if (rv != 0) {
 		snprintf(t->errmsg, DQLITE_ERRMSG_BUF_SIZE,
 			 "Error creating database dir: %d", rv);
 		return rv;
 	}
 
-	rv = FsRemoveDirFiles(t->config.dir);
+	rv = FsRemoveDirFiles(t->config.database_dir);
 	if (rv != 0) {
 		snprintf(t->errmsg, DQLITE_ERRMSG_BUF_SIZE,
 			 "Error removing files in database dir: %d", rv);

--- a/src/server.h
+++ b/src/server.h
@@ -22,6 +22,7 @@
 struct dqlite_node {
 	bool initialized; /* dqlite__init succeeded */
 
+	int lock_fd;                             /* Locked file in the data directory */
 	pthread_t thread;                        /* Main run loop thread. */
 	struct config config;                    /* Config values */
 	struct sqlite3_vfs vfs;                  /* In-memory VFS */

--- a/test/lib/cluster.h
+++ b/test/lib/cluster.h
@@ -68,32 +68,32 @@ struct server
 		munit_assert_int(_rv, ==, 0);                               \
 	}
 
-#define SETUP_SERVER(I, VERSION)                                      \
-	{                                                             \
-		struct server *_s = &f->servers[I];                   \
-		struct raft_fsm *_fsm = &f->fsms[I];                  \
-		char address[16];                                     \
-		int _rc;                                              \
-                                                                      \
-		test_logger_setup(params, &_s->logger);               \
-                                                                      \
-		sprintf(address, "%d", I + 1);                        \
-                                                                      \
-		char *dir = test_dir_setup();                         \
-		_s->dir = dir;                                        \
-                                                                      \
-		_rc = config__init(&_s->config, I + 1, address, dir); \
-		munit_assert_int(_rc, ==, 0);                         \
-                                                                      \
-		registry__init(&_s->registry, &_s->config);           \
-                                                                      \
-		_rc = VfsInit(&_s->vfs, _s->config.name);             \
-		munit_assert_int(_rc, ==, 0);                         \
-		_rc = sqlite3_vfs_register(&_s->vfs, 0);              \
-		munit_assert_int(_rc, ==, 0);                         \
-                                                                      \
-		_rc = fsm__init(_fsm, &_s->config, &_s->registry);    \
-		munit_assert_int(_rc, ==, 0);                         \
+#define SETUP_SERVER(I, VERSION)                                            \
+	{                                                                   \
+		struct server *_s = &f->servers[I];                         \
+		struct raft_fsm *_fsm = &f->fsms[I];                        \
+		char address[16];                                           \
+		int _rc;                                                    \
+                                                                            \
+		test_logger_setup(params, &_s->logger);                     \
+                                                                            \
+		sprintf(address, "%d", I + 1);                              \
+                                                                            \
+		char *dir = test_dir_setup();                               \
+		_s->dir = dir;                                              \
+                                                                            \
+		_rc = config__init(&_s->config, I + 1, address, NULL, dir); \
+		munit_assert_int(_rc, ==, 0);                               \
+                                                                            \
+		registry__init(&_s->registry, &_s->config);                 \
+                                                                            \
+		_rc = VfsInit(&_s->vfs, _s->config.name);                   \
+		munit_assert_int(_rc, ==, 0);                               \
+		_rc = sqlite3_vfs_register(&_s->vfs, 0);                    \
+		munit_assert_int(_rc, ==, 0);                               \
+                                                                            \
+		_rc = fsm__init(_fsm, &_s->config, &_s->registry);          \
+		munit_assert_int(_rc, ==, 0);                               \
 	}
 
 #define TEAR_DOWN_CLUSTER                            \

--- a/test/lib/config.h
+++ b/test/lib/config.h
@@ -11,12 +11,12 @@
 
 #define FIXTURE_CONFIG struct config config;
 
-#define SETUP_CONFIG                                          \
-	{                                                     \
-		int rc;                                       \
-		rc = config__init(&f->config, 1, "1", "dir"); \
-		munit_assert_int(rc, ==, 0);                  \
-		test_logger_setup(params, &f->config.logger); \
+#define SETUP_CONFIG                                                \
+	{                                                           \
+		int rc;                                             \
+		rc = config__init(&f->config, 1, "1", NULL, "dir"); \
+		munit_assert_int(rc, ==, 0);                        \
+		test_logger_setup(params, &f->config.logger);       \
 	}
 
 #define TEAR_DOWN_CONFIG                          \


### PR DESCRIPTION
It was suggested that some of the corruption issues reported by LXD users might be due to two LXD daemon processes running concurrently, causing two dqlite instances to concurrently modify the common data directory. LXD already has some mutual exclusion logic to prevent two daemons from running at the same time:

https://github.com/canonical/lxd/blob/1514a400f11a82b90a5294b5c1f31cd2c6dd9311/lxd/endpoints/socket.go#L39

But even so it seems worth it to do some file locking to prevent this definitively on the dqlite side.

Note that this obviously won't work unless both the contending processes are running versions of dqlite that include the locking.

Signed-off-by: Cole Miller <cole.miller@canonical.com>