### PR TITLE
Propagate raft_recover errors and improve tracing

### DIFF
--- a/src/raft/raft.c
+++ b/src/raft/raft.c
@@ -227,6 +227,7 @@ int raft_recover(struct raft *r, const struct raft_configuration *conf)
 
 	rv = r->io->recover(r->io, conf);
 	if (rv != 0) {
+		ErrMsgTransfer(r->io->errmsg, r->errmsg, "io");
 		return rv;
 	}
 


### PR DESCRIPTION
At the moment, the raft_recover error messages are not propagated, so the caller gets a cryptic error code (1), without further details.

This change ensures that the error messages are propagated and adds a few extra trace messages.

Furthermore, tracing is disabled unless we start the node (not the case when we're actually trying to recover it). For now, we're adding a "dqliteTracingMaybeEnable" call in "dqlite_node_recover_ext".