### PR TITLE
feat: add timers support in raft_io

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,6 +118,7 @@ libraft_la_SOURCES = \
   src/raft/uv_tcp.c \
   src/raft/uv_tcp_listen.c \
   src/raft/uv_tcp_connect.c \
+  src/raft/uv_timer.c \
   src/raft/uv_truncate.c \
   src/raft/uv_work.c \
   src/raft/uv_writer.c
@@ -304,6 +305,7 @@ raft_uv_integration_test_SOURCES = \
   test/raft/integration/test_uv_tcp_connect.c \
   test/raft/integration/test_uv_tcp_listen.c \
   test/raft/integration/test_uv_snapshot_put.c \
+  test/raft/integration/test_uv_timer.c \
   test/raft/integration/test_uv_truncate.c \
   test/raft/integration/test_uv_truncate_snapshot.c \
   test/raft/integration/test_uv_work.c

--- a/src/raft.h
+++ b/src/raft.h
@@ -36,7 +36,8 @@ int raft_version_number(void);
  * Error codes.
  */
 enum {
-	RAFT_NOMEM = 1,        /* Out of memory */
+	RAFT_OK = 0,
+	RAFT_NOMEM,            /* Out of memory */
 	RAFT_BADID,            /* Server ID is not valid */
 	RAFT_DUPLICATEID,      /* Server ID already in use */
 	RAFT_DUPLICATEADDRESS, /* Server address already in use */
@@ -58,7 +59,8 @@ enum {
 	RAFT_INVALID,      /* Invalid parameter */
 	RAFT_UNAUTHORIZED, /* No access to a resource */
 	RAFT_NOSPACE,      /* Not enough space on disk */
-	RAFT_TOOMANY       /* Some system or raft limit was hit */
+	RAFT_TOOMANY,      /* Some system or raft limit was hit */
+	RAFT_ERROR,        /* Generic error */
 };
 
 /**
@@ -307,10 +309,10 @@ struct page_from_to {
 	pageno_t to;
 };
 
-enum raft_result {
-	RAFT_RESULT_OK = 0,
-	RAFT_RESULT_UNEXPECTED = 1,
-	RAFT_RESULT_DONE = 2,
+enum raft_snapshot_result {
+	RAFT_SNAPSHOT_OK = 0,
+	RAFT_SNAPSHOT_UNEXPECTED = 1,
+	RAFT_SNAPSHOT_DONE = 2,
 };
 
 /**
@@ -325,14 +327,14 @@ struct raft_install_snapshot
 	struct raft_configuration conf; /* Config as of last_index. */
 	raft_index conf_index;          /* Commit index of conf. */
 	struct raft_buffer data;        /* Raw snapshot data. */
-	enum raft_result result;
+	enum raft_snapshot_result result;
 };
 #define RAFT_INSTALL_SNAPSHOT_VERSION 0
 
 struct raft_install_snapshot_result {
 	int version;
 
-	enum raft_result result;
+	enum raft_snapshot_result result;
 };
 #define RAFT_INSTALL_SNAPSHOT_RESULT_VERSION 0
 
@@ -342,7 +344,7 @@ struct raft_signature {
 	const char *db;
 	struct page_from_to page_from_to;
 	pageno_t cs_page_no;
-	enum raft_result result;
+	enum raft_snapshot_result result;
 	bool ask_calculated;
 };
 #define RAFT_SIGNATURE_VERSION 0
@@ -354,7 +356,7 @@ struct raft_signature_result {
 	struct page_checksum *cs;
 	unsigned int cs_nr;
 	pageno_t cs_page_no;
-	enum raft_result result;
+	enum raft_snapshot_result result;
 	bool calculated;
 };
 #define RAFT_SIGNATURE_RESULT_VERSION 0
@@ -365,7 +367,7 @@ struct raft_install_snapshot_mv {
 	const char *db;
 	struct page_from_to *mv;
 	unsigned int mv_nr;
-	enum raft_result result;
+	enum raft_snapshot_result result;
 };
 #define RAFT_INSTALL_SNAPSHOT_MV_VERSION 0
 
@@ -374,7 +376,7 @@ struct raft_install_snapshot_mv_result {
 
 	const char *db;
 	pageno_t last_known_page_no; /* used for retries and message losses */
-	enum raft_result result;
+	enum raft_snapshot_result result;
 };
 #define RAFT_INSTALL_SNAPSHOT_MV_RESULT_VERSION 0
 
@@ -384,7 +386,7 @@ struct raft_install_snapshot_cp {
 	const char *db;
 	pageno_t page_no;
 	struct raft_buffer page_data;
-	enum raft_result result;
+	enum raft_snapshot_result result;
 };
 #define RAFT_INSTALL_SNAPSHOT_CP_VERSION 0
 
@@ -392,7 +394,7 @@ struct raft_install_snapshot_cp_result {
 	int version;
 
 	pageno_t last_known_page_no; /* used for retries and message losses */
-	enum raft_result result;
+	enum raft_snapshot_result result;
 };
 #define RAFT_INSTALL_SNAPSHOT_CP_RESULT_VERSION 0
 
@@ -623,6 +625,15 @@ typedef void (*raft_io_recv_cb)(struct raft_io *io, struct raft_message *msg);
 
 typedef void (*raft_io_close_cb)(struct raft_io *io);
 
+struct raft_timer;
+typedef void (*raft_timer_cb)(struct raft_timer*);
+
+struct raft_timer {
+	void *data; /* User data */
+	raft_timer_cb cb; /* Request callback */
+	void *handle; /* Implementation handle */
+};
+
 /**
  * version field MUST be filled out by user.
  * When moving to a new version, the user MUST implement the newly added
@@ -630,7 +641,7 @@ typedef void (*raft_io_close_cb)(struct raft_io *io);
  */
 struct raft_io
 {
-	int version; /* 1 or 2 */
+	int version; /* 1 or 2 or 3 */
 	void *data;
 	void *impl;
 	char errmsg[RAFT_ERRMSG_BUF_SIZE];
@@ -683,8 +694,15 @@ struct raft_io
 	int (*random)(struct raft_io *io, int min, int max);
 	/* Field(s) below added since version 2. */
 	int (*async_work)(struct raft_io *io,
-			  struct raft_io_async_work *req,
-			  raft_io_async_work_cb cb);
+				struct raft_io_async_work *req,
+				raft_io_async_work_cb cb);
+	/* Field(s) below added since version 3. */
+	int (*timer_start)(struct raft_io *io,
+				struct raft_timer *req,
+				uint64_t timeout, uint64_t repeat,
+				raft_timer_cb cb);
+	int (*timer_stop)(struct raft_io *io,
+				struct raft_timer *req);
 };
 
 /**
@@ -1356,6 +1374,21 @@ RAFT_API int raft_transfer(struct raft *r,
 			   struct raft_transfer *req,
 			   raft_id id,
 			   raft_transfer_cb cb);
+
+/**
+ * Starts a timer.
+ */
+RAFT_API int raft_timer_start(struct raft *r,
+				struct raft_timer *req,
+				uint64_t timeout, uint64_t repeat,
+				raft_timer_cb cb);
+
+/**
+ * Stops a timer. If the timer wasn't started,
+ * this is a no-op.
+ */
+RAFT_API int raft_timer_stop(struct raft *r,
+				struct raft_timer *req);
 
 /**
  * User-definable dynamic memory allocation functions.

--- a/src/raft/raft.c
+++ b/src/raft/raft.c
@@ -348,3 +348,21 @@ int raft_io_describe_last_entry(struct raft_io *io,
 	entryBatchesDestroy(entries, n_entries);
 	return 0;
 }
+
+RAFT_API int raft_timer_start(struct raft *r,
+				struct raft_timer *req,
+				uint64_t timeout, uint64_t repeat,
+				raft_timer_cb cb) {
+	if (r->io->version < 3) {
+		return RAFT_INVALID;
+	}
+	return r->io->timer_start(r->io, req, timeout, repeat, cb);
+}
+
+RAFT_API int raft_timer_stop(struct raft *r,
+				struct raft_timer *req) {
+	if (r->io->version < 3) {
+		return RAFT_INVALID;
+	}
+	return r->io->timer_stop(r->io, req);
+}

--- a/src/raft/recv_install_snapshot.c
+++ b/src/raft/recv_install_snapshot.c
@@ -16,20 +16,6 @@
 #include "../utils.h"
 #include "../lib/threadpool.h"
 
-#define IN_1(E, X) E == X
-#define IN_2(E, X, ...) E == X || IN_1(E,__VA_ARGS__)
-#define IN_3(E, X, ...) E == X || IN_2(E,__VA_ARGS__)
-#define IN_4(E, X, ...) E == X || IN_3(E,__VA_ARGS__)
-#define IN_5(E, X, ...) E == X || IN_4(E,__VA_ARGS__)
-#define IN_6(E, X, ...) E == X || IN_5(E,__VA_ARGS__)
-#define IN_7(E, X, ...) E == X || IN_6(E,__VA_ARGS__)
-#define IN_8(E, X, ...) E == X || IN_7(E,__VA_ARGS__)
-#define IN_9(E, X, ...) E == X || IN_8(E,__VA_ARGS__)
-
-#define GET_IN_MACRO(_1,_2,_3,_4,_5,_6,_7,_8,_9,NAME,...) NAME
-#define IN(E, ...) \
-  (GET_IN_MACRO(__VA_ARGS__,IN_9,IN_8,IN_7,IN_6,IN_5,IN_4,IN_3,IN_2,IN_1)(E,__VA_ARGS__))
-
 /**
  * =Overview
  *
@@ -670,7 +656,7 @@ static void rpc_fill_leader(struct leader *leader)
 		rpc->message = (struct raft_message) {
 			.type = RAFT_IO_INSTALL_SNAPSHOT,
 			.install_snapshot = (struct raft_install_snapshot) {
-				.result = RAFT_RESULT_DONE,
+				.result = RAFT_SNAPSHOT_DONE,
 			},
 		};
 		break;
@@ -792,10 +778,10 @@ static bool is_an_unexpected_trigger(const struct leader *leader,
 		return false;
 	}
 
-	enum raft_result res = RAFT_RESULT_UNEXPECTED;
+	enum raft_snapshot_result res = RAFT_SNAPSHOT_UNEXPECTED;
 	switch (msg->type) {
 	case RAFT_IO_APPEND_ENTRIES_RESULT:
-		res = RAFT_RESULT_OK;
+		res = RAFT_SNAPSHOT_OK;
 		break;
 	case RAFT_IO_INSTALL_SNAPSHOT:
 		res = msg->install_snapshot.result;
@@ -822,7 +808,7 @@ static bool is_an_unexpected_trigger(const struct leader *leader,
 		res = msg->signature_result.result;
 		break;
 	}
-	return res == RAFT_RESULT_UNEXPECTED;
+	return res == RAFT_SNAPSHOT_UNEXPECTED;
 }
 
 static int follower_next_state(struct sm *sm)

--- a/src/raft/uv.c
+++ b/src/raft/uv.c
@@ -8,6 +8,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <uv.h>
 
 #include "../raft.h"
 #include "../tracing.h"
@@ -738,7 +739,7 @@ int raft_uv_init(struct raft_io *io,
 	uvSeedRand(uv);
 
 	/* Set the raft_io implementation. */
-	io->version = 2; /* future-proof'ing */
+	io->version = 3;
 	io->impl = uv;
 	io->init = uvInit;
 	io->close = uvClose;
@@ -756,6 +757,8 @@ int raft_uv_init(struct raft_io *io,
 	io->async_work = UvAsyncWork;
 	io->time = uvTime;
 	io->random = uvRandom;
+	io->timer_start = UvTimerStart;
+	io->timer_stop = UvTimerStop;
 
 	return 0;
 

--- a/src/raft/uv.h
+++ b/src/raft/uv.h
@@ -421,4 +421,13 @@ void UvRecvClose(struct uv *uv);
 
 void uvMaybeFireCloseCb(struct uv *uv);
 
+int UvTimerStart(struct raft_io *io,
+	struct raft_timer *req,
+	uint64_t timeout, uint64_t repeat,
+	raft_timer_cb cb);
+
+int UvTimerStop(struct raft_io *io,
+	struct raft_timer *req);
+
 #endif /* UV_H_ */
+ /* future-proof'ing */

--- a/src/raft/uv.h
+++ b/src/raft/uv.h
@@ -430,4 +430,3 @@ int UvTimerStop(struct raft_io *io,
 	struct raft_timer *req);
 
 #endif /* UV_H_ */
- /* future-proof'ing */

--- a/src/raft/uv_timer.c
+++ b/src/raft/uv_timer.c
@@ -1,0 +1,58 @@
+#include "./uv.h"
+#include "./heap.h"
+
+
+static void uvTimerCallback(uv_timer_t* handle) {
+    struct raft_timer *req = handle->data;
+    req->cb(req);
+}
+
+static void uvTimerFree(uv_handle_t *handle) {
+    RaftHeapFree(handle);
+}
+
+int UvTimerStart(struct raft_io *io, struct raft_timer *req, uint64_t timeout, uint64_t repeat, raft_timer_cb cb) {
+    int rv;
+    struct uv *uv = io->impl;
+	assert(!uv->closing);
+
+    uv_timer_t *timer = RaftHeapMalloc(sizeof *timer);
+    if (timer == NULL) {
+        return RAFT_NOMEM;
+    }
+    rv = uv_timer_init(uv->loop, timer);
+    if (rv != 0) {
+        goto error;
+    }
+
+    timer->data = req;
+    rv = uv_timer_start(timer, uvTimerCallback, timeout, repeat);
+    if (rv != 0) {
+        goto error;
+    }
+    req->handle = timer;
+    req->cb   = cb;
+    return RAFT_OK;
+
+error:
+    RaftHeapFree(timer);
+    return rv;
+}
+
+int UvTimerStop(struct raft_io *io, struct raft_timer *req) {
+    (void)io;
+
+    int rv;
+    uv_timer_t *timer = req->handle;
+    if (timer == NULL) {
+        return RAFT_OK;
+    }
+
+    rv = uv_timer_stop(timer);
+    if (rv != 0) {
+        return rv;
+    }
+    uv_close((uv_handle_t*)timer, uvTimerFree);
+    req->handle = NULL;
+    return RAFT_OK;
+}

--- a/src/raft/uv_timer.c
+++ b/src/raft/uv_timer.c
@@ -14,7 +14,7 @@ static void uvTimerFree(uv_handle_t *handle) {
 int UvTimerStart(struct raft_io *io, struct raft_timer *req, uint64_t timeout, uint64_t repeat, raft_timer_cb cb) {
     int rv;
     struct uv *uv = io->impl;
-	assert(!uv->closing);
+    assert(!uv->closing);
 
     uv_timer_t *timer = RaftHeapMalloc(sizeof *timer);
     if (timer == NULL) {
@@ -31,7 +31,7 @@ int UvTimerStart(struct raft_io *io, struct raft_timer *req, uint64_t timeout, u
         goto error;
     }
     req->handle = timer;
-    req->cb   = cb;
+    req->cb = cb;
     return RAFT_OK;
 
 error:

--- a/src/raft/uv_writer.c
+++ b/src/raft/uv_writer.c
@@ -261,6 +261,7 @@ int UvWriterInit(struct UvWriter *w,
 		rv = UvOsSetDirectIo(w->fd);
 		if (rv != 0) {
 			UvOsErrMsg(errmsg, "fcntl", rv);
+			rv = RAFT_IOERR;
 			goto err;
 		}
 	}

--- a/src/raft/uv_writer.c
+++ b/src/raft/uv_writer.c
@@ -261,7 +261,6 @@ int UvWriterInit(struct UvWriter *w,
 		rv = UvOsSetDirectIo(w->fd);
 		if (rv != 0) {
 			UvOsErrMsg(errmsg, "fcntl", rv);
-			rv = RAFT_IOERR;
 			goto err;
 		}
 	}

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,6 +23,27 @@
 #define POST(cond) assert((cond))
 #define ERGO(a, b) (!(a) || (b))
 
+#define IN_1(E, X) E == X
+#define IN_2(E, X, ...) E == X || IN_1(E,__VA_ARGS__)
+#define IN_3(E, X, ...) E == X || IN_2(E,__VA_ARGS__)
+#define IN_4(E, X, ...) E == X || IN_3(E,__VA_ARGS__)
+#define IN_5(E, X, ...) E == X || IN_4(E,__VA_ARGS__)
+#define IN_6(E, X, ...) E == X || IN_5(E,__VA_ARGS__)
+#define IN_7(E, X, ...) E == X || IN_6(E,__VA_ARGS__)
+#define IN_8(E, X, ...) E == X || IN_7(E,__VA_ARGS__)
+#define IN_9(E, X, ...) E == X || IN_8(E,__VA_ARGS__)
+
+#define GET_IN_MACRO(_1,_2,_3,_4,_5,_6,_7,_8,_9,NAME,...) NAME
+#define IN(E, ...) \
+  (GET_IN_MACRO(__VA_ARGS__,IN_9,IN_8,IN_7,IN_6,IN_5,IN_4,IN_3,IN_2,IN_1)(E,__VA_ARGS__))
+
+
+#if defined(__has_attribute) && __has_attribute (musttail)
+# define TAIL __attribute__ ((musttail))
+#else
+# define TAIL
+#endif
+
 #if defined(__has_attribute) && __has_attribute (noinline)
 # define NOINLINE __attribute__ ((noinline))
 #else

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,13 +37,6 @@
 #define IN(E, ...) \
   (GET_IN_MACRO(__VA_ARGS__,IN_9,IN_8,IN_7,IN_6,IN_5,IN_4,IN_3,IN_2,IN_1)(E,__VA_ARGS__))
 
-
-#if defined(__has_attribute) && __has_attribute (musttail)
-# define TAIL __attribute__ ((musttail))
-#else
-# define TAIL
-#endif
-
 #if defined(__has_attribute) && __has_attribute (noinline)
 # define NOINLINE __attribute__ ((noinline))
 #else

--- a/test/raft/integration/test_snapshot.c
+++ b/test/raft/integration/test_snapshot.c
@@ -932,7 +932,7 @@ static int fsmBigSnapshot(MUNIT_UNUSED struct raft_fsm *fsm,
     if (buf->base == NULL) {
         return RAFT_NOMEM;
     }
-    return RAFT_RESULT_OK;
+    return RAFT_OK;
 }
 
 /* At least `threshold` entries are kept in the log */

--- a/test/raft/integration/test_uv_timer.c
+++ b/test/raft/integration/test_uv_timer.c
@@ -1,0 +1,115 @@
+#include "../../../src/raft/uv.h"
+#include "../lib/runner.h"
+#include "../lib/uv.h"
+
+#include <unistd.h>
+
+/******************************************************************************
+ *
+ * Fixture with a libuv-based raft_io instance.
+ *
+ *****************************************************************************/
+
+struct fixture
+{
+    FIXTURE_UV_DEPS;
+    FIXTURE_UV;
+};
+
+/******************************************************************************
+ *
+ * Set up and tear down.
+ *
+ *****************************************************************************/
+
+static void *setUp(const MunitParameter params[], void *user_data)
+{
+    struct fixture *f = munit_malloc(sizeof *f);
+    SETUP_UV_DEPS;
+    SETUP_UV;
+    return f;
+}
+
+static void tearDown(void *data)
+{
+    struct fixture *f = data;
+    if (f == NULL) {
+        return;
+    }
+    TEAR_DOWN_UV;
+    TEAR_DOWN_UV_DEPS;
+    free(f);
+}
+
+SUITE(timer)
+
+struct test_timer {
+    struct raft_timer timer;
+    int target, count;
+    bool success;
+};
+
+void callback(struct raft_timer *t) {
+    struct test_timer *timer = (struct test_timer *)t;
+    timer->count++;
+    if (timer->count >= timer->target) {
+        timer->success = true;
+    }
+}
+
+TEST(timer, once, setUp, tearDown, 0, NULL)
+{
+    int rv;
+    struct fixture *f = data;
+    struct test_timer timer = {
+        .target = 1,
+    };
+
+    rv = UvTimerStart(&f->io, &timer.timer, 100, 0, callback);
+    munit_assert_int(rv, ==, 0);
+    LOOP_RUN_UNTIL(&timer.success);
+
+    rv = UvTimerStop(&f->io, &timer.timer);
+    munit_assert_int(rv, ==, 0);
+
+    return MUNIT_OK;
+}
+
+TEST(timer, repeated, setUp, tearDown, 0, NULL)
+{
+    int rv;
+    struct fixture *f = data;
+    struct test_timer timer = {
+        .target = 5,
+    };
+    rv = UvTimerStart(&f->io, &timer.timer, 100, 100, callback);
+    munit_assert_int(rv, ==, 0);
+    LOOP_RUN_UNTIL(&timer.success);
+
+    rv = UvTimerStop(&f->io, &timer.timer);
+    munit_assert_int(rv, ==, 0);
+
+    return MUNIT_OK;
+}
+
+TEST(timer, stop, setUp, tearDown, 0, NULL)
+{
+    int rv;
+    struct fixture *f = data;
+    struct test_timer timer = {
+        .target = 2,
+    };
+    rv = UvTimerStart(&f->io, &timer.timer, 100, 100, callback);
+    munit_assert_int(rv, ==, 0);
+    LOOP_RUN_UNTIL(&timer.success);
+
+    rv = UvTimerStop(&f->io, &timer.timer);
+    munit_assert_int(rv, ==, 0);
+
+    rv = uv_run(&f->loop, UV_RUN_ONCE);
+    if (rv < 0) {
+        munit_errorf("uv_run: %s (%d)", uv_strerror(rv), rv);
+    }
+    munit_assert_int(rv, ==, 0);
+    return MUNIT_OK;
+}

--- a/test/raft/lib/loop.c
+++ b/test/raft/lib/loop.c
@@ -3,5 +3,5 @@
 void test_loop_walk_cb(uv_handle_t *handle, void *arg)
 {
     (void)arg;
-    munit_logf(MUNIT_LOG_INFO, "handle %d", handle->type);
+    munit_logf(MUNIT_LOG_INFO, "handle %s (%d)", uv_handle_type_name(handle->type), handle->type);
 }


### PR DESCRIPTION
This PR adds the ability to start/stop timers on the `raft_io` object.

This was a part of #740 and is an effort to reduce its size.