### PR TITLE
pool: Use uintptr_t for pool thread magic number

### DIFF
--- a/src/lib/threadpool.c
+++ b/src/lib/threadpool.c
@@ -76,7 +76,7 @@ static const struct sm_conf planner_states[PS_NR] = {
 	},
 };
 
-static const uint64_t pool_thread_magic = 0xf344e2;
+static const uintptr_t pool_thread_magic = 0xf344e2;
 static uv_key_t thread_identifier_key;
 
 enum {


### PR DESCRIPTION
This ensures that it's the same size as void *, so that casting to that type won't trigger a diagnostic on any target. This fixes [an armhf build failure](https://launchpadlibrarian.net/741853277/buildlog_snap_ubuntu_noble_armhf_lxd-latest-edge_BUILDING.txt.gz).

Signed-off-by: Cole Miller <cole.miller@canonical.com>