### PR TITLE
Grab stack traces when unit test hangs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,6 +28,8 @@ jobs:
       run: |
           sudo apt update
           sudo apt install -y lcov libsqlite3-dev liblz4-dev libuv1-dev
+          # TODO: remove once the mysterious hang is fixed
+          sudo apt install -y gdb
 
     - name: Build dqlite
       env:
@@ -48,6 +50,7 @@ jobs:
         CC: ${{ matrix.compiler }}
         LIBDQLITE_TRACE: 1
       run: |
+          # TODO: return to just `make check` once the mysterious hang is fixed
           tests="integration-test \
                  raft-core-fuzzy-test \
                  raft-core-integration-test \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,20 +48,18 @@ jobs:
         CC: ${{ matrix.compiler }}
         LIBDQLITE_TRACE: 1
       run: |
-          for bin in unit-test integration-test \
-                     raft-core-fuzzy-test raft-core-integration-test \
-                     raft-core-unit-test raft-uv-integration-test \
-                     raft-uv-unit-test
-          do ./$bin || touch any-failed
-          done 2>&1 | tee -a test-suite.log
-          test '!' -e any-failed
+          tests="integration-test \
+                 raft-core-fuzzy-test \
+                 raft-core-integration-test \
+                 raft-core-unit-test \
+                 raft-uv-integration-test \
+                 raft-uv-unit-test"
+          make check TESTS="$tests"
 
-    - name: OnTestFailure
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-suite.log
-        path: test-suite.log
+          ./unit-test --no-fork &
+          pid=$!
+          bash -c "sleep 10m; sudo gdb -p $pid -batch -ex 'thread apply all bt' -ex quit; false" &
+          wait -n
 
     - name: Coverage
       env:

--- a/test/unit/lib/test_registry.c
+++ b/test/unit/lib/test_registry.c
@@ -3,6 +3,7 @@
 #include "../../../src/lib/registry.h"
 
 #include "../../lib/runner.h"
+#include "../../lib/sqlite.h"
 
 TEST_MODULE(lib_registry);
 
@@ -45,6 +46,8 @@ static void *setup(const MunitParameter params[], void *user_data)
 	(void)params;
 	(void)user_data;
 
+	SETUP_SQLITE;
+
 	registry = (struct test_registry *)munit_malloc(sizeof(*registry));
 
 	test_registry_init(registry);
@@ -58,6 +61,8 @@ static void tear_down(void *data)
 
 	test_registry_close(registry);
 	free(registry);
+
+	TEAR_DOWN_SQLITE;
 }
 
 TEST_SUITE(add);

--- a/test/unit/test_vfs2.c
+++ b/test/unit/test_vfs2.c
@@ -4,6 +4,7 @@
 #include "../../src/lib/byte.h"
 #include "../lib/fs.h"
 #include "../lib/runner.h"
+#include "../lib/sqlite.h"
 
 #include <sqlite3.h>
 
@@ -29,6 +30,9 @@ static void *set_up(const MunitParameter params[], void *user_data)
 	(void)params;
 	(void)user_data;
 	struct fixture *f = munit_malloc(sizeof(*f));
+
+	SETUP_SQLITE;
+
 	f->dir = test_dir_setup();
 	f->vfs = vfs2_make(sqlite3_vfs_find("unix"), "dqlite-vfs2");
 	munit_assert_ptr_not_null(f->vfs);
@@ -43,6 +47,8 @@ static void tear_down(void *data)
 	vfs2_destroy(f->vfs);
 	test_dir_tear_down(f->dir);
 	free(f);
+
+	TEAR_DOWN_SQLITE;
 }
 
 static void prepare_wals(const char *dbname,


### PR DESCRIPTION
We know which binary is hanging now, try to get some backtraces using GDB if it looks like it's hanging.