### PR TITLE
fix: use-after-free for prepared statement

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -50,6 +50,7 @@ static void gateway__leader_close_cb(struct leader *leader)
 	struct gateway *g = leader->data;
 	raft_free(leader);
 	g->leader = NULL;
+	stmt__registry_close(&g->stmts);
 	if (g->close_cb != NULL) {
 		g->close_cb(g);
 	}
@@ -57,12 +58,12 @@ static void gateway__leader_close_cb(struct leader *leader)
 
 static void gateway_finalize(struct gateway *g)
 {
-	stmt__registry_close(&g->stmts);
 	if (g->leader != NULL) {
 		/* Before closing the gateway, signal to the existing leader that we
 		 * are closing and wait to drain the queue. */
 		leader__close(g->leader, gateway__leader_close_cb);
 	} else if (g->close_cb != NULL) {
+		stmt__registry_close(&g->stmts);
 		g->close_cb(g);
 	}
 }

--- a/src/leader.c
+++ b/src/leader.c
@@ -71,7 +71,7 @@ static void leader_finalize(struct leader *leader)
 	PRE(leader->db->leaders > 0);
 	tracef("leader close");
 	sqlite3_interrupt(leader->conn);
-	int rc = sqlite3_close(leader->conn);
+	int rc = sqlite3_close_v2(leader->conn);
 	assert(rc == 0);
 	if (leader->db->active_leader == leader) {
 		leader_trace(leader, "done");


### PR DESCRIPTION
This PR fixes a use-after-free on the `{exec, query}_done` callback.

The problem was that if the callback of an exec or query (the one with perpared statements) calls `gateway__close` then it creates a use-after-free.

The complete picture is the following:

```C
static void handle_exec_done_cb(struct exec *exec)
{
    ...
	sqlite3_stmt *stmt = exec->stmt;
	...
	if (raft_status != 0) {
		exec_failure(g, req, raft_status); /* will call req->cb which is `gateway_handle_cb` */
		goto done;
	}
```

Which in the case of `LEADERSHIP_LOST` or `NOT_LEADER` will:

```c
static void gateway_handle_cb(struct handle *req,
			      int status,
			      uint8_t type,
			      uint8_t schema)
{
    ...
	if (status == SQLITE_IOERR_NOT_LEADER || status == SQLITE_IOERR_LEADERSHIP_LOST) {
		tracef("gateway handle cb status %d", status);
		goto abort;
	}
    ...
abort:
	conn__stop(c);
}

void conn__stop(struct conn *c)
{
	tracef("conn stop");
	if (c->closed) {
		return;
	}
	c->closed = true;
	gateway__close(&c->gateway, gatewayCloseCb);
}
```

So, the first thing that `gateway__close` does is freeing the registry (which includes the statement used by the `exec/query`!) as ``g->req == NULL`:

```C
void gateway__close(struct gateway *g, gateway_close_cb cb)
{
    ...
	if (g->req != NULL) {
        ...
	} else {
		gateway_finalize(g);
	}
}

static void gateway_finalize(struct gateway *g)
{
	stmt__registry_close(&g->stmts);
	...
```

And once the callback returns control to the done callback:

```c
static void handle_exec_done_cb(struct exec *exec)
{
    ...
	if (raft_status != 0) {
		exec_failure(g, req, raft_status);
		goto done;
	}
    ...
done:
	sqlite3_clear_bindings(stmt); /* use-after-free */
	sqlite3_reset(stmt); /* use-after-free */
}
```

which will try to use deleted memory.

The reason it happens only in `22.04` is the sqlite3 library version: the newer version do not immediately free the memory, leaving a bit more time to access a statement which is now empty (but the memory still valid from the OS perspective).

Now, there are 2 solutions here which might even cohexist (I will open 2 PRs):
 - keeping the connection alive on a leadership lost event [^1]
 - postponing the closure of the registry to when the leader is closed.

This PR uses the second strategy as it is more roboust in my mind.

[^1]: this was *most of the times* the original behaviour. There was however a specific case where a leadership loss would trigger connection closure.