### PR TITLE
Break recursion in handle_exec_sql_next (second attempt)

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -33,6 +33,11 @@ struct conn
 	struct message request;                 /* Request message meta data */
 	struct message response;                /* Response message meta data */
 	struct handle handle;
+	/* Callback that the gateway has asked to be invoked on the next loop
+	 * iteration, and its argument.  */
+	void (*defer_cb)(void *);
+	void *defer_arg;
+	uv_timer_t defer;
 	bool closed;
 	queue queue;
 };

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -18,7 +18,9 @@ void gateway__init(struct gateway *g,
 		   struct config *config,
 		   struct registry *registry,
 		   struct raft *raft,
-		   struct id_state seed)
+		   struct id_state seed,
+		   defer_impl defer,
+		   void *defer_data)
 {
 	tracef("gateway init");
 	g->config = config;
@@ -34,6 +36,8 @@ void gateway__init(struct gateway *g,
 	g->protocol = DQLITE_PROTOCOL_VERSION;
 	g->client_id = 0;
 	g->random_state = seed;
+	g->defer = defer;
+	g->defer_data = defer_data;
 }
 
 void gateway__leader_close(struct gateway *g, int reason)
@@ -96,6 +100,7 @@ void gateway__leader_close(struct gateway *g, int reason)
 void gateway__close(struct gateway *g)
 {
 	tracef("gateway close");
+
 	if (g->leader == NULL) {
 		stmt__registry_close(&g->stmts);
 		return;
@@ -718,6 +723,14 @@ static void handle_exec_sql_next(struct gateway *g,
 				 struct handle *req,
 				 bool done);
 
+static void handle_exec_sql_next_defer_cb(void *arg)
+{
+	struct gateway *g = arg;
+	PRE(g != NULL && g->req != NULL);
+	PRE(g->req->type == DQLITE_REQUEST_EXEC_SQL);
+	handle_exec_sql_next(g, g->req, true);
+}
+
 static void handle_exec_sql_cb(struct exec *exec, int status)
 {
 	tracef("handle exec sql cb status %d", status);
@@ -727,12 +740,24 @@ static void handle_exec_sql_cb(struct exec *exec, int status)
 	req->exec_count += 1;
 	sqlite3_finalize(exec->stmt);
 
-	if (status == SQLITE_DONE) {
-		handle_exec_sql_next(g, req, true);
-	} else {
+	if (status != SQLITE_DONE) {
 		assert(g->leader != NULL);
 		failure(req, status, error_message(g->leader->conn, status));
 		g->req = NULL;
+		return;
+	}
+
+	/* It would be valid to always invoke handle_exec_sql_next directly
+	 * here. But that can lead to bounded recursion when we have several
+	 * `;`-separated statements in a row that do not generate rows. To make
+	 * sure the stack depth stays under control, we have the event loop
+	 * loop invoke handle_exec_sql_next itself on the next iteration, but
+	 * only if there is a prior call to handle_exec_sql_next above us on
+	 * the stack. */
+	if (exec->async) {
+		handle_exec_sql_next(g, req, true);
+	} else {
+		g->defer(handle_exec_sql_next_defer_cb, g, g->defer_data);
 	}
 }
 

--- a/src/leader.h
+++ b/src/leader.h
@@ -49,6 +49,9 @@ struct barrier {
 	void *data;
 	struct leader *leader;
 	struct raft_barrier req;
+	/* When the callback is invoked, this field is `true` if raft_barrier
+	 * was called and `false` if the callback was invoked immediately. */
+	bool async;
 	barrier_cb cb;
 };
 
@@ -63,8 +66,12 @@ struct exec {
 	uint64_t id;
 	int status;
 	queue queue;
-	exec_cb cb;
 	pool_work_t work;
+	/* When the callback is invoked, this field is `true` if raft_barrier
+	 * or raft_apply was called and `false` if the callback was invoked
+	 * immediately. */
+	bool async;
+	exec_cb cb;
 };
 
 /**

--- a/test/integration/test_client.c
+++ b/test/integration/test_client.c
@@ -145,3 +145,29 @@ TEST(client, querySql, setUp, tearDown, 0, client_params)
 
 	return MUNIT_OK;
 }
+
+/* Stress test of an EXEC_SQL with many ';'-separated statements. */
+TEST(client, semicolons, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	(void)params;
+
+	static const char trivial_stmt[] = "CREATE TABLE IF NOT EXISTS foo (n INT);";
+
+	size_t n = 1000;
+	size_t unit = sizeof(trivial_stmt) - 1;
+	char *sql = munit_malloc(n * unit);
+	char *p = sql;
+	for (size_t i = 0; i < n; i++) {
+		memcpy(p, trivial_stmt, unit);
+		p += unit;
+	}
+	sql[n * unit - 1] = '\0';
+
+	uint64_t last_insert_id;
+	uint64_t rows_affected;
+	EXEC_SQL(sql, &last_insert_id, &rows_affected);
+
+	free(sql);
+	return MUNIT_OK;
+}

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -33,6 +33,12 @@ struct connection {
 	struct context context;
 };
 
+static void defer_but_not_really(void (*cb)(void *arg), void *arg, void *data)
+{
+	(void)data;
+	cb(arg);
+}
+
 #define FIXTURE          \
 	FIXTURE_CLUSTER; \
 	struct connection connections[N_GATEWAYS]
@@ -49,8 +55,13 @@ struct connection {
 		struct request_open open;                                  \
 		struct response_db db;                                     \
 		struct id_state seed = { { 1 } };                          \
-		gateway__init(&c->gateway, CLUSTER_CONFIG(0),              \
-			      CLUSTER_REGISTRY(0), CLUSTER_RAFT(0), seed); \
+		gateway__init(&c->gateway, \
+			      CLUSTER_CONFIG(0), \
+			      CLUSTER_REGISTRY(0), \
+			      CLUSTER_RAFT(0), \
+			      seed, \
+			      defer_but_not_really, \
+			      NULL); \
 		c->handle.data = &c->context;                              \
 		rc = buffer__init(&c->request);                            \
 		munit_assert_int(rc, ==, 0);                               \

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -33,7 +33,7 @@ struct connection {
 	struct context context;
 };
 
-static void defer_but_not_really(void (*cb)(void *arg), void *arg, void *data)
+static void defer_run_now(void (*cb)(void *arg), void *arg, void *data)
 {
 	(void)data;
 	cb(arg);
@@ -60,7 +60,7 @@ static void defer_but_not_really(void (*cb)(void *arg), void *arg, void *data)
 			      CLUSTER_REGISTRY(0), \
 			      CLUSTER_RAFT(0), \
 			      seed, \
-			      defer_but_not_really, \
+			      defer_run_now, \
 			      NULL); \
 		c->handle.data = &c->context;                              \
 		rc = buffer__init(&c->request);                            \

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -35,7 +35,7 @@ struct connection {
 	struct context context;
 };
 
-static void defer_but_not_really(void (*cb)(void *arg), void *arg, void *data)
+static void defer_run_now(void (*cb)(void *arg), void *arg, void *data)
 {
 	(void)data;
 	cb(arg);
@@ -66,7 +66,7 @@ static void defer_but_not_really(void (*cb)(void *arg), void *arg, void *data)
 			      CLUSTER_REGISTRY(i), \
 			      CLUSTER_RAFT(i), \
 			      seed, \
-			      defer_but_not_really, \
+			      defer_run_now, \
 			      NULL); \
 		c->handle.data = &c->context;                           \
 		rc = buffer__init(&c->buf1);                            \

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -35,6 +35,12 @@ struct connection {
 	struct context context;
 };
 
+static void defer_but_not_really(void (*cb)(void *arg), void *arg, void *data)
+{
+	(void)data;
+	cb(arg);
+}
+
 #define FIXTURE                                   \
 	FIXTURE_CLUSTER;                          \
 	struct connection connections[N_SERVERS]; \
@@ -55,8 +61,13 @@ struct connection {
 		struct id_state seed = { { 1 } };                       \
 		config = CLUSTER_CONFIG(i);                             \
 		config->page_size = 512;                                \
-		gateway__init(&c->gateway, config, CLUSTER_REGISTRY(i), \
-			      CLUSTER_RAFT(i), seed);                   \
+		gateway__init(&c->gateway, \
+			      config, \
+			      CLUSTER_REGISTRY(i), \
+			      CLUSTER_RAFT(i), \
+			      seed, \
+			      defer_but_not_really, \
+			      NULL); \
 		c->handle.data = &c->context;                           \
 		rc = buffer__init(&c->buf1);                            \
 		munit_assert_int(rc, ==, 0);                            \


### PR DESCRIPTION
Revised version of the reverted #681, fixing the regression #684. The bug in that PR was of the same type as that fixed in #686: passing a `NULL` callback when `uv_close`-ing a handle and then freeing the allocation containing the handle immediately.

To fix this instance of the bug, I put the `uv_timer_t` in the `conn` object instead of the gateway, since `conn` already has an asynchronous closing sequence. This means the gateway goes back to not knowing that it's running on an event loop, which is convenient for the tests.

It's probably most efficient to review this by looking at the diff against the previous PR, as merged:

```console
$ git remote add cole https://github.com/cole-miller/dqlite
$ git fetch cole
$ git diff 7dea935c44a32d1a4006ae23e072aef6f9cce509 cole/exec-sql-suspend-v2
```