### PR TITLE
refactor: separate `{Wal,Main,DiskMain}File`s behaviour

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -86,9 +86,12 @@ static int dqlite_authorizer(void *pUserData, int action, const char *third, con
 			return SQLITE_DENY;
 		}
 	} else if (action == SQLITE_PRAGMA) {
-		if (strcasecmp(third, "journal_mode") == 0 && fourth) {
-			/* Block changes to the journal mode:
-			 * only WAL mode is supported */
+		if (sqlite3_stricmp(third, "journal_mode") == 0 && fourth) {
+			/* When the user executes 'PRAGMA journal_mode=x' we ensure
+			* that the desired mode is 'wal'. */
+			return SQLITE_DENY;
+		} else if (sqlite3_stricmp(third, "wal_checkpoint") == 0
+			|| (sqlite3_stricmp(third, "wal_autocheckpoint") == 0 && fourth)) {
 			return SQLITE_DENY;
 		}
 	}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -253,7 +253,7 @@ static void vfsFrameDestroy(struct vfsFrame *f)
 struct vfsShm
 {
 	void **regions;     /* Pointers to shared memory regions. */
-	unsigned n_regions; /* Number of shared memory regions. */
+	int n_regions; /* Number of shared memory regions. */
 	unsigned refcount;  /* Number of outstanding mappings. */
 	unsigned shared[SQLITE_SHM_NLOCK];    /* Count of shared locks */
 	unsigned exclusive[SQLITE_SHM_NLOCK]; /* Count of exclusive locks */
@@ -262,16 +262,7 @@ struct vfsShm
 /* Initialize the shared memory mapping of a database file. */
 static void vfsShmInit(struct vfsShm *s)
 {
-	int i;
-
-	s->regions = NULL;
-	s->n_regions = 0;
-	s->refcount = 0;
-
-	for (i = 0; i < SQLITE_SHM_NLOCK; i++) {
-		s->shared[i] = 0;
-		s->exclusive[i] = 0;
-	}
+	*s = (struct vfsShm){0};
 }
 
 static int vfsShmLock(struct vfsShm *s, int ofst, int n, int flags)
@@ -349,7 +340,7 @@ static int vfsShmUnlock(struct vfsShm *s, int ofst, int n, int flags)
 static void vfsShmClose(struct vfsShm *s)
 {
 	void *region;
-	unsigned i;
+	int i;
 
 	assert(s != NULL);
 
@@ -485,42 +476,6 @@ static uint32_t vfsWalGetPageSize(struct vfsWal *w)
 	return vfsParsePageSize(ByteGetBe32(&w->hdr[8]));
 }
 
-/* Truncate a WAL file to zero. */
-static int vfsWalTruncate(struct vfsWal *w, sqlite3_int64 size)
-{
-	unsigned i;
-
-	/* We expect SQLite to only truncate to zero, after a
-	 * full checkpoint.
-	 *
-	 * TODO: figure out other case where SQLite might
-	 * truncate to a different size.
-	 */
-	if (size != 0) {
-		return SQLITE_PROTOCOL;
-	}
-
-	if (w->n_frames == 0) {
-		return SQLITE_OK;
-	}
-
-	assert(w->frames != NULL);
-
-	/* Restart the header. */
-	formatWalRestartHeader(w->hdr);
-
-	/* Destroy all frames. */
-	for (i = 0; i < w->n_frames; i++) {
-		vfsFrameDestroy(w->frames[i]);
-	}
-	sqlite3_free(w->frames);
-
-	w->frames = NULL;
-	w->n_frames = 0;
-
-	return SQLITE_OK;
-}
-
 /* Release all memory used by a WAL object. */
 static void vfsWalClose(struct vfsWal *w)
 {
@@ -537,6 +492,16 @@ static void vfsWalClose(struct vfsWal *w)
 	if (w->tx != NULL) {
 		sqlite3_free(w->tx);
 	}
+}
+
+static void vfsWalTruncate(struct vfsWal *w)
+{
+	formatWalRestartHeader(w->hdr);
+	vfsWalClose(w);
+	w->frames = NULL;
+	w->n_frames = 0;
+	w->tx = NULL;
+	w->n_tx = 0;
 }
 
 /* Database-specific content */
@@ -693,6 +658,85 @@ static uint32_t vfsDatabaseGetPageSize(struct vfsDatabase *d)
 	return vfsParsePageSize(ByteGetBe16(&page[16]));
 }
 
+/* Return the size of the database file in bytes. */
+static int64_t vfsDatabaseFileSize(struct vfsDatabase *d)
+{
+	int64_t size = 0;
+	if (d->n_pages > 0) {
+		size = (int64_t)d->n_pages * (int64_t)vfsDatabaseGetPageSize(d);
+	}
+	/* TODO dqlite is limited to a max database size of SIZE_MAX */
+	assert((uint64_t)size <= SIZE_MAX);
+	return size;
+}
+
+/* This function modifies part of the WAL index header to reflect the current
+ * content of the WAL.
+ *
+ * It is called in two cases. First, after a write transaction gets completed
+ * and the SQLITE_FCNTL_COMMIT_PHASETWO file control op code is triggered, in
+ * order to "rewind" the mxFrame and szPage fields of the WAL index header back
+ * to when the write transaction started, effectively "shadowing" the
+ * transaction, which will be replicated asynchronously. Second, when the
+ * replication actually succeeds and dqlite_vfs_apply() is called on the VFS
+ * that originated the transaction, in order to make the transaction visible.
+ *
+ * Note that the hash table contained in the WAL index does not get modified,
+ * and even after a rewind following a write transaction it will still contain
+ * entries for the frames committed by the transaction. That's safe because
+ * mxFrame will make clients ignore those hash table entries. However it means
+ * that in case the replication is not actually successful and
+ * dqlite_vfs_abort() is called the WAL index must be invalidated.
+ **/
+static void vfsAmendWalIndexHeader(struct vfsDatabase *d)
+{
+	struct vfsShm *shm = &d->shm;
+	struct vfsWal *wal = &d->wal;
+	uint8_t *index;
+	uint32_t frame_checksum[2] = {0, 0};
+	uint32_t n_pages = (uint32_t)d->n_pages;
+	uint32_t checksum[2] = {0, 0};
+
+	if (wal->n_frames > 0) {
+		struct vfsFrame *last = wal->frames[wal->n_frames - 1];
+		frame_checksum[0] = vfsFrameGetChecksum1(last);
+		frame_checksum[1] = vfsFrameGetChecksum2(last);
+		n_pages = vfsFrameGetDatabaseSize(last);
+	}
+
+	assert(shm->n_regions > 0);
+	index = shm->regions[0];
+
+	/* index is an alias for shm->regions[0] which is a void* that points to
+	 * memory allocated by `sqlite3_malloc64` and has the required alignment
+	 */
+	assert(*(uint32_t *)(__builtin_assume_aligned(&index[0],
+						      sizeof(uint32_t))) ==
+	       VFS__WAL_VERSION);            /* iVersion */
+	assert(index[12] == 1);              /* isInit */
+	assert(index[13] == VFS__BIGENDIAN); /* bigEndCksum */
+
+	*(uint32_t *)(__builtin_assume_aligned(&index[16], sizeof(uint32_t))) =
+	    wal->n_frames;
+	*(uint32_t *)(__builtin_assume_aligned(&index[20], sizeof(uint32_t))) =
+	    n_pages;
+	*(uint32_t *)(__builtin_assume_aligned(&index[24], sizeof(uint32_t))) =
+	    frame_checksum[0];
+	*(uint32_t *)(__builtin_assume_aligned(&index[28], sizeof(uint32_t))) =
+	    frame_checksum[1];
+
+	vfsChecksum(index, 40, checksum, checksum);
+
+	*(uint32_t *)__builtin_assume_aligned(&index[40], sizeof(uint32_t)) =
+	    checksum[0];
+	*(uint32_t *)__builtin_assume_aligned(&index[44], sizeof(uint32_t)) =
+	    checksum[1];
+
+	/* Update the second copy of the first part of the WAL index header. */
+	memcpy(index + VFS__WAL_INDEX_HEADER_SIZE, index,
+	       VFS__WAL_INDEX_HEADER_SIZE);
+}
+
 /* Truncate a database file to be exactly the given number of pages. */
 static int vfsDatabaseTruncate(struct vfsDatabase *d, sqlite_int64 size)
 {
@@ -790,7 +834,7 @@ static struct vfs *vfsCreate(void)
 		return NULL;
 	}
 
-	*v = (struct vfs){
+	*v = (struct vfs) {
 		.base_vfs = sqlite3_vfs_find("unix"),
 	};
 	assert(v->base_vfs != NULL);
@@ -1030,85 +1074,39 @@ static const sqlite3_io_methods vfsNoopMethods = {
 	.xDeviceCharacteristics = vfsNoopDeviceCharacteristics,
 };
 
-enum vfsFileType {
-	VFS__DATABASE, /* Main database file */
-	VFS__WAL       /* Write-Ahead Log */
+struct vfsWalFile
+{
+	sqlite3_file base;  /* Base class. Must be first. */
+	struct vfsWal *wal; /* Underlying in-memory wal. */
 };
 
-/* Implementation of the abstract sqlite3_file base class.
- * for the main database file */
-struct vfsFile
+/* Return the size of the WAL file in bytes. */
+static int64_t vfsWalSize(struct vfsWal *w)
 {
-	sqlite3_file base;            /* Base class. Must be first. */
-	struct vfs *vfs;              /* Pointer to volatile VFS data. */
-	enum vfsFileType type;        /* Associated file (main db or WAL). */
-	struct vfsDatabase *database; /* Underlying database content. */
-	sqlite3_file *db;             /* For on-disk DB files, actual VFS. */
-};
+	int64_t size = 0;
+	if (w->n_frames > 0) {
+		uint32_t page_size;
+		page_size = vfsWalGetPageSize(w);
+		size += VFS__WAL_HEADER_SIZE;
+		size += (int64_t)w->n_frames *
+			(int64_t)(FORMAT__WAL_FRAME_HDR_SIZE + page_size);
+	}
+	/* TODO dqlite is limited to a max database size of SIZE_MAX */
+	assert((size >= 0) && ((uint64_t)size <= SIZE_MAX));
+	return (int64_t)size;
+}
 
-static int vfsFileClose(sqlite3_file *file)
+static int vfsWalFileSize(sqlite3_file* file, sqlite3_int64 *pSize)
 {
-	(void)file;
+	struct vfsWalFile *f = (struct vfsWalFile *)file;
+	*pSize = (sqlite3_int64)vfsWalSize(f->wal);
 	return SQLITE_OK;
 }
 
-/* Read data from the main database. */
-static int vfsDatabaseRead(struct vfsDatabase *d,
-			   void *buf,
-			   int amount,
-			   sqlite_int64 offset)
+static int vfsWalFileRead(sqlite3_file* file, void* buf, int amount, sqlite3_int64 offset)
 {
-	unsigned page_size;
-	unsigned pgno;
-	void *page;
+	struct vfsWalFile *f = (struct vfsWalFile *)file;
 
-	if (d->n_pages == 0) {
-		return SQLITE_IOERR_SHORT_READ;
-	}
-
-	/* If the main database file is not empty, we expect the
-	 * page size to have been set by an initial write. */
-	page_size = vfsDatabaseGetPageSize(d);
-	assert(page_size > 0);
-
-	if (offset < (int)page_size) {
-		/* Reading from page 1. We expect the read to be
-		 * at most page_size bytes. */
-		assert(amount <= (int)page_size);
-		pgno = 1;
-	} else {
-		/* For pages greater than 1, we expect an offset
-		 * that starts exactly at a page boundary. The read
-		 * size can be less than a full page when SQLite
-		 * is compiled with SQLITE_DIRECT_OVERFLOW_READ
-		 * (enabled by default since 3.45.1). */
-		assert(amount <= (int)page_size);
-
-		assert((offset % (int)page_size) == 0);
-		pgno = (unsigned)(offset / (int)page_size) + 1;
-	}
-
-	assert(pgno > 0);
-
-	page = vfsDatabasePageLookup(d, pgno);
-
-	if (pgno == 1) {
-		/* Read the desired part of page 1. */
-		memcpy(buf, (char *)page + offset, (size_t)amount);
-	} else {
-		/* Read the page. */
-		memcpy(buf, page, (size_t)amount);
-	}
-
-	return SQLITE_OK;
-}
-
-/* Read data from the WAL. */
-static int vfsWalRead(struct vfsWal *w,
-		      void *buf,
-		      int amount,
-		      sqlite_int64 offset)
-{
 	uint32_t page_size;
 	unsigned index;
 	struct vfsFrame *frame;
@@ -1116,11 +1114,11 @@ static int vfsWalRead(struct vfsWal *w,
 	if (offset == 0) {
 		/* Read the header. */
 		assert(amount == VFS__WAL_HEADER_SIZE);
-		memcpy(buf, w->hdr, VFS__WAL_HEADER_SIZE);
+		memcpy(buf, f->wal->hdr, VFS__WAL_HEADER_SIZE);
 		return SQLITE_OK;
 	}
 
-	page_size = vfsWalGetPageSize(w);
+	page_size = vfsWalGetPageSize(f->wal);
 	assert(page_size > 0);
 
 	/* For any other frame, we expect either a header read,
@@ -1134,7 +1132,7 @@ static int vfsWalRead(struct vfsWal *w,
 		if (offset == FORMAT__WAL_FRAME_HDR_SIZE) {
 			/* Read the checksum from the WAL
 			 * header. */
-			memcpy(buf, w->hdr + offset, (size_t)amount);
+			memcpy(buf, f->wal->hdr + offset, (size_t)amount);
 			return SQLITE_OK;
 		}
 		assert(((offset - 16 - VFS__WAL_HEADER_SIZE) %
@@ -1162,7 +1160,7 @@ static int vfsWalRead(struct vfsWal *w,
 		return SQLITE_IOERR_SHORT_READ;
 	}
 
-	frame = vfsWalFrameLookup(w, index);
+	frame = vfsWalFrameLookup(f->wal, index);
 	if (frame == NULL) {
 		// Again, the requested page doesn't exist.
 		memset(buf, 0, (size_t)amount);
@@ -1184,103 +1182,9 @@ static int vfsWalRead(struct vfsWal *w,
 	return SQLITE_OK;
 }
 
-static int vfsFileRead(sqlite3_file *file,
-		       void *buf,
-		       int amount,
-		       sqlite_int64 offset)
+static int vfsWalFileWrite(sqlite3_file* file, const void* buf, int amount, sqlite3_int64 offset)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	int rv;
-
-	assert(buf != NULL);
-	assert(amount > 0);
-	assert(offset >= 0);
-	assert(f != NULL);
-
-	switch (f->type) {
-		case VFS__DATABASE:
-			rv = vfsDatabaseRead(f->database, buf, amount, offset);
-			break;
-		case VFS__WAL:
-			rv = vfsWalRead(&f->database->wal, buf, amount, offset);
-			break;
-		default:
-			rv = SQLITE_IOERR_READ;
-			break;
-	}
-
-	/* From SQLite docs:
-	 *
-	 *   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
-	 *   in the unread portions of the buffer with zeros.  A VFS that
-	 *   fails to zero-fill short reads might seem to work.  However,
-	 *   failure to zero-fill short reads will eventually lead to
-	 *   database corruption.
-	 */
-	if (rv == SQLITE_IOERR_SHORT_READ) {
-		memset(buf, 0, (size_t)amount);
-	}
-
-	return rv;
-}
-
-static int vfsDatabaseWrite(struct vfsDatabase *d,
-			    const void *buf,
-			    int amount,
-			    sqlite_int64 offset)
-{
-	unsigned pgno;
-	uint32_t page_size;
-	void *page;
-	int rc;
-
-	if (offset == 0) {
-		const uint8_t *header = buf;
-
-		/* This is the first database page. We expect
-		 * the data to contain at least the header. */
-		assert(amount >= FORMAT__DB_HDR_SIZE);
-
-		/* Extract the page size from the header. */
-		page_size = vfsParsePageSize(ByteGetBe16(&header[16]));
-		if (page_size == 0) {
-			return SQLITE_CORRUPT;
-		}
-
-		pgno = 1;
-	} else {
-		page_size = vfsDatabaseGetPageSize(d);
-
-		/* The header must have been written and the page size set. */
-		assert(page_size > 0);
-
-		/* For pages beyond the first we expect offset to be a multiple
-		 * of the page size. */
-		assert((offset % (int)page_size) == 0);
-
-		/* We expect that SQLite writes a page at time. */
-		assert(amount == (int)page_size);
-
-		pgno = ((unsigned)(offset / (int)page_size)) + 1;
-	}
-
-	rc = vfsDatabaseGetPage(d, page_size, pgno, &page);
-	if (rc != SQLITE_OK) {
-		return rc;
-	}
-
-	assert(page != NULL);
-
-	memcpy(page, buf, (size_t)amount);
-
-	return SQLITE_OK;
-}
-
-static int vfsWalWrite(struct vfsWal *w,
-		       const void *buf,
-		       int amount,
-		       sqlite_int64 offset)
-{
+	struct vfsWalFile *f = (struct vfsWalFile *)file;
 	uint32_t page_size;
 	unsigned index;
 	struct vfsFrame *frame;
@@ -1291,11 +1195,11 @@ static int vfsWalWrite(struct vfsWal *w,
 		 * bytes. */
 		assert(amount == VFS__WAL_HEADER_SIZE);
 
-		memcpy(w->hdr, buf, (size_t)amount);
+		memcpy(f->wal->hdr, buf, (size_t)amount);
 		return SQLITE_OK;
 	}
 
-	page_size = vfsWalGetPageSize(w);
+	page_size = vfsWalGetPageSize(f->wal);
 	assert(page_size > 0);
 
 	/* This is a WAL frame write. We expect either a frame
@@ -1308,7 +1212,7 @@ static int vfsWalWrite(struct vfsWal *w,
 		index =
 		    (unsigned)formatWalCalcFrameIndex((int)page_size, offset);
 
-		vfsWalFrameGet(w, index, page_size, &frame);
+		vfsWalFrameGet(f->wal, index, page_size, &frame);
 		if (frame == NULL) {
 			return SQLITE_NOMEM;
 		}
@@ -1325,7 +1229,7 @@ static int vfsWalWrite(struct vfsWal *w,
 
 		/* The header for the this frame must already
 		 * have been written, so the page is there. */
-		frame = vfsWalFrameLookup(w, index);
+		frame = vfsWalFrameLookup(f->wal, index);
 
 		assert(frame != NULL);
 
@@ -1335,113 +1239,183 @@ static int vfsWalWrite(struct vfsWal *w,
 	return SQLITE_OK;
 }
 
-static int vfsFileWrite(sqlite3_file *file,
-			const void *buf,
-			int amount,
-			sqlite_int64 offset)
+static int vfsWalFileTruncate(sqlite3_file* file, sqlite3_int64 size)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	int rv;
+	struct vfsWalFile *f = (struct vfsWalFile *)file;
+
+	/* We expect SQLite to only truncate to zero, after a
+	 * full checkpoint.
+	 *
+	 * TODO: figure out other case where SQLite might
+	 * truncate to a different size.
+	 */
+	if (size != 0) {
+		return SQLITE_PROTOCOL;
+	}
+
+	vfsWalTruncate(f->wal);
+
+	return SQLITE_OK;
+}
+
+static const sqlite3_io_methods vfsWalFileMethods = {
+	.iVersion = 1,
+	.xClose = vfsNoopClose,
+	.xRead = vfsWalFileRead,
+	.xWrite = vfsWalFileWrite,
+	.xTruncate = vfsWalFileTruncate,
+	.xSync = vfsNoopSync,
+	.xFileSize = vfsWalFileSize,
+	.xLock = vfsNoopLock,
+	.xUnlock = vfsNoopUnlock,
+	.xCheckReservedLock = vfsNoopCheckReservedLock,
+	.xFileControl = vfsNoopFileControl,
+	.xSectorSize = vfsNoopSectorSize,
+	.xDeviceCharacteristics = vfsNoopDeviceCharacteristics,
+};
+
+/* Implementation of the abstract sqlite3_file base class.
+ * for the main database file */
+struct vfsMainFile
+{
+	sqlite3_file base;            /* Base class. Must be first. */
+	struct vfs *vfs;              /* Pointer to volatile VFS data. */
+	struct vfsDatabase *database; /* Underlying database content. */
+};
+
+static int vfsMainFileRead(sqlite3_file *file,
+			   void *buf,
+			   int amount,
+			   sqlite_int64 offset)
+{
+	struct vfsMainFile *f = (struct vfsMainFile *)file;
+
+
+	unsigned page_size;
+	unsigned pgno;
+	void *page;
+
+	if (f->database->n_pages == 0) {
+		/* From SQLite docs:
+		*
+		*   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
+		*   in the unread portions of the buffer with zeros.  A VFS that
+		*   fails to zero-fill short reads might seem to work.  However,
+		*   failure to zero-fill short reads will eventually lead to
+		*   database corruption.
+		*/
+		memset(buf, 0, (size_t)amount);
+		return SQLITE_IOERR_SHORT_READ;
+	}
+
+	/* If the main database file is not empty, we expect the
+	 * page size to have been set by an initial write. */
+	page_size = vfsDatabaseGetPageSize(f->database);
+	assert(page_size > 0);
+
+	if (offset < (int)page_size) {
+		/* Reading from page 1. We expect the read to be
+		 * at most page_size bytes. */
+		assert(amount <= (int)page_size);
+		pgno = 1;
+	} else {
+		/* For pages greater than 1, we expect an offset
+		 * that starts exactly at a page boundary. The read
+		 * size can be less than a full page when SQLite
+		 * is compiled with SQLITE_DIRECT_OVERFLOW_READ
+		 * (enabled by default since 3.45.1). */
+		assert(amount <= (int)page_size);
+
+		assert((offset % (int)page_size) == 0);
+		pgno = (unsigned)(offset / (int)page_size) + 1;
+	}
+
+	assert(pgno > 0);
+
+	page = vfsDatabasePageLookup(f->database, pgno);
+
+	if (pgno == 1) {
+		/* Read the desired part of page 1. */
+		memcpy(buf, (char *)page + offset, (size_t)amount);
+	} else {
+		/* Read the page. */
+		memcpy(buf, page, (size_t)amount);
+	}
+
+	return SQLITE_OK;
+}
+
+static int vfsMainFileWrite(sqlite3_file *file,
+			    const void *buf,
+			    int amount,
+			    sqlite_int64 offset)
+{
+	struct vfsMainFile *f = (struct vfsMainFile *)file;
 
 	assert(buf != NULL);
 	assert(amount > 0);
 	assert(f != NULL);
 
-	switch (f->type) {
-		case VFS__DATABASE:
-			rv = vfsDatabaseWrite(f->database, buf, amount, offset);
-			break;
-		case VFS__WAL:
-			rv = vfsWalWrite(&f->database->wal, buf, amount, offset);
-			break;
-		default:
-			rv = SQLITE_IOERR_WRITE;
-			break;
+	unsigned pgno;
+	uint32_t page_size;
+	void *page;
+
+	if (offset == 0) {
+		const uint8_t *header = buf;
+
+		/* This is the first database page. We expect
+		 * the data to contain at least the header. */
+		assert(amount >= FORMAT__DB_HDR_SIZE);
+
+		/* Extract the page size from the header. */
+		page_size = vfsParsePageSize(ByteGetBe16(&header[16]));
+		if (page_size == 0) {
+			return SQLITE_CORRUPT;
+		}
+
+		pgno = 1;
+	} else {
+		page_size = vfsDatabaseGetPageSize(f->database);
+
+		/* The header must have been written and the page size set. */
+		assert(page_size > 0);
+
+		/* For pages beyond the first we expect offset to be a multiple
+		 * of the page size. */
+		assert((offset % (int)page_size) == 0);
+
+		/* We expect that SQLite writes a page at time. */
+		assert(amount == (int)page_size);
+
+		pgno = ((unsigned)(offset / (int)page_size)) + 1;
 	}
 
-	return rv;
+	int rv = vfsDatabaseGetPage(f->database, page_size, pgno, &page);
+	if (rv != SQLITE_OK) {
+		return rv;
+	}
+
+	assert(page != NULL);
+	memcpy(page, buf, (size_t)amount);
+	return SQLITE_OK;
 }
 
-static int vfsFileTruncate(sqlite3_file *file, sqlite_int64 size)
+static int vfsMainFileTruncate(sqlite3_file *file, sqlite_int64 size)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	int rv;
-
-	assert(f != NULL);
-
-	switch (f->type) {
-		case VFS__DATABASE:
-			rv = vfsDatabaseTruncate(f->database, size);
-			break;
-
-		case VFS__WAL:
-			rv = vfsWalTruncate(&f->database->wal, size);
-			break;
-
-		default:
-			rv = SQLITE_IOERR_TRUNCATE;
-			break;
-	}
-
-	return rv;
+	struct vfsMainFile *f = (struct vfsMainFile *)file;
+	return vfsDatabaseTruncate(f->database, size);
 }
 
-/* Return the size of the database file in bytes. */
-static size_t vfsDatabaseFileSize(struct vfsDatabase *d)
+static int vfsMainFileSize(sqlite3_file *file, sqlite_int64 *size)
 {
-	uint64_t size = 0;
-	if (d->n_pages > 0) {
-		size =
-		    (uint64_t)d->n_pages * (uint64_t)vfsDatabaseGetPageSize(d);
-	}
-	/* TODO dqlite is limited to a max database size of SIZE_MAX */
-	assert(size <= SIZE_MAX);
-	return (size_t)size;
-}
-
-/* Return the size of the WAL file in bytes. */
-static size_t vfsWalFileSize(struct vfsWal *w)
-{
-	uint64_t size = 0;
-	if (w->n_frames > 0) {
-		uint32_t page_size;
-		page_size = vfsWalGetPageSize(w);
-		size += VFS__WAL_HEADER_SIZE;
-		size += (uint64_t)w->n_frames *
-			(uint64_t)(FORMAT__WAL_FRAME_HDR_SIZE + page_size);
-	}
-	/* TODO dqlite is limited to a max database size of SIZE_MAX */
-	assert(size <= SIZE_MAX);
-	return (size_t)size;
-}
-
-static int vfsFileSize(sqlite3_file *file, sqlite_int64 *size)
-{
-	struct vfsFile *f = (struct vfsFile *)file;
-	size_t n;
-
-	switch (f->type) {
-		case VFS__DATABASE:
-			n = vfsDatabaseFileSize(f->database);
-			break;
-		case VFS__WAL:
-			/* TODO? here we assume that FileSize() is never invoked
-			 * between a header write and a page write. */
-			n = vfsWalFileSize(&f->database->wal);
-			break;
-		default:
-			n = 0;
-			break;
-	}
-
-	*size = (sqlite3_int64)n;
-
+	struct vfsMainFile *f = (struct vfsMainFile *)file;
+	*size = vfsDatabaseFileSize(f->database);
 	return SQLITE_OK;
 }
 
 /* Handle pragma a pragma file control. See the xFileControl
  * docstring in sqlite.h.in for more details. */
-static int vfsFileControlPragma(struct vfsFile *f, char **fcntl)
+static int vfsFileControlPragma(struct vfsMainFile *f, char **fcntl)
 {
 	const char *left;
 	const char *right;
@@ -1479,18 +1453,6 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fcntl)
 				return SQLITE_IOERR;
 			}
 		}
-	} else if (sqlite3_stricmp(left, "journal_mode") == 0 && right) {
-		/* When the user executes 'PRAGMA journal_mode=x' we ensure
-		 * that the desired mode is 'wal'. */
-		if (strcasecmp(right, "wal") != 0) {
-			fcntl[0] =
-			    sqlite3_mprintf("only WAL mode is supported");
-			return SQLITE_IOERR;
-		}
-	} else if (sqlite3_stricmp(left, "wal_checkpoint") == 0
-			|| (sqlite3_stricmp(left, "wal_autocheckpoint") == 0 && right)) {
-		fcntl[0] = sqlite3_mprintf("custom checkpoint not allowed");
-		return SQLITE_IOERR;
 	}
 
 	/* We're returning NOTFOUND here to tell SQLite that we wish it to go on
@@ -1500,117 +1462,39 @@ static int vfsFileControlPragma(struct vfsFile *f, char **fcntl)
 	return SQLITE_NOTFOUND;
 }
 
-/* This function modifies part of the WAL index header to reflect the current
- * content of the WAL.
- *
- * It is called in two cases. First, after a write transaction gets completed
- * and the SQLITE_FCNTL_COMMIT_PHASETWO file control op code is triggered, in
- * order to "rewind" the mxFrame and szPage fields of the WAL index header back
- * to when the write transaction started, effectively "shadowing" the
- * transaction, which will be replicated asynchronously. Second, when the
- * replication actually succeeds and dqlite_vfs_apply() is called on the VFS
- * that originated the transaction, in order to make the transaction visible.
- *
- * Note that the hash table contained in the WAL index does not get modified,
- * and even after a rewind following a write transaction it will still contain
- * entries for the frames committed by the transaction. That's safe because
- * mxFrame will make clients ignore those hash table entries. However it means
- * that in case the replication is not actually successful and
- * dqlite_vfs_abort() is called the WAL index must be invalidated.
- **/
-static void vfsAmendWalIndexHeader(struct vfsDatabase *database)
+
+static int vfsMainFileControl(sqlite3_file *file, int op, void *arg)
 {
-	struct vfsShm *shm = &database->shm;
-	struct vfsWal *wal = &database->wal;
-	uint8_t *index;
-	uint32_t frame_checksum[2] = {0, 0};
-	uint32_t n_pages = (uint32_t)database->n_pages;
-	uint32_t checksum[2] = {0, 0};
-
-	if (wal->n_frames > 0) {
-		struct vfsFrame *last = wal->frames[wal->n_frames - 1];
-		frame_checksum[0] = vfsFrameGetChecksum1(last);
-		frame_checksum[1] = vfsFrameGetChecksum2(last);
-		n_pages = vfsFrameGetDatabaseSize(last);
-	}
-
-	assert(shm->n_regions > 0);
-	index = shm->regions[0];
-
-	/* index is an alias for shm->regions[0] which is a void* that points to
-	 * memory allocated by `sqlite3_malloc64` and has the required alignment
-	 */
-	assert(*(uint32_t *)(__builtin_assume_aligned(&index[0],
-						      sizeof(uint32_t))) ==
-	       VFS__WAL_VERSION);            /* iVersion */
-	assert(index[12] == 1);              /* isInit */
-	assert(index[13] == VFS__BIGENDIAN); /* bigEndCksum */
-
-	*(uint32_t *)(__builtin_assume_aligned(&index[16], sizeof(uint32_t))) =
-	    wal->n_frames;
-	*(uint32_t *)(__builtin_assume_aligned(&index[20], sizeof(uint32_t))) =
-	    n_pages;
-	*(uint32_t *)(__builtin_assume_aligned(&index[24], sizeof(uint32_t))) =
-	    frame_checksum[0];
-	*(uint32_t *)(__builtin_assume_aligned(&index[28], sizeof(uint32_t))) =
-	    frame_checksum[1];
-
-	vfsChecksum(index, 40, checksum, checksum);
-
-	*(uint32_t *)__builtin_assume_aligned(&index[40], sizeof(uint32_t)) =
-	    checksum[0];
-	*(uint32_t *)__builtin_assume_aligned(&index[44], sizeof(uint32_t)) =
-	    checksum[1];
-
-	/* Update the second copy of the first part of the WAL index header. */
-	memcpy(index + VFS__WAL_INDEX_HEADER_SIZE, index,
-	       VFS__WAL_INDEX_HEADER_SIZE);
-}
-
-/* The SQLITE_FCNTL_COMMIT_PHASETWO file control op code is trigged by the
- * SQLite pager after completing a transaction. */
-static int vfsFileControlCommitPhaseTwo(struct vfsFile *f)
-{
-	if (f->database->wal.n_tx > 0) {
-		vfsAmendWalIndexHeader(f->database);
-	}
-	return 0;
-}
-
-static int vfsFileControl(sqlite3_file *file, int op, void *arg)
-{
-	struct vfsFile *f = (struct vfsFile *)file;
-	int rv;
-
-	assert(f->type == VFS__DATABASE);
+	struct vfsMainFile *f = (struct vfsMainFile *)file;
 
 	switch (op) {
 		case SQLITE_FCNTL_PRAGMA:
-			rv = vfsFileControlPragma(f, arg);
-			break;
+			return vfsFileControlPragma(f, arg);
 		case SQLITE_FCNTL_COMMIT_PHASETWO:
-			rv = vfsFileControlCommitPhaseTwo(f);
-			break;
+			if (f->database->wal.n_tx > 0) {
+				vfsAmendWalIndexHeader(f->database);
+			}
+			return SQLITE_OK;
 		case SQLITE_FCNTL_PERSIST_WAL:
 			/* This prevents SQLite from deleting the WAL after the
 			 * last connection is closed. */
 			*(int *)(arg) = 1;
-			rv = SQLITE_OK;
-			break;
+			return SQLITE_OK;
 		default:
-			rv = SQLITE_OK;
-			break;
+			return SQLITE_OK;
 	}
-
-	return rv;
 }
 
-static int vfsShmMap(struct vfsShm *s,
-		     unsigned region_index,
-		     unsigned region_size,
-		     bool extend,
-		     void volatile **out)
+/* Simulate shared memory by allocating on the C heap. */
+static int vfsMainFileShmMap(sqlite3_file *file, /* Handle open on database file */
+			 int region_index,   /* Region to retrieve */
+			 int region_size,    /* Size of regions */
+			 int extend, /* True to extend file if necessary */
+			 void volatile **out /* OUT: Mapped memory */
+)
 {
+	struct vfsMainFile *f = (struct vfsMainFile *)file;
+	struct vfsShm *s = &f->database->shm;
 	void *region;
 	int rv;
 
@@ -1625,17 +1509,17 @@ static int vfsShmMap(struct vfsShm *s,
 			/* We should grow the map one region at a time. */
 			assert(region_size == VFS__WAL_INDEX_REGION_SIZE);
 			assert(region_index == s->n_regions);
-			region = sqlite3_malloc64(region_size);
+			region = sqlite3_malloc64((sqlite3_uint64)region_size);
 			if (region == NULL) {
 				rv = SQLITE_NOMEM;
 				goto err;
 			}
 
-			memset(region, 0, region_size);
+			memset(region, 0, (size_t)region_size);
 
 			regions = sqlite3_realloc64(
 			    s->regions,
-			    sizeof *s->regions * (s->n_regions + 1));
+			    (sqlite3_uint64)sizeof(*s->regions) * (sqlite3_uint64)(s->n_regions + 1));
 
 			if (regions == NULL) {
 				rv = SQLITE_NOMEM;
@@ -1669,22 +1553,6 @@ err:
 	return rv;
 }
 
-/* Simulate shared memory by allocating on the C heap. */
-static int vfsFileShmMap(sqlite3_file *file, /* Handle open on database file */
-			 int region_index,   /* Region to retrieve */
-			 int region_size,    /* Size of regions */
-			 int extend, /* True to extend file if necessary */
-			 void volatile **out /* OUT: Mapped memory */
-)
-{
-	struct vfsFile *f = (struct vfsFile *)file;
-
-	assert(f->type == VFS__DATABASE);
-
-	return vfsShmMap(&f->database->shm, (unsigned)region_index,
-			 (unsigned)region_size, extend != 0, out);
-}
-
 /* If there's a uncommitted transaction, roll it back. */
 static void vfsWalRollbackIfUncommitted(struct vfsWal *w)
 {
@@ -1712,9 +1580,9 @@ static void vfsWalRollbackIfUncommitted(struct vfsWal *w)
 	w->n_tx = 0;
 }
 
-static int vfsFileShmLock(sqlite3_file *file, int ofst, int n, int flags)
+static int vfsMainFileShmLock(sqlite3_file *file, int ofst, int n, int flags)
 {
-	struct vfsFile *f;
+	struct vfsMainFile *f;
 	struct vfsShm *shm;
 	struct vfsWal *wal;
 	int rv;
@@ -1740,9 +1608,8 @@ static int vfsFileShmLock(sqlite3_file *file, int ofst, int n, int flags)
 	 * inter-process concurrency. See also the unix-excl branch from
 	 * upstream (git commit cda6b3249167a54a0cf892f949d52760ee557129). */
 
-	f = (struct vfsFile *)file;
+	f = (struct vfsMainFile *)file;
 
-	assert(f->type == VFS__DATABASE);
 	assert(f->database != NULL);
 
 	shm = &f->database->shm;
@@ -1772,7 +1639,7 @@ static int vfsFileShmLock(sqlite3_file *file, int ofst, int n, int flags)
 	return rv;
 }
 
-static void vfsFileShmBarrier(sqlite3_file *file)
+static void vfsMainFileShmBarrier(sqlite3_file *file)
 {
 	(void)file;
 	/* This is a no-op since we expect SQLite to be compiled with mutex
@@ -1780,59 +1647,60 @@ static void vfsFileShmBarrier(sqlite3_file *file)
 	 * defined, see sqliteInt.h). */
 }
 
-static void vfsShmUnmap(struct vfsShm *s)
+static int vfsMainFileShmUnmap(sqlite3_file *file, int delete_flag)
 {
+	(void)delete_flag;
+	struct vfsMainFile *f = (struct vfsMainFile *)file;
+	struct vfsShm *s = &f->database->shm;
 	s->refcount--;
 	if (s->refcount == 0) {
 		vfsShmReset(s);
 	}
-}
-
-static int vfsFileShmUnmap(sqlite3_file *file, int delete_flag)
-{
-	struct vfsFile *f = (struct vfsFile *)file;
-	(void)delete_flag;
-	vfsShmUnmap(&f->database->shm);
 	return SQLITE_OK;
 }
 
 static const sqlite3_io_methods vfsFileMethods = {
-	2,
-	vfsFileClose,
-	vfsFileRead,
-	vfsFileWrite,
-	vfsFileTruncate,
-	vfsNoopSync,
-	vfsFileSize,
-	vfsNoopLock,
-	vfsNoopUnlock,
-	vfsNoopCheckReservedLock,
-	vfsFileControl,
-	vfsNoopSectorSize,
-	vfsNoopDeviceCharacteristics,
-	vfsFileShmMap,
-	vfsFileShmLock,
-	vfsFileShmBarrier,
-	vfsFileShmUnmap,
-	0,
-	0,
+	.iVersion = 2,
+	.xClose = vfsNoopClose,
+	.xRead = vfsMainFileRead,
+	.xWrite = vfsMainFileWrite,
+	.xTruncate = vfsMainFileTruncate,
+	.xSync = vfsNoopSync,
+	.xFileSize = vfsMainFileSize,
+	.xLock = vfsNoopLock,
+	.xUnlock = vfsNoopUnlock,
+	.xCheckReservedLock = vfsNoopCheckReservedLock,
+	.xFileControl = vfsMainFileControl,
+	.xSectorSize = vfsNoopSectorSize,
+	.xDeviceCharacteristics = vfsNoopDeviceCharacteristics,
+	.xShmMap = vfsMainFileShmMap,
+	.xShmLock = vfsMainFileShmLock,
+	.xShmBarrier = vfsMainFileShmBarrier,
+	.xShmUnmap = vfsMainFileShmUnmap,
+};
+
+/* Implementation of the abstract sqlite3_file base class.
+ * for the main database file */
+struct vfsDiskMainFile
+{
+	struct vfsMainFile base;
+	sqlite3_file *underlying;             /* On disk database file. */
 };
 
 static int vfsDiskFileClose(sqlite3_file *file)
 {
-	int rc = SQLITE_OK;
-	struct vfsFile *f = (struct vfsFile *)file;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
 
-	if (f->db != NULL) {
-		rc = f->db->pMethods->xClose(f->db);
-		sqlite3_free(f->db);
-		f->db = NULL;
+	if (f->underlying != NULL) {
+		int rc = f->underlying->pMethods->xClose(f->underlying);
+		sqlite3_free(f->underlying);
+		f->underlying = NULL;
 		if (rc != SQLITE_OK) {
 			return rc;
 		}
 	}
 
-	return rc;
+	return SQLITE_OK;
 }
 
 static int vfsDiskFileRead(sqlite3_file *file,
@@ -1840,40 +1708,8 @@ static int vfsDiskFileRead(sqlite3_file *file,
 			   int amount,
 			   sqlite_int64 offset)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	int rv;
-
-	assert(buf != NULL);
-	assert(amount > 0);
-	assert(f != NULL);
-
-	if (f->db != NULL) {
-		/* Read from the actual database file. */
-		return f->db->pMethods->xRead(f->db, buf, amount, offset);
-	}
-
-	switch (f->type) {
-		case VFS__WAL:
-			rv = vfsWalRead(&f->database->wal, buf, amount, offset);
-			break;
-		default:
-			rv = SQLITE_IOERR_READ;
-			break;
-	}
-
-	/* From SQLite docs:
-	 *
-	 *   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
-	 *   in the unread portions of the buffer with zeros.  A VFS that
-	 *   fails to zero-fill short reads might seem to work.  However,
-	 *   failure to zero-fill short reads will eventually lead to
-	 *   database corruption.
-	 */
-	if (rv == SQLITE_IOERR_SHORT_READ) {
-		memset(buf, 0, (size_t)amount);
-	}
-
-	return rv;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xRead(f->underlying, buf, amount, offset);
 }
 
 /* Need to keep track of the number of database pages to allow creating correct
@@ -1905,119 +1741,48 @@ static int vfsDiskFileWrite(sqlite3_file *file,
 			    int amount,
 			    sqlite_int64 offset)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	int rv;
-
-	assert(buf != NULL);
-	assert(amount > 0);
-	assert(f != NULL);
-
-	if (f->db != NULL) {
-		/* Write to the actual database file. */
-		vfsDiskDatabaseTrackNumPages(f->database, offset);
-		rv = f->db->pMethods->xWrite(f->db, buf, amount, offset);
-		tracef("vfsDiskFileWrite %s amount:%d rv:%d", "db", amount, rv);
-		return rv;
-	}
-
-	switch (f->type) {
-		case VFS__WAL:
-			rv = vfsWalWrite(&f->database->wal, buf, amount, offset);
-			break;
-		default:
-			rv = SQLITE_IOERR_WRITE;
-			break;
-	}
-
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	
+	/* Write to the actual database file. */
+	vfsDiskDatabaseTrackNumPages(f->base.database, offset);
+	int rv = f->underlying->pMethods->xWrite(f->underlying, buf, amount, offset);
+	tracef("vfsDiskFileWrite %s amount:%d rv:%d", "db", amount, rv);
 	return rv;
 }
 
 static int vfsDiskFileTruncate(sqlite3_file *file, sqlite_int64 size)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	int rv;
-
-	assert(f != NULL);
-
-	if (f->db != NULL) {
-		return f->db->pMethods->xTruncate(f->db, size);
-	}
-
-	switch (f->type) {
-		case VFS__WAL:
-			rv = vfsWalTruncate(&f->database->wal, size);
-			break;
-		default:
-			rv = SQLITE_IOERR_TRUNCATE;
-			break;
-	}
-
-	return rv;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xTruncate(f->underlying, size);
 }
 
 static int vfsDiskFileSync(sqlite3_file *file, int flags)
 {
-	int rv;
-	struct vfsFile *f = (struct vfsFile *)file;
-
-	if (f->db != NULL) {
-		rv = f->db->pMethods->xSync(f->db, flags);
-		return rv;
-	}
-
-	return SQLITE_IOERR_FSYNC;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xSync(f->underlying, flags);
 }
 
 static int vfsDiskFileSize(sqlite3_file *file, sqlite_int64 *size)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	size_t n;
-
-	if (f->db != NULL) {
-		return f->db->pMethods->xFileSize(f->db, size);
-	}
-
-	switch (f->type) {
-		case VFS__WAL:
-			/* TODO? here we assume that FileSize() is never invoked
-			 * between a header write and a page write. */
-			n = vfsWalFileSize(&f->database->wal);
-			break;
-		default:
-			n = 0;
-			break;
-	}
-
-	*size = (sqlite3_int64)n;
-
-	return SQLITE_OK;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xFileSize(f->underlying, size);
 }
 
-/* Locking a file is a no-op, since no other process has visibility on it,
- * unless the database resides on disk. */
 static int vfsDiskFileLock(sqlite3_file *file, int lock)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	if (f->db != NULL) {
-		return f->db->pMethods->xLock(f->db, lock);
-	}
-	return SQLITE_OK;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xLock(f->underlying, lock);
 }
 
-/* Unlocking a file is a no-op, since no other process has visibility on it,
- * unless the database resides on disk. */
 static int vfsDiskFileUnlock(sqlite3_file *file, int lock)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	if (f->db != NULL) {
-		return f->db->pMethods->xUnlock(f->db, lock);
-	}
-	return SQLITE_OK;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xUnlock(f->underlying, lock);
 }
 
 /* Handle pragma a pragma file control. See the xFileControl
  * docstring in sqlite.h.in for more details. */
-static int vfsDiskFileControlPragma(struct vfsFile *f, char **fcntl)
+static int vfsDiskFileControlPragma(struct vfsDiskMainFile *f, char **fcntl)
 {
 	int rv;
 	const char *left;
@@ -2034,35 +1799,21 @@ static int vfsDiskFileControlPragma(struct vfsFile *f, char **fcntl)
 	if (strcmp(left, "page_size") == 0 && right) {
 		int page_size = atoi(right);
 		/* The first page_size pragma sets page_size member of the db
-		 * and is called by dqlite based on the page_size configuration.
-		 * Only used for on-disk databases.
-		 * */
-		if (f->db == NULL) {
-			fcntl[0] = sqlite3_mprintf("no DB file found");
-			return SQLITE_IOERR;
-		}
+		 * and is called by dqlite based on the page_size configuration. */
 		if (page_size > UINT16_MAX) {
 			fcntl[0] = sqlite3_mprintf("max page_size exceeded");
 			return SQLITE_IOERR;
 		}
-		if (f->database->page_size == 0) {
-			rv = f->db->pMethods->xFileControl(
-			    f->db, SQLITE_FCNTL_PRAGMA, fcntl);
+		if (f->base.database->page_size == 0) {
+			rv = f->underlying->pMethods->xFileControl(
+			    f->underlying, SQLITE_FCNTL_PRAGMA, fcntl);
 			if (rv == SQLITE_NOTFOUND || rv == SQLITE_OK) {
-				f->database->page_size = (uint16_t)page_size;
+				f->base.database->page_size = (uint16_t)page_size;
 			}
 			return rv;
-		} else if ((uint16_t)page_size != f->database->page_size) {
+		} else if ((uint16_t)page_size != f->base.database->page_size) {
 			fcntl[0] = sqlite3_mprintf(
 			    "changing page size is not supported");
-			return SQLITE_IOERR;
-		}
-	} else if (strcmp(left, "journal_mode") == 0 && right) {
-		/* When the user executes 'PRAGMA journal_mode=x' we ensure
-		 * that the desired mode is 'wal'. */
-		if (strcasecmp(right, "wal") != 0) {
-			fcntl[0] =
-			    sqlite3_mprintf("only WAL mode is supported");
 			return SQLITE_IOERR;
 		}
 	}
@@ -2076,18 +1827,18 @@ static int vfsDiskFileControlPragma(struct vfsFile *f, char **fcntl)
 
 static int vfsDiskFileControl(sqlite3_file *file, int op, void *arg)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
 	int rv;
-
-	assert(f->type == VFS__DATABASE);
 
 	switch (op) {
 		case SQLITE_FCNTL_PRAGMA:
 			rv = vfsDiskFileControlPragma(f, arg);
 			break;
 		case SQLITE_FCNTL_COMMIT_PHASETWO:
-			rv = vfsFileControlCommitPhaseTwo(f);
-			break;
+			if (f->base.database->wal.n_tx > 0) {
+				vfsAmendWalIndexHeader(f->base.database);
+			}
+			return SQLITE_OK;
 		case SQLITE_FCNTL_PERSIST_WAL:
 			/* This prevents SQLite from deleting the WAL after the
 			 * last connection is closed. */
@@ -2104,44 +1855,34 @@ static int vfsDiskFileControl(sqlite3_file *file, int op, void *arg)
 
 static int vfsDiskFileSectorSize(sqlite3_file *file)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	if (f->db != NULL) {
-		return f->db->pMethods->xSectorSize(f->db);
-	}
-
-	return 0;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xSectorSize(f->underlying);
 }
 
 static int vfsDiskFileDeviceCharacteristics(sqlite3_file *file)
 {
-	struct vfsFile *f = (struct vfsFile *)file;
-	if (f->db != NULL) {
-		return f->db->pMethods->xDeviceCharacteristics(f->db);
-	}
-
-	return 0;
+	struct vfsDiskMainFile *f = (struct vfsDiskMainFile *)file;
+	return f->underlying->pMethods->xDeviceCharacteristics(f->underlying);
 }
 
 static const sqlite3_io_methods vfsDiskFileMethods = {
-	2,
-	vfsDiskFileClose,
-	vfsDiskFileRead,
-	vfsDiskFileWrite,
-	vfsDiskFileTruncate,
-	vfsDiskFileSync,
-	vfsDiskFileSize,
-	vfsDiskFileLock,
-	vfsDiskFileUnlock,
-	vfsNoopCheckReservedLock,
-	vfsDiskFileControl,
-	vfsDiskFileSectorSize,
-	vfsDiskFileDeviceCharacteristics,
-	vfsFileShmMap,
-	vfsFileShmLock,
-	vfsFileShmBarrier,
-	vfsFileShmUnmap,
-	0,
-	0,
+	.iVersion = 2,
+	.xClose = vfsDiskFileClose,
+	.xRead = vfsDiskFileRead,
+	.xWrite = vfsDiskFileWrite,
+	.xTruncate = vfsDiskFileTruncate,
+	.xSync = vfsDiskFileSync,
+	.xFileSize = vfsDiskFileSize,
+	.xLock = vfsDiskFileLock,
+	.xUnlock = vfsDiskFileUnlock,
+	.xCheckReservedLock = vfsNoopCheckReservedLock,
+	.xFileControl = vfsDiskFileControl,
+	.xSectorSize = vfsDiskFileSectorSize,
+	.xDeviceCharacteristics = vfsDiskFileDeviceCharacteristics,
+	.xShmMap = vfsMainFileShmMap,
+	.xShmLock = vfsMainFileShmLock,
+	.xShmBarrier = vfsMainFileShmBarrier,
+	.xShmUnmap = vfsMainFileShmUnmap,
 };
 
 static int vfsOpen(sqlite3_vfs *vfs,
@@ -2150,14 +1891,10 @@ static int vfsOpen(sqlite3_vfs *vfs,
 		   int flags,
 		   int *out_flags)
 {
-	struct vfs *v;
-	struct vfsFile *f;
+	struct vfs *v = vfs->pAppData;
 	struct vfsDatabase *database;
-	enum vfsFileType type;
-	bool exists;
 	int exclusive = flags & SQLITE_OPEN_EXCLUSIVE;
 	int create = flags & SQLITE_OPEN_CREATE;
-	int rc;
 
 	(void)out_flags;
 
@@ -2198,259 +1935,117 @@ static int vfsOpen(sqlite3_vfs *vfs,
 	}
 
 	assert((flags & SQLITE_OPEN_DELETEONCLOSE) == 0);
-	v = (struct vfs *)(vfs->pAppData);
-	f = (struct vfsFile *)file;
 
 	/* This tells SQLite to not call Close() in case we return an error. */
-	f->base.pMethods = 0;
+	file->pMethods = 0;
 
 	/* Search if the database object exists already. */
 	database = vfsDatabaseLookup(v, filename);
-	exists = database != NULL;
 
-	if (flags & SQLITE_OPEN_MAIN_DB) {
-		type = VFS__DATABASE;
-	} else if (flags & SQLITE_OPEN_WAL) {
-		type = VFS__WAL;
-	} else {
+	if ((flags & (SQLITE_OPEN_MAIN_DB | SQLITE_OPEN_WAL)) == 0) {
 		v->error = ENOENT;
 		return SQLITE_CANTOPEN;
 	}
 
 	/* If file exists, and the exclusive flag is on, return an error. */
-	if (exists && exclusive && create && type == VFS__DATABASE) {
+	if (database != NULL && exclusive && create && (flags & SQLITE_OPEN_MAIN_DB)) {
 		v->error = EEXIST;
-		rc = SQLITE_CANTOPEN;
-		goto err;
+		return SQLITE_CANTOPEN;
 	}
 
-	if (!exists) {
-		/* When opening a WAL or journal file we expect the main
+	if (flags & SQLITE_OPEN_WAL) {
+		/* When opening the WAL file we expect the main
 		 * database file to have already been created. */
-		if (type == VFS__WAL) {
-			v->error = ENOENT;
-			rc = SQLITE_CANTOPEN;
-			goto err;
-		}
-
-		assert(type == VFS__DATABASE);
-
-		/* Check the create flag. */
-		if (!create) {
-			v->error = ENOENT;
-			rc = SQLITE_CANTOPEN;
-			goto err;
-		}
-
-		database = vfsCreateDatabase(v, filename);
 		if (database == NULL) {
-			v->error = ENOMEM;
-			rc = SQLITE_CANTOPEN;
-			goto err;
+			v->error = ENOENT;
+			return SQLITE_CANTOPEN;
 		}
-	}
 
-	/* Populate the new file handle. */
-	f->base.pMethods = &vfsFileMethods;
-	f->vfs = v;
-	f->type = type;
-	f->database = database;
+		struct vfsWalFile *walFile = (struct vfsWalFile *)file;
+		*walFile = (struct vfsWalFile){
+			.base = {
+				.pMethods = &vfsWalFileMethods,
+			},
+			.wal = &database->wal,
+		};
 
-	return SQLITE_OK;
-
-err:
-	assert(rc != SQLITE_OK);
-	return rc;
-}
-
-static int vfsDiskOpen(sqlite3_vfs *vfs,
-		       const char *filename,
-		       sqlite3_file *file,
-		       int flags,
-		       int *out_flags)
-{
-	struct vfs *v;
-	struct vfsFile *f;
-	struct vfsDatabase *database;
-	enum vfsFileType type;
-	bool exists;
-	int exclusive = flags & SQLITE_OPEN_EXCLUSIVE;
-	int create = flags & SQLITE_OPEN_CREATE;
-	int rc;
-	tracef("filename:%s", filename);
-
-	(void)out_flags;
-
-	assert(vfs != NULL);
-	assert(vfs->pAppData != NULL);
-	assert(file != NULL);
-
-	/* From sqlite3.h.in:
-	 *
-	 *   The SQLITE_OPEN_EXCLUSIVE flag is always used in conjunction with
-	 *   the SQLITE_OPEN_CREATE flag, which are both directly analogous to
-	 *   the O_EXCL and O_CREAT flags of the POSIX open() API.  The
-	 *   SQLITE_OPEN_EXCLUSIVE flag, when paired with the
-	 *   SQLITE_OPEN_CREATE, is used to indicate that file should always be
-	 *   created, and that it is an error if it already exists.  It is not
-	 *   used to indicate the file should be opened for exclusive access.
-	 */
-	assert(!exclusive || create);
-
-	v = (struct vfs *)(vfs->pAppData);
-
-	/* From SQLite documentation:
-	 *
-	 * If the zFilename parameter to xOpen is a NULL pointer then xOpen
-	 * must invent its own temporary name for the file. Whenever the
-	 * xFilename parameter is NULL it will also be the case that the
-	 * flags parameter will include SQLITE_OPEN_DELETEONCLOSE.
-	 */
-	if (filename == NULL) {
-		assert(flags & SQLITE_OPEN_DELETEONCLOSE);
-
-		/* Open an actual temporary file. */
-		return v->base_vfs->xOpen(v->base_vfs, filename, file, flags, out_flags);
-	}
-
-	if (flags & SQLITE_OPEN_MAIN_JOURNAL) {
-		/* Journal file is just a noop file as only WAL mode is supported */
-		file->pMethods = &vfsNoopMethods;
 		return SQLITE_OK;
 	}
 
-	assert((flags & SQLITE_OPEN_DELETEONCLOSE) == 0);
-	f = (struct vfsFile *)file;
+	assert(flags & SQLITE_OPEN_MAIN_DB);
 
-	/* This tells SQLite to not call Close() in case we return an error. */
-	f->base.pMethods = 0;
-	f->db = NULL;
-
-	/* Search if the database object exists already. */
-	database = vfsDatabaseLookup(v, filename);
-	exists = database != NULL;
-
-	if (flags & SQLITE_OPEN_MAIN_DB) {
-		type = VFS__DATABASE;
-	} else if (flags & SQLITE_OPEN_WAL) {
-		type = VFS__WAL;
-	} else {
-		v->error = ENOENT;
-		return SQLITE_CANTOPEN;
-	}
-
-	/* If file exists, and the exclusive flag is on, return an error. */
-	if (exists && exclusive && create && type == VFS__DATABASE) {
-		v->error = EEXIST;
-		rc = SQLITE_CANTOPEN;
-		goto err;
-	}
-
-	if (!exists) {
-		/* When opening a WAL or journal file we expect the main
-		 * database file to have already been created. */
-		if (type == VFS__WAL) {
-			v->error = ENOENT;
-			rc = SQLITE_CANTOPEN;
-			goto err;
-		}
-
-		assert(type == VFS__DATABASE);
-
-		/* Check the create flag. */
+	if (database == NULL) {
 		if (!create) {
 			v->error = ENOENT;
-			rc = SQLITE_CANTOPEN;
-			goto err;
+			return SQLITE_CANTOPEN;
 		}
 
 		database = vfsCreateDatabase(v, filename);
 		if (database == NULL) {
 			v->error = ENOMEM;
-			rc = SQLITE_CANTOPEN;
-			goto err;
+			return SQLITE_CANTOPEN;
 		}
 	}
 
-	if (type == VFS__DATABASE && v->disk) {
-		/* Open an actual database file. */
-		vfs = v->base_vfs;
-
-		f->db = sqlite3_malloc(vfs->szOsFile);
-		if (f->db == NULL) {
+	if (v->disk) {
+		sqlite3_file *underlying = sqlite3_malloc(vfs->szOsFile);
+		if (underlying == NULL) {
 			return SQLITE_NOMEM;
 		}
 
-		rc = vfs->xOpen(vfs, filename, f->db, flags, out_flags);
+		int rc = v->base_vfs->xOpen(v->base_vfs, filename, underlying, flags, out_flags);
 		if (rc != SQLITE_OK) {
-			sqlite3_free(f->db);
-			f->db = NULL;
+			sqlite3_free(underlying);
 			return rc;
 		}
+		*(struct vfsDiskMainFile *)file = (struct vfsDiskMainFile){
+			.base = {
+				.base = {
+					.pMethods = &vfsDiskFileMethods,
+				},
+				.vfs = v,
+				.database = database,
+			},
+			.underlying = underlying,
+		};
+	} else {
+		*(struct vfsMainFile *)file = (struct vfsMainFile){
+			.base = {
+				.pMethods = &vfsFileMethods,
+			},
+			.vfs = v,
+			.database = database,
+		};
 	}
-
-	/* Populate the new file handle. */
-	f->base.pMethods = &vfsDiskFileMethods;
-	f->vfs = v;
-	f->type = type;
-	f->database = database;
-
 	return SQLITE_OK;
-
-err:
-	assert(rc != SQLITE_OK);
-	return rc;
 }
 
 static int vfsDelete(sqlite3_vfs *vfs, const char *filename, int dir_sync)
 {
-	struct vfs *v;
-
 	(void)dir_sync;
-
-	assert(vfs != NULL);
-	assert(vfs->pAppData != NULL);
+	struct vfs *v = vfs->pAppData;
 
 	if (vfsFilenameEndsWith(filename, "-journal")) {
 		return SQLITE_OK;
 	}
+
 	if (vfsFilenameEndsWith(filename, "-wal")) {
 		return SQLITE_OK;
 	}
 
-	v = (struct vfs *)(vfs->pAppData);
-
-	return vfsDeleteDatabase(v, filename);
-}
-
-static int vfsDiskDelete(sqlite3_vfs *vfs, const char *filename, int dir_sync)
-{
-	int rv;
-	struct vfs *v;
-
-	(void)dir_sync;
-
-	assert(vfs != NULL);
-	assert(vfs->pAppData != NULL);
-
-	if (vfsFilenameEndsWith(filename, "-journal")) {
-		return SQLITE_OK;
-	}
-	if (vfsFilenameEndsWith(filename, "-wal")) {
-		return SQLITE_OK;
-	}
-
-	v = (struct vfs *)(vfs->pAppData);
-	rv = vfsDeleteDatabase(v, filename);
-	if (rv != 0) {
+	int rv = vfsDeleteDatabase(v, filename);
+	if (rv != SQLITE_OK) {
 		return rv;
 	}
 
-	if (!v->disk) {
-		return rv;
+	if (v->disk) {
+		rv = v->base_vfs->xDelete(v->base_vfs, filename, dir_sync);
+		if (rv != SQLITE_OK) {
+			return rv;
+		}
 	}
 
-	return v->base_vfs->xDelete(v->base_vfs, filename, dir_sync);
+	return SQLITE_OK;
 }
 
 static int vfsAccess(sqlite3_vfs *vfs,
@@ -2473,41 +2068,18 @@ static int vfsAccess(sqlite3_vfs *vfs,
 	database = vfsDatabaseLookup(v, filename);
 	if (database == NULL) {
 		*result = 0;
+	} else if (v->disk) {
+		if (vfsFilenameEndsWith(filename, "-journal")) {
+			*result = 1;
+		} else if (vfsFilenameEndsWith(filename, "-wal")) {
+			*result = 1;
+		} else {
+			/* dqlite database object exists, now check if the regular
+			* SQLite file exists. */
+			return v->base_vfs->xAccess(vfs, filename, flags, result);
+		}
 	} else {
 		*result = 1;
-	}
-
-	return SQLITE_OK;
-}
-
-static int vfsDiskAccess(sqlite3_vfs *vfs,
-			 const char *filename,
-			 int flags,
-			 int *result)
-{
-	struct vfs *v;
-	struct vfsDatabase *database;
-
-	(void)flags;
-
-	assert(vfs != NULL);
-	assert(vfs->pAppData != NULL);
-
-	v = (struct vfs *)(vfs->pAppData);
-
-	/* If the database object exists, we consider all associated files as
-	 * existing and accessible. */
-	database = vfsDatabaseLookup(v, filename);
-	if (database == NULL) {
-		*result = 0;
-	} else if (vfsFilenameEndsWith(filename, "-journal")) {
-		*result = 1;
-	} else if (vfsFilenameEndsWith(filename, "-wal")) {
-		*result = 1;
-	} else {
-		/* dqlite database object exists, now check if the regular
-		 * SQLite file exists. */
-		return v->base_vfs->xAccess(vfs, filename, flags, result);
 	}
 
 	return SQLITE_OK;
@@ -2628,7 +2200,7 @@ int VfsInit(struct sqlite3_vfs *vfs, const char *name)
 		return DQLITE_NOMEM;
 	}
 	vfs->pAppData = v;
-	vfs->szOsFile = sizeof(struct vfsFile);
+	vfs->szOsFile = MAX(sizeof(struct vfsMainFile), sizeof(struct vfsWalFile));
 	if (vfs->szOsFile < v->base_vfs->szOsFile) {
 		vfs->szOsFile = v->base_vfs->szOsFile;
 	}
@@ -3074,7 +2646,7 @@ int VfsSnapshot(sqlite3_vfs *vfs, const char *filename, void **data, size_t *n)
 
 	wal = &database->wal;
 
-	*n = vfsDatabaseFileSize(database) + vfsWalFileSize(wal);
+	*n = (size_t)(vfsDatabaseFileSize(database) + vfsWalSize(wal));
 	/* TODO: we should fix the tests and use sqlite3_malloc instead. */
 	*data = raft_malloc(*n);
 	if (*data == NULL) {
@@ -3231,13 +2803,14 @@ static int vfsWalRestore(struct vfsWal *w,
 	unsigned n_frames;
 	unsigned i;
 	size_t offset;
-	int rv;
 
 	if (n == 0) {
 		return 0;
 	}
 
 	assert(w->n_tx == 0);
+
+	vfsWalTruncate(w);
 
 	assert(n > VFS__WAL_HEADER_SIZE);
 	assert(((n - (size_t)VFS__WAL_HEADER_SIZE) %
@@ -3246,11 +2819,12 @@ static int vfsWalRestore(struct vfsWal *w,
 	n_frames = (unsigned)((n - (size_t)VFS__WAL_HEADER_SIZE) /
 			      ((size_t)vfsFrameSize(page_size)));
 
-	frames = sqlite3_malloc64(sizeof *frames * n_frames);
+	frames = sqlite3_malloc64(sizeof(*frames) * n_frames);
 	if (frames == NULL) {
 		goto oom;
 	}
 
+	memcpy(w->hdr, data, VFS__WAL_HEADER_SIZE);
 	for (i = 0; i < n_frames; i++) {
 		struct vfsFrame *frame = vfsFrameCreate(page_size);
 		const uint8_t *p;
@@ -3270,11 +2844,6 @@ static int vfsWalRestore(struct vfsWal *w,
 		memcpy(frame->header, p, VFS__FRAME_HEADER_SIZE);
 		memcpy(frame->page, p + VFS__FRAME_HEADER_SIZE, page_size);
 	}
-
-	memcpy(w->hdr, data, VFS__WAL_HEADER_SIZE);
-
-	rv = vfsWalTruncate(w, 0);
-	assert(rv == 0);
 
 	w->frames = frames;
 	w->n_frames = n_frames;
@@ -3306,13 +2875,6 @@ int VfsRestore(sqlite3_vfs *vfs,
 
 	wal = &database->wal;
 
-	/* Truncate any existing content. */
-	rv = vfsWalTruncate(wal, 0);
-	if (rv != 0) {
-		tracef("wal truncate failed %d", rv);
-		return rv;
-	}
-
 	/* Restore the content of the main database and of the WAL. */
 	rv = vfsDatabaseRestore(database, data, n);
 	if (rv != 0) {
@@ -3341,20 +2903,6 @@ int VfsEnableDisk(struct sqlite3_vfs *vfs)
 	struct vfs *v = vfs->pAppData;
 	v->disk = true;
 
-	vfs->xOpen = vfsDiskOpen;
-	vfs->xDelete = vfsDiskDelete;
-	vfs->xAccess = vfsDiskAccess;
-	/* TODO check if below functions need alteration for on-disk case. */
-	vfs->xFullPathname = vfsFullPathname;
-	vfs->xDlOpen = vfsDlOpen;
-	vfs->xDlError = vfsDlError;
-	vfs->xDlSym = vfsDlSym;
-	vfs->xDlClose = vfsDlClose;
-	vfs->xRandomness = vfsRandomness;
-	vfs->xSleep = vfsSleep;
-	vfs->xCurrentTime = vfsCurrentTime;
-	vfs->xGetLastError = vfsGetLastError;
-	vfs->xCurrentTimeInt64 = vfsCurrentTimeInt64;
 	return 0;
 }
 
@@ -3379,7 +2927,7 @@ int VfsDiskSnapshotWal(sqlite3_vfs *vfs,
 
 	/* Copy WAL to last buffer. */
 	wal = &database->wal;
-	buf->len = vfsWalFileSize(wal);
+	buf->len = (size_t)vfsWalSize(wal);
 	buf->base = sqlite3_malloc64(buf->len);
 	/* WAL can have 0 length! */
 	if (buf->base == NULL && buf->len != 0) {
@@ -3539,13 +3087,6 @@ int VfsDiskRestore(sqlite3_vfs *vfs,
 
 	wal = &database->wal;
 
-	/* Truncate any existing content. */
-	rv = vfsWalTruncate(wal, 0);
-	if (rv != 0) {
-		tracef("wal truncate failed %d", rv);
-		return rv;
-	}
-
 	/* Restore the content of the main database and of the WAL. */
 	rv = vfsDiskDatabaseRestore(database, path, data, main_size);
 	if (rv != 0) {
@@ -3579,7 +3120,7 @@ uint64_t VfsDatabaseSize(sqlite3_vfs *vfs,
 	assert(database != NULL);
 
 	wal = &database->wal;
-	new_wal_size = (uint64_t)vfsWalFileSize(wal);
+	new_wal_size = (uint64_t)vfsWalSize(wal);
 	if (new_wal_size == 0) {
 		new_wal_size += (uint64_t)VFS__WAL_HEADER_SIZE;
 	}

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -5,14 +5,12 @@
 
 #include "../../include/dqlite.h"
 
-#include "../lib/config.h"
 #include "../lib/fs.h"
 #include "../lib/heap.h"
 #include "../lib/runner.h"
 #include "../lib/sqlite.h"
 
 #include "../../src/format.h"
-#include "../../src/raft.h"
 #include "../../src/vfs.h"
 
 static char *bools[] = {"0", "1", NULL};
@@ -1353,46 +1351,6 @@ TEST(VfsShmLock, release, setUp, tearDown, 0, vfs_params)
 	munit_assert_int(rc, ==, 0);
 
 	free(file);
-
-	return MUNIT_OK;
-}
-
-/******************************************************************************
- *
- * xFileControl
- *
- ******************************************************************************/
-
-SUITE(VfsFileControl)
-
-/* Trying to set the journal mode to anything other than "wal" produces an
- * error. */
-TEST(VfsFileControl, journal, setUp, tearDown, 0, vfs_params)
-{
-	struct fixture *f = data;
-	sqlite3_file *file = __file_create_main_db(f);
-	char *fnctl[] = {
-	    "",
-	    "journal_mode",
-	    "memory",
-	    "",
-	};
-	int rc;
-
-	(void)params;
-	(void)data;
-
-	/* Setting the page size a first time returns NOTFOUND, which is what
-	 * SQLite effectively expects. */
-	rc = file->pMethods->xFileControl(file, SQLITE_FCNTL_PRAGMA, fnctl);
-	munit_assert_int(rc, ==, SQLITE_IOERR);
-
-	rc = file->pMethods->xClose(file);
-	munit_assert_int(rc, ==, 0);
-	free(file);
-
-	/* Free allocated memory from call to sqlite3_mprintf */
-	sqlite3_free(fnctl[0]);
 
 	return MUNIT_OK;
 }


### PR DESCRIPTION
This PR further separates the behaviour of the many different files SQLite uses. In detail, it splits the behaviour in 3 different structs:

 - `vfsWalFile` which is only related to `WAL` operation. This file is always in memory for dqlite
 - `vfsMainFile` the real database file. This file is always in memory for dqlite. This file also indirectly manages the shared memory (`-shm` file).
 - `vfsDiskMainFile` again, the real database file, but in `disk` mode. This file is on disk.

