### PR TITLE
gateway: Break recursion in handle_exec_sql

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -311,7 +311,7 @@ int conn__start(struct conn *c,
 	c->transport.data = c;
 	c->uv_transport = uv_transport;
 	c->close_cb = close_cb;
-	gateway__init(&c->gateway, config, registry, raft, seed);
+	gateway__init(&c->gateway, config, loop, registry, raft, seed);
 	rv = buffer__init(&c->read);
 	if (rv != 0) {
 		goto err_after_transport_init;

--- a/src/conn.c
+++ b/src/conn.c
@@ -127,6 +127,7 @@ static void raft_connect(struct conn *c)
 	/* Close the connection without actually closing the transport, since
 	 * the stream will be used by raft */
 	c->closed = true;
+	gateway__close(&c->gateway);
 	closeCb(&c->transport);
 }
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -731,7 +731,7 @@ static void handle_exec_sql_next(struct gateway *g,
 static void schedule_exec_sql_next_cb(uv_timer_t *t)
 {
 	struct gateway *g = t->data;
-	PRE(g->req != NULL);
+	PRE(g != NULL && g->req != NULL);
 	PRE(g->req->type == DQLITE_REQUEST_EXEC_SQL);
 	handle_exec_sql_next(g, g->req, true);
 }
@@ -739,8 +739,8 @@ static void schedule_exec_sql_next_cb(uv_timer_t *t)
 static void schedule_exec_sql_next(struct gateway *g)
 {
 	PRE(g->req->type == DQLITE_REQUEST_EXEC_SQL);
-	g->sched.data = g;
 	if (g->sched.loop != NULL) {
+		g->sched.data = g;
 		uv_timer_start(&g->sched, schedule_exec_sql_next_cb, 0, 0);
 	} else {
 		schedule_exec_sql_next_cb(&g->sched);
@@ -757,7 +757,7 @@ static void handle_exec_sql_cb(struct exec *exec, int status)
 	sqlite3_finalize(exec->stmt);
 
 	if (status == SQLITE_DONE) {
-		/* The next line simply for the event loop to call
+		/* The next line simply arranges for the event loop to call
 		 * handle_exec_sql_next on the next iteration. We could just
 		 * call handle_exec_sql_next here, but that causes bounded
 		 * recursion when needsBarrier is false, with the maximum stack

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -35,10 +35,20 @@ struct gateway {
 	uint64_t protocol;           /* Protocol format version */
 	uint64_t client_id;
 	struct id_state random_state; /* For generating IDs */
+	/* handle_exec_sql uses this to defer some work to the next loop
+	 * iteration. */
+	uv_timer_t sched;
 };
 
+/**
+ * Initialize a gateway.
+ *
+ * Passing NULL for the `loop` is permitted. Currently the loop is only used
+ * optionally to break potential recursion in handle_exec_sql.
+ */
 void gateway__init(struct gateway *g,
 		   struct config *config,
+		   uv_loop_t *loop,
 		   struct registry *registry,
 		   struct raft *raft,
 		   struct id_state seed);

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -35,8 +35,9 @@ struct gateway {
 	uint64_t protocol;           /* Protocol format version */
 	uint64_t client_id;
 	struct id_state random_state; /* For generating IDs */
-	/* handle_exec_sql uses this to defer some work to the next loop
-	 * iteration. */
+	/* The EXEC_SQL request handler uses this to defer work to the next
+	 * loop iteration, to avoid recursion when processing multi-statement
+	 * SQL strings. */
 	uv_timer_t sched;
 };
 
@@ -44,7 +45,8 @@ struct gateway {
  * Initialize a gateway.
  *
  * Passing NULL for the `loop` is permitted. Currently the loop is only used
- * optionally to break potential recursion in handle_exec_sql.
+ * optionally to break potential recursion when handling an EXEC_SQL request
+ * that containss multiple `;`-separated statements.
  */
 void gateway__init(struct gateway *g,
 		   struct config *config,

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -38,7 +38,7 @@ struct gateway {
 	/* The EXEC_SQL request handler uses this to defer work to the next
 	 * loop iteration, to avoid recursion when processing multi-statement
 	 * SQL strings. */
-	uv_timer_t sched;
+	uv_timer_t defer;
 };
 
 /**

--- a/src/leader.h
+++ b/src/leader.h
@@ -49,6 +49,9 @@ struct barrier {
 	void *data;
 	struct leader *leader;
 	struct raft_barrier req;
+	/* When the callback is invoked, this field is `true` if raft_barrier
+	 * was called and `false` if the callback was invoked immediately. */
+	bool async;
 	barrier_cb cb;
 };
 
@@ -63,8 +66,12 @@ struct exec {
 	uint64_t id;
 	int status;
 	queue queue;
-	exec_cb cb;
 	pool_work_t work;
+	/* When the callback is invoked, this field is `true` if raft_barrier
+	 * or raft_apply was called and `false` if the callback was invoked
+	 * immediately. */
+	bool async;
+	exec_cb cb;
 };
 
 /**

--- a/test/integration/test_client.c
+++ b/test/integration/test_client.c
@@ -145,3 +145,29 @@ TEST(client, querySql, setUp, tearDown, 0, client_params)
 
 	return MUNIT_OK;
 }
+
+/* Stress test of an EXEC_SQL with many ';'-separated statements. */
+TEST(client, semicolons, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	(void)params;
+
+	static const char trivial_stmt[] = "CREATE TABLE IF NOT EXISTS foo (n INT);";
+
+	size_t n = 1000;
+	size_t unit = sizeof(trivial_stmt) - 1;
+	char *sql = munit_malloc(n * unit);
+	char *p = sql;
+	for (size_t i = 0; i < n; i++) {
+		memcpy(p, trivial_stmt, unit);
+		p += unit;
+	}
+	sql[n * unit - 1] = '\0';
+
+	uint64_t last_insert_id;
+	uint64_t rows_affected;
+	EXEC_SQL(sql, &last_insert_id, &rows_affected);
+
+	free(sql);
+	return MUNIT_OK;
+}

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -49,8 +49,12 @@ struct connection {
 		struct request_open open;                                  \
 		struct response_db db;                                     \
 		struct id_state seed = { { 1 } };                          \
-		gateway__init(&c->gateway, CLUSTER_CONFIG(0),              \
-			      CLUSTER_REGISTRY(0), CLUSTER_RAFT(0), seed); \
+		gateway__init(&c->gateway, \
+			      CLUSTER_CONFIG(0), \
+			      NULL, \
+			      CLUSTER_REGISTRY(0), \
+			      CLUSTER_RAFT(0), \
+			      seed); \
 		c->handle.data = &c->context;                              \
 		rc = buffer__init(&c->request);                            \
 		munit_assert_int(rc, ==, 0);                               \

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -55,8 +55,12 @@ struct connection {
 		struct id_state seed = { { 1 } };                       \
 		config = CLUSTER_CONFIG(i);                             \
 		config->page_size = 512;                                \
-		gateway__init(&c->gateway, config, CLUSTER_REGISTRY(i), \
-			      CLUSTER_RAFT(i), seed);                   \
+		gateway__init(&c->gateway, \
+			      config, \
+			      NULL, \
+			      CLUSTER_REGISTRY(i), \
+			      CLUSTER_RAFT(i), \
+			      seed); \
 		c->handle.data = &c->context;                           \
 		rc = buffer__init(&c->buf1);                            \
 		munit_assert_int(rc, ==, 0);                            \


### PR DESCRIPTION
#679 turned up the fact that we can enter bounded recursion in `handle_exec_sql`, with the maximum number of stack frames being proportional to the number of `;`-separated statements in the `EXEC_SQL` request. This PR breaks that recursion by yielding to the event loop at one link in the chain.

Signed-off-by: Cole Miller <cole.miller@canonical.com>