### PR TITLE
Allow vacuum on main

### DIFF
--- a/src/leader.c
+++ b/src/leader.c
@@ -1,5 +1,8 @@
+#include <ctype.h>
+#include <sqlite3.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <strings.h>
 
 #include "../include/dqlite.h"
 
@@ -12,6 +15,7 @@
 #include "lib/sm.h"
 #include "lib/threadpool.h"
 #include "server.h"
+#include "stmt.h"
 #include "tracing.h"
 #include "utils.h"
 #include "vfs.h"
@@ -451,6 +455,81 @@ static void exec_done(struct exec *req, int asyncness)
 
 static void exec_apply_cb(struct raft_apply *, int, void *);
 
+static const char* skip_whitespace(const char* str) {
+    while (*str && isspace(*str)) {
+        str++;
+    }
+    return str;
+}
+
+struct vacuum_stmt {
+    const char* schema;   // Pointer to the schema name (if any)
+    size_t schema_len;
+    const char* target;   // Pointer to the target filename (if any)
+    size_t target_len;
+};
+
+int parse_vacuum_stmt(const char* sql, struct vacuum_stmt* stmt) {
+	memset(stmt, 0, sizeof(*stmt));
+
+    sql = skip_whitespace(sql);
+    if (strncasecmp(sql, "VACUUM", 6) != 0) return SQLITE_ERROR;
+    sql = skip_whitespace(sql+6);
+
+    if (*sql == ';' || *sql == '\0') {
+        return SQLITE_OK;
+    }
+
+    const char* start = sql;
+    while (*sql && !isspace(*sql) && *sql != ';') {
+        sql++;
+    }
+
+    size_t len = sql - start;
+    sql = skip_whitespace(sql);
+    
+    stmt->schema = start;
+    stmt->schema_len = len;
+
+    if (*sql == ';' || *sql == '\0') {
+        return SQLITE_OK;
+    }
+   
+    start = sql;
+    while (*sql && !isspace(*sql) && *sql != ';') {
+        sql++;
+    }
+    
+    stmt->target = (char*)start;
+    stmt->target_len = sql - start;
+	sql = skip_whitespace(sql);
+	if ((*sql != ';') && (*sql != '\0')) {
+		return SQLITE_ERROR;
+	}
+    return SQLITE_OK;
+}
+
+
+static int is_allowed_vacuum(struct sqlite3_stmt* stmt) {
+	struct vacuum_stmt vacuum;
+	if (parse_vacuum_stmt(sqlite3_sql(stmt), &vacuum) != SQLITE_OK) {
+		return 0;
+	}
+
+	bool main_target = 
+		// no-schema
+		((vacuum.target_len == 0) && (vacuum.schema_len == 0)) ||
+		// unquoted schema
+		(vacuum.schema_len == 4 && strncasecmp(vacuum.schema, "main", 4) == 0) ||
+		( // quoted schema
+			vacuum.schema_len == 6 && (
+				strncasecmp(vacuum.schema, "'main'", 6) == 0 ||
+				strncasecmp(vacuum.schema, "\"main\"", 6) == 0
+		));
+
+	return main_target;
+}
+
 static int exec_apply(struct exec *req)
 {
 	struct leader *l = req->leader;
@@ -462,7 +541,7 @@ static int exec_apply(struct exec *req)
 	unsigned i;
 	int rv;
 	
-	if (sqlite3_stricmp(sqlite3_sql(req->stmt), "VACUUM") == 0) {
+	if (is_allowed_vacuum(req->stmt)) {
 		sqlite3_limit(sqlite3_db_handle(req->stmt), SQLITE_LIMIT_ATTACHED, 1);
 		req->status = sqlite3_step(req->stmt);
 		sqlite3_limit(sqlite3_db_handle(req->stmt), SQLITE_LIMIT_ATTACHED, 0);

--- a/src/leader.c
+++ b/src/leader.c
@@ -461,8 +461,14 @@ static int exec_apply(struct exec *req)
 	unsigned n;
 	unsigned i;
 	int rv;
-
-	req->status = sqlite3_step(req->stmt);
+	
+	if (sqlite3_stricmp(sqlite3_sql(req->stmt), "VACUUM") == 0) {
+		sqlite3_limit(sqlite3_db_handle(req->stmt), SQLITE_LIMIT_ATTACHED, 1);
+		req->status = sqlite3_step(req->stmt);
+		sqlite3_limit(sqlite3_db_handle(req->stmt), SQLITE_LIMIT_ATTACHED, 0);
+	} else {
+		req->status = sqlite3_step(req->stmt);
+	}
 	sm_move(&req->sm, EXEC_STEPPED);
 
 	rv = VfsPoll(vfs, db->path, &frames, &n);


### PR DESCRIPTION
As discussed in these days on MM, VACUUM seems to be a transactional operation.

While it is true that it needs to attach a temporary database, new pages are then copied *in the WAL* and, as such, the attachment of the temporary file does not violate the VFS assumption about WAL and main file being unique after every statement.

The tricky part is however to allow sqlite to attach a database only during VACUUM. This PR achieves that by parsing the sql statement.