### PR TITLE
feat: proper timeout handling for snapshots

### DIFF
--- a/src/raft/recv_install_snapshot.c
+++ b/src/raft/recv_install_snapshot.c
@@ -346,21 +346,21 @@ enum to_state {
 static const struct sm_conf to_sm_conf[TO_NR] = {
 	[TO_INIT] = {
 		.flags   = SM_INITIAL | SM_FINAL,
-		.name    = "to_init",
+		.name    = "init",
 		.allowed = BITS(TO_STARTED),
 	},
 	[TO_STARTED] = {
 		.flags   = SM_FINAL,
-		.name    = "to_started",
+		.name    = "started",
 		.allowed = BITS(TO_EXPIRED) | BITS(TO_CANCELED),
 	},
 	[TO_EXPIRED] = {
 		.flags   = SM_FINAL,
-		.name    = "to_expired",
+		.name    = "expired",
 	},
 	[TO_CANCELED] = {
 		.flags   = SM_FINAL,
-		.name    = "to_canceled",
+		.name    = "canceled",
 	},
 };
 /* clang-format on */
@@ -454,7 +454,7 @@ static void leader_to_start(struct leader *leader,
 	sm_move(&to->sm, TO_STARTED);
 }
 
-static void leader_to_fini(struct leader *leader, struct timeout *to)
+static void leader_to_cancel(struct leader *leader, struct timeout *to)
 {
 	leader->ops->to_stop(to);
 	sm_move(&to->sm, TO_CANCELED);
@@ -740,7 +740,7 @@ again:
 			leader_to_start(leader, &leader->rpc.timeout, 10000, rpc_to_cb);
 			return;
 		case RPC_REPLIED:
-			leader_to_fini(leader, &leader->rpc.timeout);
+			leader_to_cancel(leader, &leader->rpc.timeout);
 			rpc_fini(&leader->rpc);
 			sm_move(sm, leader_next_state(sm));
 			goto again;

--- a/src/raft/recv_install_snapshot.c
+++ b/src/raft/recv_install_snapshot.c
@@ -279,10 +279,9 @@ static const struct sm_conf rpc_sm_conf[RPC_NR] = {
 		         | BITS(RPC_ERROR),
 	},
 	[RPC_FILLED] = {
-		.flags   = SM_INITIAL | SM_FINAL,
 		.name    = "filled",
 		.allowed = BITS(RPC_SENT)
-		        | BITS(RPC_ERROR),
+		         | BITS(RPC_ERROR),
 	},
 	[RPC_SENT] = {
 		.name    = "sent",
@@ -795,10 +794,10 @@ again:
 		}
 		rpc_fill_follower(follower);
 		rc = rpc_send(&follower->rpc, ops->sender_send, follower_sent_cb);
-		if (rc == 0) {
-			break;
+		if (rc != 0) {
+			goto again;
 		}
-		goto again;
+		break;
 	case FS_SIG_PROCESSED:
 	case FS_CHUNCK_PROCESSED:
 	case FS_CHUNCK_REPLIED:

--- a/src/raft/recv_install_snapshot.c
+++ b/src/raft/recv_install_snapshot.c
@@ -13,7 +13,6 @@
 #include "../lib/sm.h"
 #include "../raft.h"
 #include "../raft/recv_install_snapshot.h"
-#include "../raft/uv_os.h"
 #include "../utils.h"
 
 /**
@@ -262,6 +261,7 @@
 
 enum rpc_state {
 	RPC_INIT,
+	RPC_FILLED,
 	RPC_SENT,
 	RPC_TIMEDOUT,
 	RPC_REPLIED,
@@ -270,18 +270,26 @@ enum rpc_state {
 	RPC_NR,
 };
 
+/* clang-format off */
 static const struct sm_conf rpc_sm_conf[RPC_NR] = {
 	[RPC_INIT] = {
 		.flags   = SM_INITIAL | SM_FINAL,
 		.name    = "init",
-		.allowed = BITS(RPC_SENT) | BITS(RPC_ERROR),
+		.allowed = BITS(RPC_FILLED)
+		         | BITS(RPC_ERROR),
+	},
+	[RPC_FILLED] = {
+		.flags   = SM_INITIAL | SM_FINAL,
+		.name    = "filled",
+		.allowed = BITS(RPC_SENT)
+		        | BITS(RPC_ERROR),
 	},
 	[RPC_SENT] = {
 		.name    = "sent",
 		.allowed = BITS(RPC_TIMEDOUT)
 		         | BITS(RPC_REPLIED)
 		         | BITS(RPC_ERROR)
-				 | BITS(RPC_END),
+		         | BITS(RPC_END),
 	},
 	[RPC_TIMEDOUT] = {
 		.name    = "timedout",
@@ -290,17 +298,19 @@ static const struct sm_conf rpc_sm_conf[RPC_NR] = {
 	[RPC_REPLIED] = {
 		.name    = "replied",
 		.allowed = BITS(RPC_INIT)
-				 | BITS(RPC_END),
+		         | BITS(RPC_END),
 	},
 	[RPC_ERROR] = {
 		.name    = "error",
 		.allowed = BITS(RPC_INIT),
+		.flags   = SM_FINAL,
 	},
 	[RPC_END] = {
 		.name    = "end",
-		.allowed = BITS(RPC_INIT),
+		.flags   = SM_FINAL,
 	},
 };
+/* clang-format on */
 
 enum work_state {
 	WORK_INIT,
@@ -333,6 +343,7 @@ enum to_state {
 	TO_NR,
 };
 
+/* clang-format off */
 static const struct sm_conf to_sm_conf[TO_NR] = {
 	[TO_INIT] = {
 		.flags   = SM_INITIAL | SM_FINAL,
@@ -350,9 +361,10 @@ static const struct sm_conf to_sm_conf[TO_NR] = {
 	},
 	[TO_CANCELED] = {
 		.flags   = SM_FINAL,
-		.name    = "w_canceled",
+		.name    = "to_canceled",
 	},
 };
+/* clang-format on */
 
 #define M_MSG_SENT   ((const struct raft_message *) 3)
 #define M_TIMEOUT    ((const struct raft_message *) 2)
@@ -413,28 +425,40 @@ static void follower_work_done(struct work *w)
 	follower_tick(follower, M_WORK_DONE);
 }
 
-static void to_init(struct timeout *to)
+static void rpc_to_cb(uv_timer_t *handle)
 {
-	sm_init(&to->sm, to_sm_invariant, NULL, to_sm_conf, "to", TO_INIT);
-}
-
-static void leader_to_cb(struct timeout *t, int rc)
-{
-	(void)rc;
-	struct leader *leader = CONTAINER_OF(t, struct leader, timeout);
-	sm_move(&t->sm, TO_EXPIRED);
+	struct timeout *to = CONTAINER_OF(handle, struct timeout, handle);
+	struct rpc *rpc = CONTAINER_OF(to, struct rpc, timeout);
+	struct leader *leader = CONTAINER_OF(rpc, struct leader, rpc);
+	sm_move(&to->sm, TO_EXPIRED);
+	sm_move(&rpc->sm, RPC_TIMEDOUT);
 	leader_tick(leader, M_TIMEOUT);
 }
 
-static void to_start(struct timeout *to, unsigned delay, to_cb_op to_cb)
+static void leader_to_cb(uv_timer_t *handle)
 {
-	(void)delay;
+	struct timeout *to = CONTAINER_OF(handle, struct timeout, handle);
 	struct leader *leader = CONTAINER_OF(to, struct leader, timeout);
+	sm_move(&to->sm, TO_EXPIRED);
+	leader_tick(leader, M_TIMEOUT);
+}
 
-	to_init(to);
-	leader->ops->to_start(&leader->timeout, 10000, to_cb);
+static void leader_to_start(struct leader *leader,
+		struct timeout *to,
+		unsigned delay,
+		to_cb_op to_cb)
+{
+	leader->ops->to_init(to);
+	sm_init(&to->sm, to_sm_invariant, NULL, to_sm_conf, "to", TO_INIT);
+	leader->ops->to_start(to, delay, to_cb);
 	sm_relate(&leader->sm, &to->sm);
 	sm_move(&to->sm, TO_STARTED);
+}
+
+static void leader_to_fini(struct leader *leader, struct timeout *to)
+{
+	leader->ops->to_stop(to);
+	sm_move(&to->sm, TO_CANCELED);
 }
 
 static void leader_sent_cb(struct sender *s, int rc)
@@ -447,8 +471,6 @@ static void leader_sent_cb(struct sender *s, int rc)
 		return;
 	}
 
-	sm_move(&rpc->sm, RPC_SENT);
-	leader->ops->to_start(&rpc->timeout, 10000, leader_to_cb);
 	leader_tick(leader, M_MSG_SENT);
 }
 
@@ -462,16 +484,14 @@ static void follower_sent_cb(struct sender *s, int rc)
 		return;
 	}
 
-	sm_move(&rpc->sm, RPC_SENT);
 	follower_tick(follower, M_MSG_SENT);
 }
 
 static bool is_a_trigger_leader(const struct leader *leader, const struct raft_message *incoming)
 {
 	(void)leader;
-	/* Leader has no triggers on sending a message, it reacts when follower
-	 * replies */
-	return incoming != M_MSG_SENT;
+	(void)incoming;
+	return true;
 }
 
 static bool is_a_trigger_follower(const struct follower *follower,
@@ -542,18 +562,18 @@ static void rpc_fill_leader(struct leader *leader)
 {
 	rpc_init(&leader->rpc);
 	sm_relate(&leader->sm, &leader->rpc.sm);
+	sm_move(&leader->rpc.sm, RPC_FILLED);
 }
 
 static void rpc_fill_follower(struct follower *follower)
 {
 	rpc_init(&follower->rpc);
 	sm_relate(&follower->sm, &follower->rpc.sm);
+	sm_move(&follower->rpc.sm, RPC_FILLED);
 }
 
-static int rpc_send(struct rpc *rpc, sender_send_op op, to_cb_op to_cb,
-		sender_cb_op sent_cb)
+static int rpc_send(struct rpc *rpc, sender_send_op op, sender_cb_op sent_cb)
 {
-	(void)to_cb;
 	int rc = op(&rpc->sender, &rpc->message, sent_cb);
 	return rc;
 }
@@ -562,6 +582,9 @@ static void follower_rpc_tick(struct rpc *rpc)
 {
 	switch(sm_state(&rpc->sm)) {
 	case RPC_INIT:
+		break;
+	case RPC_FILLED:
+		sm_move(&rpc->sm, RPC_SENT);
 		break;
 	case RPC_SENT:
 	case RPC_TIMEDOUT:
@@ -577,6 +600,9 @@ static void leader_rpc_tick(struct rpc *rpc)
 {
 	switch(sm_state(&rpc->sm)) {
 	case RPC_INIT:
+		break;
+	case RPC_FILLED:
+		sm_move(&rpc->sm, RPC_SENT);
 		break;
 	case RPC_SENT:
 		sm_move(&rpc->sm, RPC_REPLIED);
@@ -710,25 +736,30 @@ again:
 	case LS_REQ_SIG_LOOP:
 	case LS_CHECK_F_HAS_SIGS:
 		leader_rpc_tick(&leader->rpc);
-		if (sm_state(&leader->rpc.sm) == RPC_REPLIED) {
+		switch (sm_state(&leader->rpc.sm)) {
+		case RPC_SENT:
+			leader_to_start(leader, &leader->rpc.timeout, 10000, rpc_to_cb);
+			return;
+		case RPC_REPLIED:
+			leader_to_fini(leader, &leader->rpc.timeout);
 			rpc_fini(&leader->rpc);
 			sm_move(sm, leader_next_state(sm));
 			goto again;
 		}
 
 		rpc_fill_leader(leader);
-		rc = rpc_send(&leader->rpc, ops->sender_send, leader_to_cb, leader_sent_cb);
-		if (rc == 0) {
-			break;
+		rc = rpc_send(&leader->rpc, ops->sender_send, leader_sent_cb);
+		if (rc != 0) {
+			goto again;
 		}
-		goto again;
+		break;
 	case LS_WAIT_SIGS:
 		if (leader_next_state(sm) > sm_state(sm)) {
 			sm_move(sm, leader_next_state(sm));
 			goto again;
 		}
 
-		to_start(&leader->timeout, 10000, leader_to_cb);
+		leader_to_start(leader, &leader->timeout, 10000, leader_to_cb);
 		sm_move(sm, leader_next_state(sm));
 		break;
 	default:
@@ -763,7 +794,7 @@ again:
 			goto again;
 		}
 		rpc_fill_follower(follower);
-		rc = rpc_send(&follower->rpc, ops->sender_send, NULL, follower_sent_cb);
+		rc = rpc_send(&follower->rpc, ops->sender_send, follower_sent_cb);
 		if (rc == 0) {
 			break;
 		}

--- a/src/raft/recv_install_snapshot.h
+++ b/src/raft/recv_install_snapshot.h
@@ -12,7 +12,7 @@ struct work;
 struct sender;
 struct timeout;
 
-typedef void (*to_cb_op)(struct timeout *t, int rc);
+typedef void (*to_cb_op)(uv_timer_t *handle);
 typedef void (*work_op)(struct work *w);
 typedef void (*sender_cb_op)(struct sender *s, int rc);
 
@@ -29,6 +29,8 @@ struct sender {
 struct timeout {
 	to_cb_op cb;
 	struct sm sm;
+
+	uv_timer_t handle;
 };
 
 struct rpc {
@@ -45,6 +47,7 @@ typedef int (*sender_send_op)(struct sender *s,
 struct leader_ops {
 	work_op ht_create;
 
+	void (*to_init)(struct timeout *to);
 	void (*to_stop)(struct timeout *to);
 	void (*to_start)(struct timeout *to, unsigned delay, to_cb_op cb);
 
@@ -73,7 +76,7 @@ struct leader {
 	struct timeout timeout;
 	const struct leader_ops *ops;
 
-	/* dummy flags */
+	/* TODO dummy flags */
 	bool sigs_calculated;
 	bool sigs_more;
 	bool pages_more;
@@ -86,7 +89,7 @@ struct follower {
 	work_op work_cb;
 	const struct follower_ops *ops;
 
-	/* dummy flags */
+	/* TODO dummy flags */
 	bool sigs_calculated;
 };
 
@@ -119,6 +122,7 @@ enum leader_states {
 	LS_NR,
 };
 
+/* clang-format off */
 static const struct sm_conf leader_sm_conf[LS_NR] = {
 	[LS_F_ONLINE] = {
 		.flags   = SM_INITIAL | SM_FINAL,
@@ -133,7 +137,7 @@ static const struct sm_conf leader_sm_conf[LS_NR] = {
 	[LS_F_NEEDS_SNAP] = {
 		.name    = "needs-snapshot",
 		.allowed = BITS(LS_CHECK_F_HAS_SIGS)
-			 | BITS(LS_F_NEEDS_SNAP)
+		         | BITS(LS_F_NEEDS_SNAP)
 		         | BITS(LS_F_ONLINE),
 	},
 	[LS_CHECK_F_HAS_SIGS] = {
@@ -178,7 +182,7 @@ static const struct sm_conf leader_sm_conf[LS_NR] = {
 	[LS_PAGE_SENT] = {
 		.name    = "page-sent",
 		.allowed = BITS(LS_READ_PAGES_LOOP)
-			 | BITS(LS_SNAP_DONE)
+		         | BITS(LS_SNAP_DONE)
 		         | BITS(LS_F_ONLINE),
 	},
 	[LS_SNAP_DONE] = {
@@ -191,6 +195,7 @@ static const struct sm_conf leader_sm_conf[LS_NR] = {
 		.allowed = BITS(LS_F_ONLINE),
 	},
 };
+/* clang-format on */
 
 enum follower_states {
 	FS_NORMAL,
@@ -218,91 +223,93 @@ enum follower_states {
 	FS_NR,
 };
 
+/* clang-format off */
 static const struct sm_conf follower_sm_conf[FS_NR] = {
 	[FS_NORMAL] = {
 		.flags = SM_INITIAL | SM_FINAL,
 		.name = "normal",
 		.allowed = BITS(FS_HT_CREATE)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_HT_CREATE] = {
 		.name = "ht_create",
 		.allowed = BITS(FS_HT_WAIT)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_HT_WAIT] = {
 		.name = "ht_waiting",
 		.allowed = BITS(FS_SIGS_CALC_STARTED)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIGS_CALC_STARTED] = {
 		.name = "signatures_calc_started",
 		.allowed = BITS(FS_SIGS_CALC_LOOP)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIGS_CALC_LOOP] = {
 		.name = "signatures_calc_loop",
 		.allowed = BITS(FS_SIGS_CALC_MSG_RECEIVED)
-			     | BITS(FS_SIGS_CALC_DONE)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_SIGS_CALC_DONE)
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIGS_CALC_MSG_RECEIVED] = {
 		.name = "signatures_msg_received",
 		.allowed = BITS(FS_SIGS_CALC_LOOP)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIGS_CALC_DONE] = {
 		.name = "signatures_calc_done",
 		.allowed = BITS(FS_SIG_RECEIVING)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIG_RECEIVING] = {
 		.name = "signature_received",
 		.allowed = BITS(FS_SIG_PROCESSED)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIG_PROCESSED] = {
 		.name = "signature_processed",
 		.allowed = BITS(FS_SIG_READ)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIG_READ] = {
 		.name = "signature_read",
 		.allowed = BITS(FS_SIG_REPLIED)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_SIG_REPLIED] = {
 		.name = "signature_sent",
 		.allowed = BITS(FS_CHUNCK_RECEIVING)
-				 | BITS(FS_SIG_RECEIVING)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_SIG_RECEIVING)
+		         | BITS(FS_NORMAL),
 	},
 	[FS_CHUNCK_RECEIVING] = {
 		.name = "chunk_received",
 		.allowed = BITS(FS_CHUNCK_PROCESSED)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_CHUNCK_PROCESSED] = {
 		.name = "chunk_processed",
 		.allowed = BITS(FS_CHUNCK_APPLIED)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_CHUNCK_APPLIED] = {
 		.name = "chunk_applied",
 		.allowed = BITS(FS_CHUNCK_REPLIED)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_NORMAL),
 	},
 	[FS_CHUNCK_REPLIED] = {
 		.name = "chunk_replied",
 		.allowed = BITS(FS_CHUNCK_PROCESSED)
-				 | BITS(FS_FINAL)
-				 | BITS(FS_NORMAL),
+		         | BITS(FS_FINAL)
+		         | BITS(FS_NORMAL),
 	},
 	[FS_FINAL] = {
 		.name = "final",
 		.allowed = BITS(FS_NORMAL),
 	},
 };
+/* clang-format on */
 /* end of TODO make this private */
 
 /* Process an InstallSnapshot RPC from the given server. */


### PR DESCRIPTION
Added both unit tests and tests that use libuv timers directly

## Test with uv_timer_t
![uv_timer_t](https://github.com/canonical/dqlite/assets/24965409/95a0f94e-979f-47d7-8581-99c0a0bc6522)

## Test with mock implementation of timers
![ut](https://github.com/canonical/dqlite/assets/24965409/9573f43a-9f32-443c-acda-ac2b7b75f378)

