### PR TITLE
Fix frames leak when VfsPoll fails

### DIFF
--- a/src/leader.c
+++ b/src/leader.c
@@ -467,7 +467,7 @@ static int exec_apply(struct exec *req)
 
 	rv = VfsPoll(vfs, db->path, &frames, &n);
 	if (rv != 0) {
-		return rv;
+		goto finish;
 	}
 	sm_move(&req->sm, EXEC_POLLED);
 	if (n == 0) {


### PR DESCRIPTION
VfsPoll can fail to acquire the WAL write lock, and the caller still needs to release the frames of the transaction in this case. Restores the behavior from before the exec_tick rewrite. Hat tip @marco6.

Signed-off-by: Cole Miller <cole.miller@canonical.com>