### PR TITLE
fix: reduce trace stack usage

### DIFF
--- a/src/tracing.c
+++ b/src/tracing.c
@@ -96,3 +96,15 @@ void stderrTracerEmit(const char *file,
 	if (level >= tracer__level)
 		tracerEmit(file, line, func, level, message);
 }
+
+void _tracef0(const char *file, unsigned int line, const char *func, unsigned int level, const char *fmt, ...)
+{
+	va_list args;
+	char msg[1024];
+	if (UNLIKELY(_dqliteTracingEnabled)) {
+		va_start (args, fmt);
+		vsnprintf(msg, sizeof msg, fmt, args);
+		va_end (args);
+		stderrTracerEmit(file, line, func, level, msg);
+	}
+}

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -6,6 +6,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <time.h>
 
 #include "../include/dqlite.h"
@@ -21,15 +22,11 @@ DQLITE_VISIBLE_TO_TESTS void stderrTracerEmit(const char *file,
 					      unsigned int level,
 					      const char *message);
 
-#define tracef0(LEVEL, ...)                                            \
-	do {                                                           \
-		if (UNLIKELY(_dqliteTracingEnabled)) {                 \
-			char _msg[1024];                               \
-			snprintf(_msg, sizeof _msg, __VA_ARGS__);      \
-			stderrTracerEmit(__FILE__, __LINE__, __func__, \
-					 (LEVEL), _msg);               \
-		}                                                      \
-	} while (0)
+// FIXME same oreder as upper
+DQLITE_VISIBLE_TO_TESTS NOINLINE
+void _tracef0(const char *file, unsigned int line, const char *func, unsigned int level, const char *fmt, ...);
+
+#define tracef0(LEVEL, ...) _tracef0(__FILE__, __LINE__, __func__, LEVEL, __VA_ARGS__)
 
 enum dqlite_trace_level {
 	/** Represents an invalid trace level */

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,6 +23,12 @@
 #define POST(cond) assert((cond))
 #define ERGO(a, b) (!(a) || (b))
 
+#if defined(__has_attribute) && __has_attribute (noinline)
+# define NOINLINE __attribute__ ((noinline))
+#else
+# define NOINLINE
+#endif
+
 static inline bool is_po2(unsigned long n) {
 	return n > 0 && (n & (n - 1)) == 0;
 }


### PR DESCRIPTION
This PR wraps the logic to write traces in a noinline function so that stack message will not take space in the stack frame of the caller.

Related: #679. I'm really not sure if it is enough to fix it though.