### PR TITLE
 perf: improve barrier implementation 

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -220,8 +220,7 @@ static int apply_checkpoint(struct fsm *f, const struct command_checkpoint *c)
 }
 
 static int fsm__apply(struct raft_fsm *fsm,
-		      const struct raft_buffer *buf,
-		      void **result)
+		      const struct raft_buffer *buf)
 {
 	tracef("fsm apply");
 	struct fsm *f = fsm->data;
@@ -254,7 +253,6 @@ static int fsm__apply(struct raft_fsm *fsm,
 
 	raft_free(command);
 err:
-	*result = NULL;
 	return rc;
 }
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -940,8 +940,10 @@ static int handle_add(struct gateway *g, struct handle *req)
 	if (r == NULL) {
 		return DQLITE_NOMEM;
 	}
-	r->gateway = g;
-	r->req.data = r;
+	*r = (struct change) {
+		.gateway = g,
+		.req = { .data = r },
+	};
 	g->req = req;
 
 	rv = raft_add(g->raft, &r->req, request.id, request.address,
@@ -983,8 +985,10 @@ static int handle_promote_or_assign(struct gateway *g, struct handle *req)
 		tracef("malloc failed");
 		return DQLITE_NOMEM;
 	}
-	r->gateway = g;
-	r->req.data = r;
+	*r = (struct change) {
+		.gateway = g,
+		.req = { .data = r },
+	};
 	g->req = req;
 
 	rv = raft_assign(g->raft, &r->req, request.id,
@@ -1015,8 +1019,10 @@ static int handle_remove(struct gateway *g, struct handle *req)
 		tracef("malloc failed");
 		return DQLITE_NOMEM;
 	}
-	r->gateway = g;
-	r->req.data = r;
+	*r = (struct change) {
+		.gateway = g,
+		.req = { .data = r },
+	};
 	g->req = req;
 
 	rv = raft_remove(g->raft, &r->req, request.id, raftChangeCb);

--- a/src/raft.h
+++ b/src/raft.h
@@ -974,6 +974,7 @@ struct raft
 			    round_index; /* Target of the current round. */
 			raft_time round_start; /* Start of current round. */
 			queue requests; /* Outstanding client requests. */
+			queue barriers; /* Outstanding barrier requests. */
 			uint32_t
 			    voter_contacts; /* Current number of voting nodes we
 					       are in contact with */
@@ -1287,10 +1288,6 @@ struct raft_barrier
 {
 	RAFT__REQUEST;
 	raft_barrier_cb cb;
-
-	/* Singly linked list for bundled requests targetting the same raft
-	 * index. */
-	struct raft_barrier *next;
 };
 
 /**

--- a/src/raft.h
+++ b/src/raft.h
@@ -738,8 +738,7 @@ struct raft_fsm
 	int version; /* 1, 2 or 3 */
 	void *data;
 	int (*apply)(struct raft_fsm *fsm,
-		     const struct raft_buffer *buf,
-		     void **result);
+		     const struct raft_buffer *buf);
 	int (*snapshot)(struct raft_fsm *fsm,
 			struct raft_buffer *bufs[],
 			unsigned *n_bufs);
@@ -1243,7 +1242,7 @@ RAFT_API int raft_voter_contacts(struct raft *r);
  * the FSM when a quorum is reached.
  */
 struct raft_apply;
-typedef void (*raft_apply_cb)(struct raft_apply *req, int status, void *result);
+typedef void (*raft_apply_cb)(struct raft_apply *req, int status);
 struct raft_apply
 {
 	RAFT__REQUEST;
@@ -1440,8 +1439,6 @@ DQLITE_VISIBLE_TO_TESTS void raft_heap_set_default(void);
  * the backing memory, is undefined.
  */
 DQLITE_VISIBLE_TO_TESTS const struct raft_heap *raft_heap_get(void);
-
-#undef RAFT__REQUEST
 
 struct raft_uv_transport;
 

--- a/src/raft/convert.c
+++ b/src/raft/convert.c
@@ -66,7 +66,7 @@ static void convertFailApply(struct raft_apply *req)
 {
 	PRE(req != NULL);
 	if (req->cb != NULL) {
-		req->cb(req, RAFT_LEADERSHIPLOST, NULL);
+		req->cb(req, RAFT_LEADERSHIPLOST);
 	}
 }
 

--- a/src/raft/request.h
+++ b/src/raft/request.h
@@ -43,16 +43,7 @@ static inline bool request_invariant(const struct sm *sm, int prev)
 
 /* Abstract request type */
 struct request {
-	/* Must be kept in sync with RAFT__REQUEST in raft.h */
-	void *data;
-	int type;
-	raft_index index;
-	queue queue;
-	struct sm sm;
-	uint8_t req_id[16];
-	uint8_t client_id[16];
-	uint8_t unique_id[16];
-	uint64_t reserved[4];
+	RAFT__REQUEST;
 };
 
 #endif /* REQUEST_H_ */

--- a/src/roles.c
+++ b/src/roles.c
@@ -198,7 +198,10 @@ static void startChange(struct dqlite_node *d)
 	if (change == NULL) {
 		return;
 	}
-	change->data = d;
+	*change = (struct raft_change) {
+		.data = d,
+	};
+
 	/* TODO request ID */
 	rv = raft_assign(&d->raft, change, id, translateDqliteRole(role),
 			 changeCb);

--- a/test/integration/test_fsm.c
+++ b/test/integration/test_fsm.c
@@ -776,7 +776,6 @@ TEST(fsm, applyFail, setUp, tearDown, 0, NULL)
 	struct raft_buffer buf;
 	struct fixture *f = data;
 	struct raft_fsm *fsm = &f->servers[0].dqlite->raft_fsm;
-	void *result = (void *)(uintptr_t)0xDEADBEEF;
 
 	/* Create a frames command without data. */
 	c = (struct command_frames) {
@@ -790,9 +789,8 @@ TEST(fsm, applyFail, setUp, tearDown, 0, NULL)
 	rv = command__encode(COMMAND_FRAMES, &c, &buf);
 
 	/* Apply the command and expect it to fail. */
-	rv = fsm->apply(fsm, &buf, &result);
+	rv = fsm->apply(fsm, &buf);
 	munit_assert_int(rv, !=, 0);
-	munit_assert_ptr_null(result);
 
 	raft_free(buf.base);
 	return MUNIT_OK;
@@ -805,7 +803,6 @@ TEST(fsm, applyUnknownTypeFail, setUp, tearDown, 0, NULL)
 	struct raft_buffer buf;
 	struct fixture *f = data;
 	struct raft_fsm *fsm = &f->servers[0].dqlite->raft_fsm;
-	void *result = (void *)(uintptr_t)0xDEADBEEF;
 
 	/* Create a frames command without data. */
 	c = (struct command_frames) {
@@ -822,9 +819,8 @@ TEST(fsm, applyUnknownTypeFail, setUp, tearDown, 0, NULL)
 	((uint8_t *)(buf.base))[1] = COMMAND_CHECKPOINT + 8;
 
 	/* Apply the command and expect it to fail. */
-	rv = fsm->apply(fsm, &buf, &result);
+	rv = fsm->apply(fsm, &buf);
 	munit_assert_int(rv, ==, DQLITE_PROTO);
-	munit_assert_ptr_null(result);
 
 	raft_free(buf.base);
 	return MUNIT_OK;

--- a/test/raft/fuzzy/test_liveness.c
+++ b/test/raft/fuzzy/test_liveness.c
@@ -120,10 +120,9 @@ static void tear_down(void *data)
 
 SUITE(liveness)
 
-static void apply_cb(struct raft_apply *req, int status, void *result)
+static void apply_cb(struct raft_apply *req, int status)
 {
     (void)status;
-    (void)result;
     free(req);
 }
 

--- a/test/raft/fuzzy/test_replication.c
+++ b/test/raft/fuzzy/test_replication.c
@@ -92,10 +92,9 @@ TEST(replication, availability, setup, tear_down, 0, _params)
     return MUNIT_OK;
 }
 
-static void apply_cb(struct raft_apply *req, int status, void *result)
+static void apply_cb(struct raft_apply *req, int status)
 {
     (void)status;
-    (void)result;
     free(req);
 }
 

--- a/test/raft/integration/test_apply.c
+++ b/test/raft/integration/test_apply.c
@@ -43,10 +43,9 @@ struct result
     struct raft *raft;
 };
 
-static void applyCbAssertResult(struct raft_apply *req, int status, void *_)
+static void applyCbAssertResult(struct raft_apply *req, int status)
 {
     struct result *result = req->data;
-    (void)_;
     munit_assert_int(status, ==, result->status);
     if (status == 0) {
         munit_assert_ulong(result->prev_applied, <,

--- a/test/raft/integration/test_replication.c
+++ b/test/raft/integration/test_replication.c
@@ -1072,13 +1072,10 @@ TEST(replication, resultRetry, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-static void applyAssertStatusCb(struct raft_apply *req,
-                                int status,
-                                void *result)
+static void applyAssertStatusCb(struct raft_apply *req, int status)
 {
-    (void)result;
-    int status_expected = (int)(intptr_t)(req->data);
-    munit_assert_int(status_expected, ==, status);
+	int status_expected = (int)(intptr_t)(req->data);
+	munit_assert_int(status_expected, ==, status);
 }
 
 /* When the leader fails to write some new entries to disk, it steps down. */

--- a/test/raft/lib/fsm.c
+++ b/test/raft/lib/fsm.c
@@ -16,8 +16,7 @@ struct fsm
 enum { SET_X = 1, SET_Y, ADD_X, ADD_Y };
 
 static int fsmApply(struct raft_fsm *fsm,
-                    const struct raft_buffer *buf,
-                    void **result)
+                    const struct raft_buffer *buf)
 {
     struct fsm *f = fsm->data;
     const void *cursor = buf->base;
@@ -47,8 +46,6 @@ static int fsmApply(struct raft_fsm *fsm,
         default:
             return -1;
     }
-
-    *result = NULL;
 
     return 0;
 }


### PR DESCRIPTION
This is another PR that aims at reducing the footprint of creating a barrier and in particular aims at reducing the write amplification (and its dependency on an fsync and a quorum) for writes *and* reads.