### PR TITLE
Snapshot pool integration, first version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -221,6 +221,7 @@ libraft_la_LDFLAGS = $(UV_LIBS)
 raft_core_unit_test_SOURCES = \
   $(libraft_la_SOURCES) \
   src/lib/sm.c \
+  src/lib/threadpool.c \
   src/tracing.c \
   test/raft/unit/main_core.c \
   test/raft/unit/test_byte.c \
@@ -238,6 +239,7 @@ raft_core_unit_test_LDADD = libtest.la
 raft_core_integration_test_SOURCES = \
   src/tracing.c \
   src/lib/sm.c \
+  src/lib/threadpool.c \
   test/raft/integration/main_core.c \
   test/raft/integration/test_apply.c \
   test/raft/integration/test_assign.c \
@@ -263,6 +265,7 @@ raft_core_integration_test_LDADD = libtest.la libraft.la
 
 raft_core_fuzzy_test_SOURCES = \
   src/lib/sm.c \
+  src/lib/threadpool.c \
   src/tracing.c \
   test/raft/fuzzy/main_core.c \
   test/raft/fuzzy/test_election.c \
@@ -295,6 +298,7 @@ raft_uv_integration_test_SOURCES = \
   $(libraft_la_SOURCES) \
   src/tracing.c \
   src/lib/sm.c \
+  src/lib/threadpool.c \
   test/raft/integration/main_uv.c \
   test/raft/integration/test_uv_init.c \
   test/raft/integration/test_uv_append.c \

--- a/src/lib/threadpool.h
+++ b/src/lib/threadpool.h
@@ -2,6 +2,7 @@
 #define __THREAD_POOL__
 
 #include <uv.h>
+#include <stdbool.h>
 #include "queue.h"
 
 /**
@@ -111,6 +112,7 @@ void pool_queue_work(pool_t *pool,
 		     enum pool_work_type type,
 		     void (*work_cb)(pool_work_t *w),
 		     void (*after_work_cb)(pool_work_t *w));
+bool pool_is_pool_thread(void);
 
 pool_t *pool_ut_fallback(void);
 

--- a/src/raft.h
+++ b/src/raft.h
@@ -379,6 +379,7 @@ struct raft_signature {
 	struct page_from_to page_from_to;
 	pageno_t cs_page_no;
 	enum raft_result result;
+	bool ask_calculated;
 };
 #define RAFT_SIGNATURE_VERSION 0
 
@@ -390,6 +391,7 @@ struct raft_signature_result {
 	unsigned int cs_nr;
 	pageno_t cs_page_no;
 	enum raft_result result;
+	bool calculated;
 };
 #define RAFT_SIGNATURE_RESULT_VERSION 0
 

--- a/src/raft/recv_install_snapshot.c
+++ b/src/raft/recv_install_snapshot.c
@@ -16,6 +16,20 @@
 #include "../utils.h"
 #include "../lib/threadpool.h"
 
+#define IN_1(E, X) E == X
+#define IN_2(E, X, ...) E == X || IN_1(E,__VA_ARGS__)
+#define IN_3(E, X, ...) E == X || IN_2(E,__VA_ARGS__)
+#define IN_4(E, X, ...) E == X || IN_3(E,__VA_ARGS__)
+#define IN_5(E, X, ...) E == X || IN_4(E,__VA_ARGS__)
+#define IN_6(E, X, ...) E == X || IN_5(E,__VA_ARGS__)
+#define IN_7(E, X, ...) E == X || IN_6(E,__VA_ARGS__)
+#define IN_8(E, X, ...) E == X || IN_7(E,__VA_ARGS__)
+#define IN_9(E, X, ...) E == X || IN_8(E,__VA_ARGS__)
+
+#define GET_IN_MACRO(_1,_2,_3,_4,_5,_6,_7,_8,_9,NAME,...) NAME
+#define IN(E, ...) \
+  (GET_IN_MACRO(__VA_ARGS__,IN_9,IN_8,IN_7,IN_6,IN_5,IN_4,IN_3,IN_2,IN_1)(E,__VA_ARGS__))
+
 /**
  * =Overview
  *
@@ -501,22 +515,91 @@ static void follower_sent_cb(struct sender *s, int rc)
 
 static bool is_a_trigger_leader(const struct leader *leader, const struct raft_message *incoming)
 {
-	(void)leader;
-	(void)incoming;
-	return true;
+	int state = sm_state(&leader->sm);
+
+	/* Special cases: */
+	if (incoming == M_WORK_DONE) {
+		return IN(state, LS_HT_WAIT, LS_PAGE_SENT, LS_PERSISTED_SIG_PART,
+				LS_PAGE_READ);
+	} else if (incoming == M_MSG_SENT) {
+		if (sm_state(&leader->rpc.sm) != RPC_FILLED) {
+			return false;
+		}
+		return IN(state, LS_PAGE_READ, LS_SNAP_DONE, LS_F_NEEDS_SNAP,
+				LS_REQ_SIG_LOOP, LS_CHECK_F_HAS_SIGS);
+	} else if (incoming == M_TIMEOUT) {
+		return IN(state, LS_PAGE_READ, LS_SNAP_DONE, LS_F_NEEDS_SNAP,
+				LS_REQ_SIG_LOOP, LS_CHECK_F_HAS_SIGS, LS_WAIT_SIGS);
+	}
+
+	/* From now on, the message pointer is a valid pointer. */
+	PRE(incoming != M_MSG_SENT && incoming != M_TIMEOUT &&
+			incoming != M_WORK_DONE);
+
+	/* Leader has not send the AppendEntries message but reacts on its
+	 * reply. */
+	if (state == LS_F_ONLINE) {
+		// TODO check if raft entry is present, else it is not a trigger.
+		return incoming->type == RAFT_IO_APPEND_ENTRIES_RESULT;
+	}
+
+	/* Leader is waiting for follower reply. */
+	if (sm_state(&leader->rpc.sm) != RPC_SENT) {
+		/* We are not expecting a reply. */
+		return false;
+	};
+	switch (state) {
+	case LS_PAGE_READ:
+		return IN(incoming->type, RAFT_IO_INSTALL_SNAPSHOT_CP_RESULT,
+				RAFT_IO_INSTALL_SNAPSHOT_MV_RESULT);
+	case LS_SNAP_DONE:
+	case LS_F_NEEDS_SNAP:
+		return incoming->type == RAFT_IO_INSTALL_SNAPSHOT_RESULT;
+	case LS_REQ_SIG_LOOP:
+	case LS_CHECK_F_HAS_SIGS:
+		return incoming->type == RAFT_IO_SIGNATURE_RESULT;
+	}
+	return false;
 }
 
 static bool is_a_trigger_follower(const struct follower *follower,
 		const struct raft_message *incoming)
 {
-	switch (sm_state(&follower->sm)) {
-	case FS_SIGS_CALC_LOOP:
-		return incoming != M_WORK_DONE;
-	case FS_SIG_PROCESSED:
-	case FS_CHUNCK_PROCESSED:
-		return incoming == M_WORK_DONE;
+	int state = sm_state(&follower->sm);
+
+	/* Special cases: */
+	if (incoming == M_WORK_DONE) {
+		return IN(state, FS_SIG_PROCESSED, FS_CHUNCK_PROCESSED,
+				FS_SIG_PROCESSED, FS_CHUNCK_PROCESSED, FS_CHUNCK_REPLIED,
+				FS_HT_WAIT);
+	} else if (incoming == M_MSG_SENT) {
+		if (sm_state(&follower->rpc.sm) != RPC_FILLED) {
+			return false;
+		}
+		return IN(state, FS_NORMAL, FS_SIGS_CALC_LOOP, FS_SIG_READ,
+				FS_CHUNCK_APPLIED, FS_SNAP_DONE);
+	} else if (incoming == M_TIMEOUT) {
+		/* No timeouts in follower. */
+		return false;
 	}
-	return true;
+
+	/* From now on, the message pointer is a valid pointer. */
+	PRE(incoming != M_MSG_SENT && incoming != M_TIMEOUT &&
+			incoming != M_WORK_DONE);
+
+	switch (state) {
+	case FS_NORMAL:
+	case FS_SNAP_DONE:
+		return incoming->type == RAFT_IO_INSTALL_SNAPSHOT;
+	case FS_SIGS_CALC_LOOP:
+		return incoming->type == RAFT_IO_SIGNATURE;
+	case FS_SIG_RECEIVING:
+		return incoming->type == RAFT_IO_SIGNATURE;
+	case FS_CHUNCK_RECEIVING:
+		return IN(incoming->type, RAFT_IO_INSTALL_SNAPSHOT_CP,
+				RAFT_IO_INSTALL_SNAPSHOT_MV);
+	}
+	return false;
 }
 
 static bool is_a_duplicate(const void *state,
@@ -572,16 +655,83 @@ static void work_fill_follower(struct follower *follower)
 
 static void rpc_fill_leader(struct leader *leader)
 {
-	rpc_init(&leader->rpc);
-	sm_relate(&leader->sm, &leader->rpc.sm);
-	sm_move(&leader->rpc.sm, RPC_FILLED);
+	struct rpc *rpc = &leader->rpc;
+
+	rpc_init(rpc);
+	sm_relate(&leader->sm, &rpc->sm);
+
+	switch (sm_state(&leader->sm)) {
+	case LS_PAGE_READ:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_INSTALL_SNAPSHOT_CP, // TODO CP OR MV.
+		};
+		break;
+	case LS_SNAP_DONE:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_INSTALL_SNAPSHOT,
+			.install_snapshot = (struct raft_install_snapshot) {
+				.result = RAFT_RESULT_DONE,
+			},
+		};
+		break;
+	case LS_F_NEEDS_SNAP:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_INSTALL_SNAPSHOT,
+		};
+		break;
+	case LS_REQ_SIG_LOOP:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_SIGNATURE,
+		};
+		break;
+	case LS_CHECK_F_HAS_SIGS:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_SIGNATURE,
+			.signature = (struct raft_signature) {
+				.ask_calculated = true,
+			},
+		};
+		break;
+	}
+
+	sm_move(&rpc->sm, RPC_FILLED);
 }
 
 static void rpc_fill_follower(struct follower *follower)
 {
-	rpc_init(&follower->rpc);
-	sm_relate(&follower->sm, &follower->rpc.sm);
-	sm_move(&follower->rpc.sm, RPC_FILLED);
+	struct rpc *rpc = &follower->rpc;
+
+	rpc_init(rpc);
+	sm_relate(&follower->sm, &rpc->sm);
+
+	switch (sm_state(&follower->sm)) {
+	case FS_SIGS_CALC_LOOP:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_SIGNATURE_RESULT,
+			.signature_result = (struct raft_signature_result) {
+				.calculated = follower->sigs_calculated,
+			},
+		};
+		break;
+	case FS_SIG_READ:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_SIGNATURE_RESULT,
+		};
+		break;
+	case FS_CHUNCK_APPLIED:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_INSTALL_SNAPSHOT_CP_RESULT,
+		};
+		break;
+	case FS_NORMAL:
+	case FS_SNAP_DONE:
+		rpc->message = (struct raft_message) {
+			.type = RAFT_IO_INSTALL_SNAPSHOT_RESULT,
+		};
+		break;
+	}
+
+	sm_move(&rpc->sm, RPC_FILLED);
 }
 
 static int rpc_send(struct rpc *rpc, sender_send_op op, sender_cb_op sent_cb)
@@ -644,7 +794,7 @@ static bool is_an_unexpected_trigger(const struct leader *leader,
 
 	enum raft_result res = RAFT_RESULT_UNEXPECTED;
 	switch (msg->type) {
-	case RAFT_IO_APPEND_ENTRIES:
+	case RAFT_IO_APPEND_ENTRIES_RESULT:
 		res = RAFT_RESULT_OK;
 		break;
 	case RAFT_IO_INSTALL_SNAPSHOT:
@@ -814,7 +964,6 @@ again:
 		break;
 	case FS_SIG_PROCESSED:
 	case FS_CHUNCK_PROCESSED:
-	case FS_CHUNCK_REPLIED:
 	case FS_HT_WAIT:
 		sm_move(sm, follower_next_state(sm));
 		goto again;
@@ -829,6 +978,7 @@ again:
 	case FS_SIG_REPLIED:
 	case FS_SIGS_CALC_DONE:
 	case FS_SIGS_CALC_MSG_RECEIVED:
+	case FS_CHUNCK_REPLIED:
 	case FS_FINAL:
 		sm_move(sm, follower_next_state(sm));
 		break;

--- a/src/raft/recv_install_snapshot.c
+++ b/src/raft/recv_install_snapshot.c
@@ -14,6 +14,7 @@
 #include "../raft.h"
 #include "../raft/recv_install_snapshot.h"
 #include "../utils.h"
+#include "../lib/threadpool.h"
 
 /**
  * =Overview
@@ -301,11 +302,11 @@ static const struct sm_conf rpc_sm_conf[RPC_NR] = {
 	},
 	[RPC_ERROR] = {
 		.name    = "error",
-		.allowed = BITS(RPC_INIT),
 		.flags   = SM_FINAL,
 	},
 	[RPC_END] = {
 		.name    = "end",
+		.allowed = BITS(RPC_END),
 		.flags   = SM_FINAL,
 	},
 };
@@ -369,12 +370,6 @@ static const struct sm_conf to_sm_conf[TO_NR] = {
 #define M_TIMEOUT    ((const struct raft_message *) 2)
 #define M_WORK_DONE  ((const struct raft_message *) 1)
 
-static bool is_main_thread(void)
-{
-	// TODO: thread local storage.
-	return true;
-}
-
 static bool work_sm_invariant(const struct sm *sm, int prev_state)
 {
 	(void)sm;
@@ -410,17 +405,23 @@ static bool to_sm_invariant(const struct sm *sm, int prev_state)
 	return true;
 }
 
-static void leader_work_done(struct work *w)
+static void leader_work_done(pool_work_t *w)
 {
-	struct leader *leader = CONTAINER_OF(w, struct leader, work);
-	sm_move(&w->sm, WORK_DONE);
+	struct work *work = CONTAINER_OF(w, struct work, pool_work);
+	struct leader *leader = CONTAINER_OF(work, struct leader, work);
+
+	PRE(leader->ops->is_main_thread());
+	sm_move(&work->sm, WORK_DONE);
 	leader_tick(leader, M_WORK_DONE);
 }
 
-static void follower_work_done(struct work *w)
+static void follower_work_done(pool_work_t *w)
 {
-	struct follower *follower = CONTAINER_OF(w, struct follower, work);
-	sm_move(&w->sm, WORK_DONE);
+	struct work *work = CONTAINER_OF(w, struct work, pool_work);
+	struct follower *follower = CONTAINER_OF(work, struct follower, work);
+
+	PRE(follower->ops->is_main_thread());
+	sm_move(&work->sm, WORK_DONE);
 	follower_tick(follower, M_WORK_DONE);
 }
 
@@ -429,6 +430,11 @@ static void rpc_to_cb(uv_timer_t *handle)
 	struct timeout *to = CONTAINER_OF(handle, struct timeout, handle);
 	struct rpc *rpc = CONTAINER_OF(to, struct rpc, timeout);
 	struct leader *leader = CONTAINER_OF(rpc, struct leader, rpc);
+
+	PRE(leader->ops->is_main_thread());
+	if (sm_state(&to->sm) == TO_CANCELED) {
+		return;
+	}
 	sm_move(&to->sm, TO_EXPIRED);
 	sm_move(&rpc->sm, RPC_TIMEDOUT);
 	leader_tick(leader, M_TIMEOUT);
@@ -438,6 +444,11 @@ static void leader_to_cb(uv_timer_t *handle)
 {
 	struct timeout *to = CONTAINER_OF(handle, struct timeout, handle);
 	struct leader *leader = CONTAINER_OF(to, struct leader, timeout);
+
+	PRE(leader->ops->is_main_thread());
+	if (sm_state(&to->sm) == TO_CANCELED) {
+		return;
+	}
 	sm_move(&to->sm, TO_EXPIRED);
 	leader_tick(leader, M_TIMEOUT);
 }
@@ -465,11 +476,11 @@ static void leader_sent_cb(struct sender *s, int rc)
 	struct rpc *rpc = CONTAINER_OF(s, struct rpc, sender);
 	struct leader *leader = CONTAINER_OF(rpc, struct leader, rpc);
 
+	PRE(leader->ops->is_main_thread());
 	if (UNLIKELY(rc != 0)) {
 		sm_move(&rpc->sm, RPC_ERROR);
 		return;
 	}
-
 	leader_tick(leader, M_MSG_SENT);
 }
 
@@ -478,11 +489,11 @@ static void follower_sent_cb(struct sender *s, int rc)
 	struct rpc *rpc = CONTAINER_OF(s, struct rpc, sender);
 	struct follower *follower = CONTAINER_OF(rpc, struct follower, rpc);
 
+	PRE(follower->ops->is_main_thread());
 	if (UNLIKELY(rc != 0)) {
 		sm_move(&rpc->sm, RPC_ERROR);
 		return;
 	}
-
 	follower_tick(follower, M_MSG_SENT);
 }
 
@@ -701,7 +712,7 @@ __attribute__((unused)) void leader_tick(struct leader *leader, const struct raf
 	struct sm *sm = &leader->sm;
 	const struct leader_ops *ops = leader->ops;
 
-	PRE(is_main_thread());
+	PRE(ops->is_main_thread());
 
 	if (!is_a_trigger_leader(leader, incoming) ||
 	    is_a_duplicate(leader, incoming))
@@ -778,7 +789,7 @@ __attribute__((unused)) void follower_tick(struct follower *follower, const stru
 	    is_a_duplicate(follower, incoming))
 		return;
 
-	PRE(is_main_thread());
+	PRE(ops->is_main_thread());
 
 again:
 	switch (sm_state(&follower->sm)) {

--- a/src/raft/recv_install_snapshot.h
+++ b/src/raft/recv_install_snapshot.h
@@ -25,6 +25,7 @@ struct work {
 };
 
 struct sender {
+	// TODO embbed the uv req here.
 	sender_cb_op cb;
 };
 

--- a/src/raft/recv_install_snapshot.h
+++ b/src/raft/recv_install_snapshot.h
@@ -222,6 +222,7 @@ enum follower_states {
 	FS_CHUNCK_APPLIED,
 	FS_CHUNCK_REPLIED,
 
+	FS_SNAP_DONE,
 	FS_FINAL,
 
 	FS_NR,
@@ -305,7 +306,12 @@ static const struct sm_conf follower_sm_conf[FS_NR] = {
 	[FS_CHUNCK_REPLIED] = {
 		.name = "chunk_replied",
 		.allowed = BITS(FS_CHUNCK_PROCESSED)
-		         | BITS(FS_FINAL)
+		         | BITS(FS_SNAP_DONE)
+		         | BITS(FS_NORMAL),
+	},
+	[FS_SNAP_DONE] = {
+		.name = "snap_done",
+		.allowed = BITS(FS_FINAL)
 		         | BITS(FS_NORMAL),
 	},
 	[FS_FINAL] = {

--- a/src/raft/recv_install_snapshot.h
+++ b/src/raft/recv_install_snapshot.h
@@ -58,7 +58,7 @@ struct leader_ops {
 
 	void (*work_queue)(struct work *w,
 			    work_op work, work_op after_cb);
-	bool (*is_main_thread)(void);
+	bool (*is_pool_thread)(void);
 };
 
 struct follower_ops {
@@ -70,7 +70,7 @@ struct follower_ops {
 	sender_send_op sender_send;
 	void (*work_queue)(struct work *w,
 			    work_op work, work_op after_cb);
-	bool (*is_main_thread)(void);
+	bool (*is_pool_thread)(void);
 };
 
 struct leader {

--- a/test/raft/unit/test_snapshot.c
+++ b/test/raft/unit/test_snapshot.c
@@ -239,6 +239,10 @@ TEST(snapshot_follower, basic, set_up, tear_down, 0, NULL) {
 	PRE(sm_state(&follower.sm) == FS_CHUNCK_APPLIED);
 	ut_rpc_sent(&follower.rpc);
 
+	PRE(sm_state(&follower.sm) == FS_SNAP_DONE);
+	ut_follower_message_received(&follower, ut_install_snapshot());
+	ut_rpc_sent(&follower.rpc);
+
 	sm_fini(&follower.sm);
 	return MUNIT_OK;
 }
@@ -633,6 +637,10 @@ TEST(snapshot_follower, pool, set_up, tear_down, 0, NULL) {
 	wait_work();
 
 	PRE(sm_state(&follower->sm) == FS_CHUNCK_APPLIED);
+	ut_rpc_sent(&follower->rpc);
+
+	PRE(sm_state(&follower->sm) == FS_SNAP_DONE);
+	ut_follower_message_received(follower, ut_install_snapshot());
 	ut_rpc_sent(&follower->rpc);
 
 	sm_fini(&follower->sm);


### PR DESCRIPTION
This PR integrates the pool with the snapshot installation. This is a first version without the real implementation for the callbacks and I/O. It solves a few issues found along the way, namely it includes:
* pool integration for background work,
* emulating the async nature of rpc sending by scheduling a callback using libuv,
* first versions of rpc_fill and is_a_trigger, that means that the code can now generate primitive messages and expect the correct ones,
* tests now assert that the messages sent are the correct ones,
* added missing state which I noticed when writing new tests.

See the commit list for more information as the functionality is split into self-contained units.