### PR TITLE
Trivial change to force package rebuild

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -49,6 +49,7 @@ jobs:
         DEBEMAIL: "dqlitebot@lists.canonical.com"
         TARGET: ${{ matrix.target }}
       run: |
+          echo Version $VERSION
           cp -R dqlite-ppa/debian dqlite/
           cd dqlite/
           VERSION="$(git describe --tags | sed -e "s/^v//" -e "s/-/+git/")"


### PR DESCRIPTION
Something weird happened the first time and the `dqlite1.17` packages that got published to the PPA come from the wrong commit.