### PR TITLE
fix: read main file when out of range

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1178,28 +1178,15 @@ static int vfsWalRead(struct vfsWal *w,
 	}
 
 	if (index == 0) {
-		/* From SQLite docs:
-		*
-		*   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
-		*   in the unread portions of the buffer with zeros.  A VFS that
-		*   fails to zero-fill short reads might seem to work.  However,
-		*   failure to zero-fill short reads will eventually lead to
-		*   database corruption.
-		*/
+		// This is an attempt to read a page that was
+		// never written.
 		memset(buf, 0, (size_t)amount);
 		return SQLITE_IOERR_SHORT_READ;
 	}
 
 	frame = vfsWalFrameLookup(w, index);
 	if (frame == NULL) {
-		/* From SQLite docs:
-		*
-		*   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
-		*   in the unread portions of the buffer with zeros.  A VFS that
-		*   fails to zero-fill short reads might seem to work.  However,
-		*   failure to zero-fill short reads will eventually lead to
-		*   database corruption.
-		*/
+		// Again, the requested page doesn't exist.
 		memset(buf, 0, (size_t)amount);
 		return SQLITE_IOERR_SHORT_READ;
 	}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1063,6 +1063,14 @@ static int vfsDatabaseRead(struct vfsDatabase *d,
 	void *page;
 
 	if (d->n_pages == 0) {
+		/* From SQLite docs:
+		*
+		*   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
+		*   in the unread portions of the buffer with zeros.  A VFS that
+		*   fails to zero-fill short reads might seem to work.  However,
+		*   failure to zero-fill short reads will eventually lead to
+		*   database corruption.
+		*/
 		memset(buf, 0, (size_t)amount);
 		return SQLITE_IOERR_SHORT_READ;
 	}
@@ -1094,6 +1102,14 @@ static int vfsDatabaseRead(struct vfsDatabase *d,
 	page = vfsDatabasePageLookup(d, pgno);
 
 	if (page == NULL) {
+		/* From SQLite docs:
+		*
+		*   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
+		*   in the unread portions of the buffer with zeros.  A VFS that
+		*   fails to zero-fill short reads might seem to work.  However,
+		*   failure to zero-fill short reads will eventually lead to
+		*   database corruption.
+		*/
 		memset(buf, 0, (size_t)amount);
 		return SQLITE_IOERR_SHORT_READ;
 	}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1063,6 +1063,7 @@ static int vfsDatabaseRead(struct vfsDatabase *d,
 	void *page;
 
 	if (d->n_pages == 0) {
+		memset(buf, 0, (size_t)amount);
 		return SQLITE_IOERR_SHORT_READ;
 	}
 
@@ -1091,6 +1092,11 @@ static int vfsDatabaseRead(struct vfsDatabase *d,
 	assert(pgno > 0);
 
 	page = vfsDatabasePageLookup(d, pgno);
+
+	if (page == NULL) {
+		memset(buf, 0, (size_t)amount);
+		return SQLITE_IOERR_SHORT_READ;
+	}
 
 	if (pgno == 1) {
 		/* Read the desired part of page 1. */

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1178,15 +1178,28 @@ static int vfsWalRead(struct vfsWal *w,
 	}
 
 	if (index == 0) {
-		// This is an attempt to read a page that was
-		// never written.
+		/* From SQLite docs:
+		*
+		*   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
+		*   in the unread portions of the buffer with zeros.  A VFS that
+		*   fails to zero-fill short reads might seem to work.  However,
+		*   failure to zero-fill short reads will eventually lead to
+		*   database corruption.
+		*/
 		memset(buf, 0, (size_t)amount);
 		return SQLITE_IOERR_SHORT_READ;
 	}
 
 	frame = vfsWalFrameLookup(w, index);
 	if (frame == NULL) {
-		// Again, the requested page doesn't exist.
+		/* From SQLite docs:
+		*
+		*   If xRead() returns SQLITE_IOERR_SHORT_READ it must also fill
+		*   in the unread portions of the buffer with zeros.  A VFS that
+		*   fails to zero-fill short reads might seem to work.  However,
+		*   failure to zero-fill short reads will eventually lead to
+		*   database corruption.
+		*/
 		memset(buf, 0, (size_t)amount);
 		return SQLITE_IOERR_SHORT_READ;
 	}

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -2414,7 +2414,7 @@ TEST_CASE(exec_sql, autovacuum_full, NULL)
 		" --   database corruption.                                         "
 		"\n)"
 	);
-	EXEC_SQL("DROP INDEX IF EXISTS non_existing_index");
+	EXEC_SQL("DROP TABLE IF EXISTS non_existing_table");
 
 	return MUNIT_OK;
 }

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -2401,7 +2401,7 @@ TEST_CASE(exec_sql, autovacuum_full, NULL)
 		" id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT                     "
 		" -- When the definition of a table is big                          "
 		" -- enough to create an 'overflow page' and                        "
-		" -- auto_vacuum is enabled, the DROP TABLE                         "
+		" -- auto_vacuum is enabled, the autovacuum                         "
 		" -- logic can try to access a page number which                    "
 		" -- is above the size of the database. In this                     "
 		" -- case, the VFS is required to return SQLITE_IOERR_SHORT_READ    "
@@ -2414,7 +2414,6 @@ TEST_CASE(exec_sql, autovacuum_full, NULL)
 		" --   database corruption.                                         "
 		"\n)"
 	);
-	EXEC_SQL("DROP TABLE IF EXISTS non_existing_table");
 
 	return MUNIT_OK;
 }


### PR DESCRIPTION
This PR fixes the reading of the main file in the case of an "over the limit" read, which might happen when enabling autovacuum.