### PR TITLE
Fix the build when liblz4 is missing and test it

### DIFF
--- a/.github/workflows/nolz4.yaml
+++ b/.github/workflows/nolz4.yaml
@@ -1,0 +1,39 @@
+name: CI Tests (no liblz4)
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up dependencies
+      run: |
+          sudo apt update
+          sudo apt install -y libsqlite3-dev libuv1-dev
+          sudo apt remove -y liblz4-dev
+
+    - name: Build dqlite (liblz4 not present)
+      run: |
+          autoreconf -i
+          ./configure --enable-build-raft
+          make -j$(nproc)
+          make clean
+
+    - name: Build dqlite (liblz4 requested and not present)
+      run: |
+          autoreconf -i
+          ! ./configure --enable-build-raft --with-lz4
+    - name: Install liblz4
+      run: |
+          sudo apt install liblz4-dev
+
+    - name: Build dqlite (liblz4 present but ignored)
+      run: |
+          ./configure --enable-build-raft --without-lz4
+          make -j$(nproc)
+          ! ldd .libs/libdqlite.so | grep lz4

--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ AS_IF([test "x$enable_build_raft" = "xyes"],
       [AS_IF([test "x$with_lz4" != "xno"],
 	     [PKG_CHECK_MODULES(LZ4, [liblz4 >= 1.7.1], [have_lz4=yes], [have_lz4=no])],
 	     [have_lz4=no])
-       AS_IF([test "x$with_lz4" != "xno" -a "x$have_lz4" = "xno"],
+       AS_IF([test "x$with_lz4" = "xyes" -a "x$have_lz4" = "xno"],
 	     [AC_MSG_ERROR([liblz4 required but not found])],
 	     [])],
       # Not building raft


### PR DESCRIPTION
The build was broken when `--enable-build-raft` was passed and liblz4 was missing due to a logic error in configure.ac. Fix this and test this particular build configuration in CI.

I only noticed this because we don't install liblz4-dev for the PPA builds and it's preventing setting `--enable-build-raft` there (canonical/dqlite-ppa#7).