### PR TITLE
Two-node vfs2 unit test

### DIFF
--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -86,8 +86,8 @@ enum {
  *                 |  v    v-+ xWrite(WAL)
  *                 |--ACTIVE-+
  *                 |  |
- *      vfs2_abort |  | COMMIT_PHASETWO
- *                 |  |
+ *     vfs2_abort, |  | COMMIT_PHASETWO
+ *     vfs2_unhide |  |
  *                 |  v
  *                 |--HIDDEN
  *                 |  |

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -858,8 +858,11 @@ static int vfs2_shm_lock(sqlite3_file *file, int ofst, int n, int flags)
 		}
 
 		if (ofst == WAL_WRITE_LOCK) {
-			/* Unlocking the write lock: roll back any uncommitted
-			 * transaction. */
+			/* If the last frame of the pending transaction has no
+			 * commit marker when SQLite releases the write lock, it
+			 * means that the transaction rolled back before it
+			 * committed. We respond by throwing away our stored
+			 * frames and resetting the state machine. */
 			assert(n == 1);
 			if (sm_state(&e->wtx_sm) > WTX_BASE &&
 			    e->pending_txn_last_frame_commit == 0) {

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1450,6 +1450,9 @@ static int walk_wal(sqlite3_file *wal,
 		if (rv != SQLITE_OK) {
 			goto err;
 		}
+		/* If the salts for this frame don't match those in the WAL header,
+		 * the frame is (probably) left over from a previous generation of
+		 * the WAL, and so we've found the end of the current generation. */
 		if (!salts_equal(fhdr.salts, hdr.salts)) {
 			break;
 		}

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1596,7 +1596,8 @@ static int open_entry(struct common *common, const char *name, struct entry *e)
 		e->wal_cursor > 0 ? WLK_LOCKED : WLK_UNLOCKED);
 	sm_relate(&e->wtx_sm, &e->wlk_sm);
 
-	sm_init(&e->ckpt_sm, no_invariant, NULL, ckpt_states, "ckpt", CKPT_QUIESCENT);
+	sm_init(&e->ckpt_sm, no_invariant, NULL, ckpt_states, "ckpt",
+		CKPT_QUIESCENT);
 	sm_relate(&e->wtx_sm, &e->ckpt_sm);
 
 	sm_move(&e->wtx_sm, e->wal_cursor > 0 ? WTX_FOLLOWING

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -516,7 +516,7 @@ static int shm_add_pgno(struct shm *shm, uint32_t frame, uint32_t pgno)
 		return SQLITE_OK;
 	}
 
-	uint32_t regno = (frame - SHM_SHORT_PGNOS_LEN) / SHM_LONG_PGNOS_LEN;
+	uint32_t regno = 1 + (frame - SHM_SHORT_PGNOS_LEN) / SHM_LONG_PGNOS_LEN;
 	uint32_t index = (frame - SHM_SHORT_PGNOS_LEN) % SHM_LONG_PGNOS_LEN;
 	PRE(regno <= (uint32_t)shm->num_regions + 1);
 	struct shm_region *region;
@@ -1332,7 +1332,7 @@ static void shm_update_ht(struct shm *shm, uint32_t frame)
 		return;
 	}
 
-	uint32_t regno = (frame - SHM_SHORT_PGNOS_LEN) / SHM_LONG_PGNOS_LEN;
+	uint32_t regno = 1 + (frame - SHM_SHORT_PGNOS_LEN) / SHM_LONG_PGNOS_LEN;
 	uint32_t index = (frame - SHM_SHORT_PGNOS_LEN) % SHM_LONG_PGNOS_LEN;
 	PRE(regno <= (uint32_t)shm->num_regions);
 	struct shm_region *region = shm->regions[regno];

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1456,7 +1456,7 @@ int vfs2_apply(sqlite3_file *file, struct vfs2_wal_slice stop)
 	int rv = wal_cur->pMethods->xRead(
 	    wal_cur, &fhdr, sizeof(fhdr),
 	    wal_offset_from_cursor(e->page_size, stop.start + stop.len - 1));
-	if (rv == SQLITE_OK) {
+	if (rv != SQLITE_OK) {
 		return rv;
 	}
 	set_mx_frame(e, commit, fhdr);

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -56,8 +56,9 @@ enum {
 	WTX_EMPTY,
 	/* Non-leader, at least one transaction in WAL-cur is not committed. */
 	WTX_FOLLOWING,
-	/* Leader, all transactions in WAL-cur are committed (but at least one
-	   is not checkpointed). */
+	/* All transactions in WAL-cur are committed, but at least one is not
+	 * checkpointed. (Both leaders and non-leaders can be in this state).
+	 */
 	WTX_BASE,
 	/* Leader, transaction in progress. */
 	WTX_ACTIVE,

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1406,6 +1406,13 @@ static int walk_wal(sqlite3_file *wal,
 			       ByteGetBe32(hdr.cksum2) };
 	int rv;
 
+	/* TODO(cole): support WALs that use a non-native byte order for the
+	 * checksums (because our data directory was transferred from another
+	 * machine). */
+	if (ByteGetBe32(hdr.magic) != (is_bigendian() ? BE_MAGIC : LE_MAGIC)) {
+		return SQLITE_ERROR;
+	}
+
 	/* Check whether we have been provided a stopping point that corresponds
 	 * to a transaction in the current WAL. (It's possible that the stopping
 	 * point corresponds to a transaction that's in WAL-prev instead.) */

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -38,8 +38,8 @@
 
 #define READ_MARK_UNUSED 0xffffffff
 
-#define DB_HEADER_SIZE 100
-#define DB_HEADER_NPAGES_OFFSET 28
+#define DB_FILE_HEADER_SIZE 100
+#define DB_FILE_HEADER_NPAGES_OFFSET 28
 
 static const uint32_t invalid_magic = 0x17171717;
 
@@ -1772,14 +1772,14 @@ int vfs2_add_uncommitted(sqlite3_file *file,
 		sums.cksum2 = ByteGetBe32(e->wal_cur_hdr.cksum2);
 		/* The database size in pages is kept in a field of the database
 		 * header. */
-		uint8_t b[DB_HEADER_SIZE];
+		uint8_t b[DB_FILE_HEADER_SIZE];
 		rv =
 		    xfile->orig->pMethods->xRead(xfile->orig, &b, sizeof(b), 0);
 		/* TODO(cole) this can't fail provided that the main file
 		 * has been created; ensure that this is the case even if
 		 * we haven't run a checkpoint yet. */
 		assert(rv == SQLITE_OK);
-		db_size = ByteGetBe32(b + DB_HEADER_NPAGES_OFFSET);
+		db_size = ByteGetBe32(b + DB_FILE_HEADER_NPAGES_OFFSET);
 	}
 	POST(db_size > 0);
 

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -3,6 +3,7 @@
 #include "lib/byte.h"
 #include "lib/queue.h"
 #include "lib/sm.h"
+#include "tracing.h"
 #include "utils.h"
 
 #include <pthread.h>
@@ -1877,4 +1878,13 @@ int vfs2_pseudo_read_end(sqlite3_file *file, unsigned i)
 	PRE(e->shm_locks[i] > 0);
 	e->shm_locks[i] -= 1;
 	return 0;
+}
+
+void vfs2_ut_sm_relate(sqlite3_file *orig, sqlite3_file *targ)
+{
+	struct file *forig = (struct file *)orig;
+	PRE(forig->flags & SQLITE_OPEN_MAIN_DB);
+	struct file *ftarg = (struct file *)targ;
+	PRE(ftarg->flags & SQLITE_OPEN_MAIN_DB);
+	sm_relate(&forig->entry->wtx_sm, &ftarg->entry->wtx_sm);
 }

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1710,6 +1710,9 @@ int vfs2_add_uncommitted(sqlite3_file *file,
 	struct file *xfile = (struct file *)file;
 	PRE(xfile->flags & SQLITE_OPEN_MAIN_DB);
 	struct entry *e = xfile->entry;
+	if (e->page_size == 0) {
+		e->page_size = page_size;
+	}
 	PRE(page_size == e->page_size);
 	int rv;
 

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1468,7 +1468,6 @@ int vfs2_apply(sqlite3_file *file, struct vfs2_wal_slice stop)
 
 int vfs2_poll(sqlite3_file *file,
 	      dqlite_vfs_frame **frames,
-	      unsigned *n,
 	      struct vfs2_wal_slice *sl)
 {
 	struct file *xfile = (struct file *)file;
@@ -1488,8 +1487,7 @@ int vfs2_poll(sqlite3_file *file,
 
 	/* Note, not resetting pending_txn_{start,len} because they are used by
 	 * later states */
-	if (n != NULL && frames != NULL) {
-		*n = len;
+	if (frames != NULL) {
 		*frames = e->pending_txn_frames;
 	} else {
 		for (uint32_t i = 0; i < e->pending_txn_len; i++) {

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1005,6 +1005,7 @@ static void set_mx_frame(struct entry *e,
 	struct vfs2_shm_region0 *r0 = e->shm_regions[0];
 	PRE(mx <= REGION0_PGNOS_LEN);
 	for (uint32_t i = old_mx; i < mx; i++) {
+		/* TODO(cole) Support hash tables beyond the first. */
 		PRE(i < REGION0_PGNOS_LEN);
 		pgno_ht_insert(r0->ht, REGION0_HT_LEN, (uint16_t)i,
 			       r0->pgnos[i]);
@@ -1784,6 +1785,7 @@ int vfs2_add_uncommitted(sqlite3_file *file,
 	POST(db_size > 0);
 
 	struct vfs2_shm_region0 *r0 = e->shm_regions[0];
+	/* TODO(cole) Support hash tables beyond the first. */
 	PRE(e->wal_cursor < REGION0_PGNOS_LEN);
 	r0->pgnos[e->wal_cursor] = (uint32_t)frames[0].page_number;
 

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -427,7 +427,7 @@ static struct shm_region *shm_grow(struct shm *shm)
 	}
 	p[index] = r;
 	shm->regions = p;
-	shm->num_regions++;
+	shm->num_regions = index + 1;
 	return r;
 
 err_after_alloc_region:

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1260,7 +1260,8 @@ static void pgno_ht_insert(uint16_t *ht, uint16_t fx, uint32_t pgno)
 	}
 	/* SQLite uses 1-based frame indices in this context, reserving
 	 * 0 for a sentinel value. */
-	ht[hash % SHM_HT_LEN] = fx + 1;
+	fx++;
+	ht[hash % SHM_HT_LEN] = fx;
 }
 
 /**

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -228,11 +228,13 @@ static const struct sm_conf shm_states[SHM_NR] = {
 	},
 	[SHM_RECOVERED] = {
 		.name = "recovered",
-		.allowed = BITS(SHM_MANAGED)
+		.allowed = BITS(SHM_MANAGED),
+		.flags = SM_FINAL
 	},
 	[SHM_MANAGED] = {
 		.name = "managed",
-		.allowed = BITS(SHM_MANAGED)
+		.allowed = BITS(SHM_MANAGED),
+		.flags = SM_FINAL
 	},
 };
 
@@ -250,7 +252,7 @@ static const struct sm_conf ckpt_states[CKPT_NR] = {
 	[CKPT_QUIESCENT] = {
 		.name = "quiescent",
 		.allowed = BITS(CKPT_CHECKPOINTING),
-		.flags = SM_INITIAL
+		.flags = SM_INITIAL|SM_FINAL
 	},
 	[CKPT_CHECKPOINTING] = {
 		.name = "checkpointing",

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -392,8 +392,8 @@ struct shm_region {
  *
  * Each region is stored in its own heap allocation of size
  * VFS2_WAL_INDEX_REGION_SIZE. Using separate allocations ensures that existing
- * region pointers remain valid when new regions are mapped, as SQLite
- * expects.
+ * region pointers held by SQLite remain valid when new regions are mapped, as
+ * SQLite expects.
  */
 struct shm {
 	struct shm_region **regions;

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -2364,6 +2364,8 @@ static unsigned read_lock(unsigned i)
 
 int vfs2_pseudo_read_begin(sqlite3_file *file, uint32_t target, unsigned *out)
 {
+	/* FIXME(cole) this implementation is incorrect and needs to be
+	 * replaced. */
 	struct file *xfile = (struct file *)file;
 	PRE(xfile->flags & SQLITE_OPEN_MAIN_DB);
 	struct entry *e = xfile->entry;

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -62,10 +62,11 @@ enum {
 	/* Leader, transaction committed by SQLite and hidden. */
 	WTX_HIDDEN,
 	/* Leader, transation committed by SQLite, hidden, and polled. */
-	WTX_POLLED
+	WTX_POLLED,
+	WTX_NR
 };
 
-static const struct sm_conf wtx_states[SM_STATES_MAX] = {
+static const struct sm_conf wtx_states[WTX_NR] = {
 	[WTX_CLOSED] = {
 		.flags = SM_INITIAL|SM_FINAL,
 		.name = "closed",

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -969,7 +969,7 @@ static struct wal_index_full_hdr initial_full_hdr(struct wal_hdr whdr)
 	ihdr.basic[0].cksums = sums;
 	ihdr.basic[1] = ihdr.basic[0];
 	ihdr.marks[0] = 0;
-	ihdr.marks[1] = 0;
+	ihdr.marks[1] = READ_MARK_UNUSED;
 	ihdr.marks[2] = READ_MARK_UNUSED;
 	ihdr.marks[3] = READ_MARK_UNUSED;
 	ihdr.marks[4] = READ_MARK_UNUSED;

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1752,11 +1752,12 @@ int vfs2_add_uncommitted(sqlite3_file *file,
 	struct file *xfile = (struct file *)file;
 	PRE(xfile->flags & SQLITE_OPEN_MAIN_DB);
 	struct entry *e = xfile->entry;
-	if (e->page_size == 0) {
-		e->page_size = page_size;
-	}
-	PRE(page_size == e->page_size);
 	int rv;
+
+	/* We require the page size to have been initialized by this point,
+	 * either by reading the WAL when opening the entry or by `PRAGMA
+	 * page_size`. */
+	PRE(page_size == e->page_size);
 
 	/* The write lock is always held if there is at least one
 	 * uncommitted frame in WAL-cur. In FOLLOWING state, we allow

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1505,7 +1505,9 @@ int vfs2_poll(sqlite3_file *file,
 		sl->len = len;
 	}
 
-	sm_move(&xfile->entry->wtx_sm, WTX_POLLED);
+	if (len > 0) {
+		sm_move(&xfile->entry->wtx_sm, WTX_POLLED);
+	}
 
 	return 0;
 }

--- a/src/vfs2.c
+++ b/src/vfs2.c
@@ -1670,6 +1670,11 @@ static struct wal_hdr next_wal_hdr(const struct entry *e)
 	}
 	BytePutBe32(salt1, ret.salts.salt1);
 	sqlite3_randomness(sizeof(ret.salts.salt2), (void *)&ret.salts.salt2);
+	struct cksums sums = {};
+	update_cksums(native_magic(), (const uint8_t *)&ret,
+		      offsetof(struct wal_hdr, cksum1), &sums);
+	BytePutBe32(sums.cksum1, ret.cksum1);
+	BytePutBe32(sums.cksum2, ret.cksum2);
 	return ret;
 }
 

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -103,7 +103,4 @@ int vfs2_pseudo_read_end(sqlite3_file *file, unsigned i);
  */
 void vfs2_destroy(sqlite3_vfs *vfs);
 
-// TODO access read marks and shm_locks
-// TODO access information about checkpoints
-
 #endif

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -12,15 +12,20 @@
  * Create a new VFS object that wraps the given VFS object.
  *
  * The returned VFS is allocated on the heap and lives until vfs2_destroy is
- * called.  Its methods are thread-safe if those of the wrapped VFS are, but
- * the methods of the sqlite3_file objects it creates are not thread-safe.
- * Therefore, a database connection that's created using this VFS should only
- * be used on the thread that opened it. The functions below that operate on
- * sqlite3_file objects created by this VFS should also only be used on that
- * thread.
+ * called. The provided name is not copied or freed, and must outlive the VFS.
+ *
+ * The methods of the resulting sqlite3_vfs object are thread-safe, but the
+ * xOpen method creates sqlite3_file objects whose methods are not thread-safe.
+ * Therefore, when a database connection is opened using the returned VFS, it
+ * must not subsequently be used on other threads without additional
+ * synchronization. This also goes for the functions below that operate directly
+ * on sqlite3_file.
  */
 sqlite3_vfs *vfs2_make(sqlite3_vfs *orig, const char *name);
 
+/**
+ * A pair of salt values from the header of a WAL file.
+ */
 struct vfs2_salts {
 	uint8_t salt1[4];
 	uint8_t salt2[4];
@@ -28,6 +33,10 @@ struct vfs2_salts {
 
 /**
  * Identifying information about a write transaction.
+ *
+ * The salts identify a WAL file. The `start` and `len` fields have units of
+ * frames and identify a range of frames within that WAL file that represent a
+ * transaction.
  */
 struct vfs2_wal_slice {
 	struct vfs2_salts salts;
@@ -36,10 +45,17 @@ struct vfs2_wal_slice {
 };
 
 /**
- * Retrieve frames that were appended to the WAL by the last write transaction,
- * and reacquire the write lock.
+ * Retrieve a description of a write transaction that was just written to the
+ * WAL.
  *
- * Call this on the database main file object (SQLITE_FCNTL_FILE_POINTER).
+ * The first argument is the main file handle for the database. This function
+ * also acquires the WAL write lock, preventing another write transaction from
+ * overwriting the first one until vfs2_unhide is called.
+ *
+ * The `frames` out argument is populated with an array containing
+ * the frames of the transaction, and the `sl` out argument is populated with a
+ * WAL slice describing the transaction. The length of the frames array is
+ * `sl.len`.
  *
  * Polling the same transaction more than once is an error.
  */
@@ -47,12 +63,45 @@ int vfs2_poll(sqlite3_file *file,
 	      dqlite_vfs_frame **frames,
 	      struct vfs2_wal_slice *sl);
 
+/**
+ * Mark a write transaction that was previously polled as committed, making it
+ * visible to future transactions.
+ *
+ * This function also releases the WAL write lock, allowing another write
+ * transaction to execute. It should be called on the main file handle
+ * (SQLITE_FCNTL_FILE_POINTER).
+ *
+ * It's an error to call this function if no write transaction is currently
+ * pending due to vfs2_poll.
+ */
 int vfs2_unhide(sqlite3_file *file);
 
+/**
+ * Make some transactions in the WAL visible to readers.
+ *
+ * The first argument is the main file for the database
+ * (SQLITE_FCNTL_FILE_POINTER). All transactions up to and including the one
+ * described by the second argument will be marked as committed and made
+ * visible. The WAL write lock is also released if there are no uncommitted
+ * transactions left in the WAL.
+ *
+ * The affected transactions must have been added to the WAL by
+ * vfs2_add_committed.
+ */
 int vfs2_apply(sqlite3_file *file, struct vfs2_wal_slice stop);
 
 /**
- * Add frames to the WAL after receiving them in an AppendEntrie message.
+ * Add the frames of a write transaction directly to the end of the WAL.
+ *
+ * The first argument is the main file handle for the database. On success, the
+ * WAL write lock is acquired if it was not held already. The added frames are
+ * initially invisible to readers, and must be made visible by calling
+ * vfs2_commit or removed from the WAL by calling vfs2_unadd.
+ *
+ * A WAL slice describing the new transaction is written to the last argument.
+ *
+ * The `page_size` for the new frames must match the page size already set for
+ * this database.
  */
 int vfs2_add_uncommitted(sqlite3_file *file,
 			 uint32_t page_size,
@@ -60,8 +109,23 @@ int vfs2_add_uncommitted(sqlite3_file *file,
 			 unsigned n,
 			 struct vfs2_wal_slice *out);
 
+/**
+ * Remove some transactions from the WAL.
+ *
+ * The first argument is the main file handle for the database
+ * (SQLITE_FCNTL_FILE_POINTER). The second argument is a WAL slice. The
+ * transaction described by this slice, and all following transactions, will be
+ * removed from the WAL. The WAL write lock will be released if there are no
+ * uncommitted transactions in the WAL afterward.
+ *
+ * All removed transactions must have been added to the WAL by
+ * vfs2_add_uncommitted, and must not have been made visible using vfs2_commit.
+ */
 int vfs2_unadd(sqlite3_file *file, struct vfs2_wal_slice stop);
 
+/**
+ * Request to read a specific transaction from a WAL file.
+ */
 struct vfs2_wal_txn {
 	struct vfs2_wal_slice meta;
 	dqlite_vfs_frame *frames;
@@ -90,8 +154,23 @@ int vfs2_read_wal(sqlite3_file *file,
  */
 int vfs2_abort(sqlite3_file *file);
 
+/**
+ * Try to set a read lock at a fixed place in the WAL-index.
+ *
+ * The first argument is the main file handle for the database
+ * (SQLITE_FCNTL_FILE_POINTER). The second argument is the desired value for the
+ * read mark, in units of frames. On success, the index of the read mark is
+ * written to the last argument, and the corresponding WAL read lock is held.
+ *
+ * This function may fail if all read marks are in used when it is called.
+ */
 int vfs2_pseudo_read_begin(sqlite3_file *file, uint32_t target, unsigned *out);
 
+/**
+ * Unset a read mark that was set by vfs2_pseudo_read_begin.
+ *
+ * This also releases the corresponding read lock.
+ */
 int vfs2_pseudo_read_end(sqlite3_file *file, unsigned i);
 
 /**

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -45,7 +45,6 @@ struct vfs2_wal_slice {
  */
 int vfs2_poll(sqlite3_file *file,
 	      dqlite_vfs_frame **frames,
-	      unsigned *n,
 	      struct vfs2_wal_slice *sl);
 
 int vfs2_unhide(sqlite3_file *file);

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -190,4 +190,17 @@ void vfs2_destroy(sqlite3_vfs *vfs);
  */
 void vfs2_ut_sm_relate(sqlite3_file *orig, sqlite3_file *targ);
 
+#define VFS2_WAL_HDR_SIZE 32
+
+/**
+ * Write a WAL header with the provided fields to the given buffer.
+ *
+ * The size of the buffer must be at least VFS2_WAL_HDR_SIZE bytes.
+ */
+void vfs2_ut_make_wal_hdr(uint8_t *buf,
+			  uint32_t page_size,
+			  uint32_t ckpoint_seqno,
+			  uint32_t salt1,
+			  uint32_t salt2);
+
 #endif

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -181,4 +181,13 @@ int vfs2_pseudo_read_end(sqlite3_file *file, unsigned i);
  */
 void vfs2_destroy(sqlite3_vfs *vfs);
 
+/**
+ * Declare a relationship between two databases opened by (possibly distinct)
+ * vfs2 instances.
+ *
+ * Intended for use by unit tests. The arguments are main file handles
+ * (SQLITE_FCNTL_FILE_POINTER).
+ */
+void vfs2_ut_sm_relate(sqlite3_file *orig, sqlite3_file *targ);
+
 #endif

--- a/src/vfs2.h
+++ b/src/vfs2.h
@@ -1,6 +1,8 @@
 #ifndef DQLITE_VFS2_H
 #define DQLITE_VFS2_H
 
+#include "../include/dqlite.h" /* dqlite_vfs_frame */
+
 #include <sqlite3.h>
 
 #include <stddef.h>
@@ -33,12 +35,6 @@ struct vfs2_wal_slice {
 	uint32_t len;
 };
 
-struct vfs2_wal_frame {
-	uint32_t page_number;
-	uint32_t commit;
-	void *page;
-};
-
 /**
  * Retrieve frames that were appended to the WAL by the last write transaction,
  * and reacquire the write lock.
@@ -48,7 +44,7 @@ struct vfs2_wal_frame {
  * Polling the same transaction more than once is an error.
  */
 int vfs2_poll(sqlite3_file *file,
-	      struct vfs2_wal_frame **frames,
+	      dqlite_vfs_frame **frames,
 	      unsigned *n,
 	      struct vfs2_wal_slice *sl);
 
@@ -56,9 +52,12 @@ int vfs2_unhide(sqlite3_file *file);
 
 int vfs2_apply(sqlite3_file *file, struct vfs2_wal_slice stop);
 
+/**
+ * Add frames to the WAL after receiving them in an AppendEntrie message.
+ */
 int vfs2_add_uncommitted(sqlite3_file *file,
 			 uint32_t page_size,
-			 const struct vfs2_wal_frame *frames,
+			 const dqlite_vfs_frame *frames,
 			 unsigned n,
 			 struct vfs2_wal_slice *out);
 
@@ -66,7 +65,7 @@ int vfs2_unadd(sqlite3_file *file, struct vfs2_wal_slice stop);
 
 struct vfs2_wal_txn {
 	struct vfs2_wal_slice meta;
-	struct vfs2_wal_frame *frames;
+	dqlite_vfs_frame *frames;
 };
 
 /**

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -156,7 +156,7 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	munit_assert_int(rv, ==, SQLITE_OK);
 
 	struct vfs2_wal_slice sl;
-	rv = vfs2_poll(fp, NULL, NULL, &sl);
+	rv = vfs2_poll(fp, NULL, &sl);
 	munit_assert_int(rv, ==, 0);
 	rv = vfs2_unhide(fp);
 	munit_assert_int(rv, ==, 0);
@@ -173,7 +173,7 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	rv = sqlite3_exec(db, "INSERT INTO foo (bar) values (22)", NULL, NULL,
 			  NULL);
 	munit_assert_int(rv, ==, 0);
-	rv = vfs2_poll(fp, NULL, NULL, &sl);
+	rv = vfs2_poll(fp, NULL, &sl);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_uint32(sl.start, ==, 2);
 	munit_assert_uint32(sl.len, ==, 1);
@@ -213,10 +213,9 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	munit_assert_int(rv, ==, SQLITE_DONE);
 
 	dqlite_vfs_frame *frames;
-	unsigned n;
-	rv = vfs2_poll(fp, &frames, &n, &sl);
+	rv = vfs2_poll(fp, &frames, &sl);
 	munit_assert_int(rv, ==, 0);
-	munit_assert_uint(n, ==, 1);
+	munit_assert_uint(sl.len, ==, 1);
 	munit_assert_not_null(frames);
 	munit_assert_not_null(frames[0].data);
 	sqlite3_free(frames[0].data);
@@ -386,7 +385,7 @@ TEST(vfs2, rollback, set_up, tear_down, 0, NULL)
 	sqlite3_file *fp;
 	sqlite3_file_control(db, "main", SQLITE_FCNTL_FILE_POINTER, &fp);
 	struct vfs2_wal_slice sl;
-	rv = vfs2_poll(fp, NULL, NULL, &sl);
+	rv = vfs2_poll(fp, NULL, &sl);
 	munit_assert_int(rv, ==, 0);
 	rv = vfs2_unhide(fp);
 	rv = sqlite3_exec(db, "BEGIN", NULL, NULL, NULL);

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -388,9 +388,12 @@ TEST(vfs2, leader_and_follower, set_up, tear_down, 0, NULL)
 	OK(vfs2_poll(leader_fp, &frames, &leader_sl));
 	munit_assert_uint(leader_sl.len, ==, 2);
 
-	/* The follower receives the transaction. */
+	/* The follower opens its database. */
 	sqlite3 *follower_db = node_open_db(follower, "test.db");
 	sqlite3_file *follower_fp = main_file(follower_db);
+	vfs2_ut_sm_relate(leader_fp, follower_fp);
+
+	/* The follower receives the transaction. */
 	struct vfs2_wal_slice follower_sl;
 	OK(vfs2_add_uncommitted(follower_fp, PAGE_SIZE, frames, leader_sl.len,
 				&follower_sl));

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -271,7 +271,6 @@ TEST(vfs2, startup_both_nonempty, set_up, tear_down, 0, NULL)
 	struct fixture *f = data;
 	struct node *node = &f->nodes[0];
 	char buf[PATH_MAX];
-	int rv;
 
 	snprintf(buf, PATH_MAX, "%s/%s", node->dir, "test.db");
 	assert_wal_sizes(buf, 0, 0);
@@ -284,17 +283,8 @@ TEST(vfs2, startup_both_nonempty, set_up, tear_down, 0, NULL)
 	prepare_wals(buf, wal1_hdronly, sizeof(wal1_hdronly), wal2_hdronly,
 		     sizeof(wal2_hdronly));
 	sqlite3 *db = node_open_db(node, "test.db");
-	rv = sqlite3_exec(db,
-			  "PRAGMA page_size=" PAGE_SIZE_STR
-			  ";"
-			  "PRAGMA journal_mode=WAL;"
-			  "PRAGMA wal_autocheckpoint=0",
-			  NULL, NULL, NULL);
-	munit_assert_int(rv, ==, SQLITE_OK);
-	rv = sqlite3_exec(db, "CREATE TABLE foo (n INTEGER)", NULL, NULL, NULL);
-	munit_assert_int(rv, ==, SQLITE_OK);
-	rv = sqlite3_close(db);
-	munit_assert_int(rv, ==, SQLITE_OK);
+	OK(sqlite3_exec(db, "CREATE TABLE foo (n INTEGER)", NULL, NULL, NULL));
+	OK(sqlite3_close(db));
 
 	/* WAL2 ends up with the frames. */
 	assert_wal_sizes(buf, WAL_SIZE_FROM_FRAMES(0), WAL_SIZE_FROM_FRAMES(2));

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -82,6 +82,8 @@ static sqlite3 *node_open_db(const struct node *node, const char *name)
 			  "PRAGMA wal_autocheckpoint=0",
 			  NULL, NULL, NULL);
 	munit_assert_int(rv, ==, SQLITE_OK);
+	rv = sqlite3_db_config(db, SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE, 1, NULL);
+	munit_assert_int(rv, ==, SQLITE_OK);
 	return db;
 }
 

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -60,6 +60,9 @@ static void tear_down(void *data)
 	free(f);
 }
 
+/**
+ * Open a connection to a test database for this node.
+ */
 static sqlite3 *open_test_db(const struct node *node)
 {
 	char buf[PATH_MAX];
@@ -80,6 +83,9 @@ static sqlite3 *open_test_db(const struct node *node)
 	return db;
 }
 
+/**
+ * Write two WALs to disk with the given contents.
+ */
 static void prepare_wals(const char *dbname,
 			 const unsigned char *wal1,
 			 size_t wal1_len,
@@ -113,6 +119,9 @@ static void prepare_wals(const char *dbname,
 	}
 }
 
+/**
+ * Assert the lengths of WAL1 and WAL2 on disk.
+ */
 static void check_wals(const char *dbname, off_t wal1_len, off_t wal2_len)
 {
 	char buf[PATH_MAX];
@@ -130,6 +139,9 @@ static void check_wals(const char *dbname, off_t wal1_len, off_t wal2_len)
 			  (rv < 0 && errno == ENOENT && wal2_len == 0));
 }
 
+/**
+ * Single-node test with several transactions and a checkpoint.
+ */
 TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 {
 	struct fixture *f = data;
@@ -233,6 +245,10 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 
 #define WAL_SIZE_FROM_FRAMES(n) (32 + (24 + PAGE_SIZE) * (n))
 
+/**
+ * Create a WAL header with the sequence number and salts set to the
+ * given values.
+ */
 static void make_wal_hdr(uint8_t *buf,
 			 uint32_t ckpoint_seqno,
 			 uint32_t salt1,
@@ -276,6 +292,9 @@ static void make_wal_hdr(uint8_t *buf,
 	p += 4;
 }
 
+/**
+ * When only one WAL is nonempty at startup, that WAL becomes WAL-cur.
+ */
 TEST(vfs2, startup_one_nonempty, set_up, tear_down, 0, NULL)
 {
 	struct fixture *f = data;
@@ -305,6 +324,10 @@ TEST(vfs2, startup_one_nonempty, set_up, tear_down, 0, NULL)
 	return MUNIT_OK;
 }
 
+/**
+ * When both WALs are nonempty at startup, the one with the higher salt1
+ * value becomes WAL-cur.
+ */
 TEST(vfs2, startup_both_nonempty, set_up, tear_down, 0, NULL)
 {
 	struct fixture *f = data;
@@ -339,6 +362,9 @@ TEST(vfs2, startup_both_nonempty, set_up, tear_down, 0, NULL)
 	return MUNIT_OK;
 }
 
+/**
+ * Single-node test of rolling back a transaction.
+ */
 TEST(vfs2, rollback, set_up, tear_down, 0, NULL)
 {
 	struct fixture *f = data;

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -212,14 +212,14 @@ TEST(vfs2, basic, set_up, tear_down, 0, NULL)
 	rv = sqlite3_step(stmt);
 	munit_assert_int(rv, ==, SQLITE_DONE);
 
-	struct vfs2_wal_frame *frames;
+	dqlite_vfs_frame *frames;
 	unsigned n;
 	rv = vfs2_poll(fp, &frames, &n, &sl);
 	munit_assert_int(rv, ==, 0);
 	munit_assert_uint(n, ==, 1);
 	munit_assert_not_null(frames);
-	munit_assert_not_null(frames[0].page);
-	sqlite3_free(frames[0].page);
+	munit_assert_not_null(frames[0].data);
+	sqlite3_free(frames[0].data);
 	sqlite3_free(frames);
 
 	rv = vfs2_unhide(fp);

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -283,9 +283,8 @@ TEST(vfs2, startup_frames_in_one, set_up, tear_down, 0, NULL)
 	struct vfs2_wal_slice sl;
 	OK(vfs2_poll(fp, NULL, &sl));
 	OK(sqlite3_close(db));
-	/* WAL2 has the frames. The value 4 here reflect the invalid magic
-	 * number that we write to the outgoing WAL. */
-	assert_wal_sizes(node, "test.db", 4, WAL_SIZE_FROM_FRAMES(2));
+	/* WAL2 has the frames. */
+	assert_wal_sizes(node, "test.db", 0, WAL_SIZE_FROM_FRAMES(2));
 
 	db = node_open_db(node, "test.db");
 	fp = main_file(db);
@@ -381,7 +380,7 @@ TEST(vfs2, leader_and_follower, set_up, tear_down, 0, NULL)
 	OK(sqlite3_exec(leader_db, "CREATE TABLE foo (n INTEGER)", NULL, NULL,
 			NULL));
 	/* WAL2 gets the frames after a WAL swap. */
-	assert_wal_sizes(leader, "test.db", 4, WAL_SIZE_FROM_FRAMES(2));
+	assert_wal_sizes(leader, "test.db", 0, WAL_SIZE_FROM_FRAMES(2));
 	sqlite3_file *leader_fp = main_file(leader_db);
 	dqlite_vfs_frame *frames;
 	struct vfs2_wal_slice leader_sl;
@@ -398,7 +397,7 @@ TEST(vfs2, leader_and_follower, set_up, tear_down, 0, NULL)
 	OK(vfs2_add_uncommitted(follower_fp, PAGE_SIZE, frames, leader_sl.len,
 				&follower_sl));
 	/* WAL2 gets the frames after a WAL swap. */
-	assert_wal_sizes(follower, "test.db", 4, WAL_SIZE_FROM_FRAMES(2));
+	assert_wal_sizes(follower, "test.db", 0, WAL_SIZE_FROM_FRAMES(2));
 	sqlite3_free(frames[0].data);
 	sqlite3_free(frames[1].data);
 	sqlite3_free(frames);

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -16,7 +16,7 @@
 #define PAGE_SIZE 512
 #define PAGE_SIZE_STR "512"
 
-#define OK(rv) munit_assert_int(rv, ==, 0)
+#define OK(rv) munit_assert_int((rv), ==, 0)
 
 SUITE(vfs2);
 

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -121,7 +121,7 @@ static void prepare_wals(const char *dbname,
 /**
  * Assert the lengths of WAL1 and WAL2 on disk.
  */
-static void check_wals(const char *dbname, off_t wal1_len, off_t wal2_len)
+static void assert_wal_sizes(const char *dbname, off_t wal1_len, off_t wal2_len)
 {
 	char buf[PATH_MAX];
 	struct stat st;
@@ -290,7 +290,7 @@ TEST(vfs2, startup_one_nonempty, set_up, tear_down, 0, NULL)
 
 	snprintf(buf, PATH_MAX, "%s/%s", node->dir, "test.db");
 
-	check_wals(buf, 0, 0);
+	assert_wal_sizes(buf, 0, 0);
 
 	uint8_t wal2_hdronly[WAL_SIZE_FROM_FRAMES(0)] = { 0 };
 	make_wal_hdr(wal2_hdronly, 0, 17, 103);
@@ -299,7 +299,7 @@ TEST(vfs2, startup_one_nonempty, set_up, tear_down, 0, NULL)
 	OK(sqlite3_exec(db, "CREATE TABLE foo (n INTEGER)", NULL, NULL, NULL));
 	OK(sqlite3_close(db));
 
-	check_wals(buf, WAL_SIZE_FROM_FRAMES(2), WAL_SIZE_FROM_FRAMES(0));
+	assert_wal_sizes(buf, WAL_SIZE_FROM_FRAMES(2), WAL_SIZE_FROM_FRAMES(0));
 
 	return MUNIT_OK;
 }
@@ -316,7 +316,7 @@ TEST(vfs2, startup_both_nonempty, set_up, tear_down, 0, NULL)
 	int rv;
 
 	snprintf(buf, PATH_MAX, "%s/%s", node->dir, "test.db");
-	check_wals(buf, 0, 0);
+	assert_wal_sizes(buf, 0, 0);
 
 	uint8_t wal1_hdronly[WAL_SIZE_FROM_FRAMES(0)] = { 0 };
 	make_wal_hdr(wal1_hdronly, 0, 18, 103);
@@ -337,7 +337,7 @@ TEST(vfs2, startup_both_nonempty, set_up, tear_down, 0, NULL)
 	rv = sqlite3_close(db);
 	munit_assert_int(rv, ==, SQLITE_OK);
 
-	check_wals(buf, WAL_SIZE_FROM_FRAMES(0), WAL_SIZE_FROM_FRAMES(2));
+	assert_wal_sizes(buf, WAL_SIZE_FROM_FRAMES(0), WAL_SIZE_FROM_FRAMES(2));
 
 	return MUNIT_OK;
 }


### PR DESCRIPTION
This PR contains a new unit test for vfs2 that simulates replicating a transaction between a leader and a follower, plus supporting fixes:

- Remove FLUSH from the state machine and vfs2_commit_barrier from the public API.
- Several fixes picked from the previous integration PR (see individual commits for more details):
  - Replace `vfs2_wal_frame` with `dqlite_vfs_frame`.
  - Calculate and set the checksum fields in the WAL header.
  - Initialize the page size for a database, if not already set, when calling vfs2_add_uncommitted.
  - Call sqlite3_randomness instead of `xRandomness` from the `unix` VFS to randomize the WAL header salts.
- Updating the hash table in the first shm region of the WAL-index whenever `mxFrame` increases on the follower.
- Properly writing the WAL header when the WAL is written for the first time.
- Finalizing the memory allocated for the WAL-index when an entry is closed, rather than when xShmUnmap is last called.

Signed-off-by: Cole Miller <cole.miller@canonical.com>