### PR TITLE
fix: free shallow snapshot headers correctly

### DIFF
--- a/src/raft/snapshot.c
+++ b/src/raft/snapshot.c
@@ -7,7 +7,6 @@
 #include "assert.h"
 #include "configuration.h"
 #include "err.h"
-#include "log.h"
 
 void snapshotClose(struct raft_snapshot *s)
 {

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1685,8 +1685,8 @@ static int vfsFileShmLock(sqlite3_file *file, int ofst, int n, int flags)
 		/* When releasing the write lock, if we find a pending
 		 * uncommitted transaction then a rollback must have occurred.
 		 * In that case we delete the pending transaction. */
-		tracef("ROLLBACK TIME");
 		if (flags == (SQLITE_SHM_UNLOCK | SQLITE_SHM_EXCLUSIVE)) {
+			tracef("ROLLBACK TIME");
 			vfsWalRollbackIfUncommitted(wal);
 		}
 	}


### PR DESCRIPTION
This PR changes a bit the logic to free snapshot headers as the stress test in #740 showed a bug: while it is true that pages are never freed and can be shallowly referenced, the size of the database might change as writes are still allowed to continue during snapshot. This results in freeing the wrong buffer as the size of the database is used to "skip" buffers during finalize time.

The solution here uses the information stored *in the header* for each database instead.