### PR TITLE
chore: drop support for 20.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
         compiler:


### PR DESCRIPTION
Given that Ubuntu Focal Fossa (20.04) is EOL and jobs cannot run anymore this PR removes support for it in v1.18.

v1.17 can still support that version.