### PR TITLE
feat: use SQLITE_STATIC binding

### DIFF
--- a/src/bind.c
+++ b/src/bind.c
@@ -6,43 +6,36 @@ static int bind_one(sqlite3_stmt *stmt, int n, struct value *value)
 {
 	int rc;
 
-	/* TODO: the binding calls below currently use SQLITE_TRANSIENT when
-	 * passing pointers to data (for TEXT or BLOB datatypes). This way
-	 * SQLite makes its private copy of the data before the bind call
-	 * returns, and we can reuse the message body buffer. The overhead of
-	 * the copy is typically low, but if it becomes a concern, this could be
-	 * optimized to make no copy and instead prevent the message body from
-	 * being reused. */
 	switch (value->type) {
-		case SQLITE_INTEGER:
-			rc = sqlite3_bind_int64(stmt, n, value->integer);
-			break;
-		case SQLITE_FLOAT:
-			rc = sqlite3_bind_double(stmt, n, value->real);
-			break;
-		case SQLITE_BLOB:
-			rc = sqlite3_bind_blob(stmt, n, value->blob.base,
-					       (int)value->blob.len,
-					       SQLITE_TRANSIENT);
-			break;
-		case SQLITE_NULL:
-			rc = sqlite3_bind_null(stmt, n);
-			break;
-		case SQLITE_TEXT:
-			rc = sqlite3_bind_text(stmt, n, value->text, -1,
-					       SQLITE_TRANSIENT);
-			break;
-		case DQLITE_ISO8601:
-			rc = sqlite3_bind_text(stmt, n, value->text, -1,
-					       SQLITE_TRANSIENT);
-			break;
-		case DQLITE_BOOLEAN:
-			rc = sqlite3_bind_int64(stmt, n,
-						value->boolean == 0 ? 0 : 1);
-			break;
-		default:
-			rc = DQLITE_PROTO;
-			break;
+	case SQLITE_INTEGER:
+		rc = sqlite3_bind_int64(stmt, n, value->integer);
+		break;
+	case SQLITE_FLOAT:
+		rc = sqlite3_bind_double(stmt, n, value->real);
+		break;
+	case SQLITE_BLOB:
+		rc = sqlite3_bind_blob(stmt, n, value->blob.base,
+						(int)value->blob.len,
+						SQLITE_STATIC);
+		break;
+	case SQLITE_NULL:
+		rc = sqlite3_bind_null(stmt, n);
+		break;
+	case SQLITE_TEXT:
+		rc = sqlite3_bind_text(stmt, n, value->text, -1,
+						SQLITE_STATIC);
+		break;
+	case DQLITE_ISO8601:
+		rc = sqlite3_bind_text(stmt, n, value->text, -1,
+						SQLITE_STATIC);
+		break;
+	case DQLITE_BOOLEAN:
+		rc = sqlite3_bind_int64(stmt, n,
+					value->boolean == 0 ? 0 : 1);
+		break;
+	default:
+		rc = DQLITE_PROTO;
+		break;
 	}
 
 	return rc;


### PR DESCRIPTION
The whole protocol and the `gateway.c` implementation assume that the current request message is fixed in memory and is never overwritten until a response has been sent (including multiple message responses like the query rows). This is also why the part around interrupting long queries doesn't work.

Given that the solution to the above would be to allocate a message for each request, it is safe to use `SQLITE_STATIC` and let SQLite reference data in the message.