### PR TITLE
refactor: remove useless undef

### DIFF
--- a/src/raft/client.c
+++ b/src/raft/client.c
@@ -492,4 +492,3 @@ err:
 	return rv;
 }
 
-#undef tracef

--- a/src/raft/configuration.c
+++ b/src/raft/configuration.c
@@ -398,4 +398,3 @@ void configurationTrace(const struct raft *r,
 	}
 	tracef("=== CONFIG END ===");
 }
-#undef tracef

--- a/src/raft/convert.c
+++ b/src/raft/convert.c
@@ -275,4 +275,3 @@ void convertToUnavailable(struct raft *r)
 	convertSetState(r, RAFT_UNAVAILABLE);
 }
 
-#undef tracef

--- a/src/raft/election.c
+++ b/src/raft/election.c
@@ -324,4 +324,3 @@ bool electionTally(struct raft *r, size_t voter_index)
 	return votes >= half + 1;
 }
 
-#undef tracef

--- a/src/raft/progress.c
+++ b/src/raft/progress.c
@@ -322,4 +322,3 @@ bool progressSnapshotDone(struct raft *r, const unsigned i)
 	return p->match_index >= p->snapshot_index;
 }
 
-#undef tracef

--- a/src/raft/recv.c
+++ b/src/raft/recv.c
@@ -222,4 +222,3 @@ int recvUpdateLeader(struct raft *r, const raft_id id, const char *address)
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/recv_append_entries.c
+++ b/src/raft/recv_append_entries.c
@@ -164,4 +164,3 @@ reply:
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/recv_append_entries_result.c
+++ b/src/raft/recv_append_entries_result.c
@@ -72,4 +72,3 @@ int recvAppendEntriesResult(struct raft *r,
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/recv_install_snapshot.c
+++ b/src/raft/recv_install_snapshot.c
@@ -1072,4 +1072,3 @@ reply:
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/recv_request_vote.c
+++ b/src/raft/recv_request_vote.c
@@ -147,4 +147,3 @@ reply:
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/recv_request_vote_result.c
+++ b/src/raft/recv_request_vote_result.c
@@ -151,4 +151,3 @@ int recvRequestVoteResult(struct raft *r,
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/recv_timeout_now.c
+++ b/src/raft/recv_timeout_now.c
@@ -78,4 +78,3 @@ int recvTimeoutNow(struct raft *r,
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/replication.c
+++ b/src/raft/replication.c
@@ -1989,4 +1989,3 @@ inline bool replicationInstallSnapshotBusy(struct raft *r)
 	return r->last_stored == 0 && r->snapshot.put.data != NULL;
 }
 
-#undef tracef

--- a/src/raft/snapshot.c
+++ b/src/raft/snapshot.c
@@ -110,4 +110,3 @@ int snapshotCopy(const struct raft_snapshot *src, struct raft_snapshot *dst)
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/start.c
+++ b/src/raft/start.c
@@ -229,4 +229,3 @@ int raft_start(struct raft *r)
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/tick.c
+++ b/src/raft/tick.c
@@ -256,4 +256,3 @@ void tickCb(struct raft_io *io)
 	}
 }
 
-#undef tracef

--- a/src/raft/uv.c
+++ b/src/raft/uv.c
@@ -826,4 +826,3 @@ void raft_uv_set_auto_recovery(struct raft_io *io, bool flag)
 	uv->auto_recovery = flag;
 }
 
-#undef tracef

--- a/src/raft/uv_finalize.c
+++ b/src/raft/uv_finalize.c
@@ -173,4 +173,3 @@ int UvFinalize(struct uv *uv,
 	return 0;
 }
 
-#undef tracef

--- a/src/raft/uv_list.c
+++ b/src/raft/uv_list.c
@@ -114,4 +114,3 @@ error:
 	return rv;
 }
 
-#undef tracef

--- a/src/raft/uv_prepare.c
+++ b/src/raft/uv_prepare.c
@@ -336,4 +336,3 @@ void UvPrepareClose(struct uv *uv)
 	}
 }
 
-#undef tracef

--- a/src/raft/uv_recv.c
+++ b/src/raft/uv_recv.c
@@ -420,4 +420,3 @@ void UvRecvClose(struct uv *uv)
 	}
 }
 
-#undef tracef

--- a/src/raft/uv_segment.c
+++ b/src/raft/uv_segment.c
@@ -1160,4 +1160,3 @@ out:
 	return rv;
 }
 
-#undef tracef

--- a/src/raft/uv_send.c
+++ b/src/raft/uv_send.c
@@ -516,4 +516,3 @@ void UvSendClose(struct uv *uv)
 	}
 }
 
-#undef tracef

--- a/src/raft/uv_snapshot.c
+++ b/src/raft/uv_snapshot.c
@@ -805,4 +805,3 @@ err:
 	return rv;
 }
 
-#undef tracef

--- a/src/raft/uv_truncate.c
+++ b/src/raft/uv_truncate.c
@@ -257,4 +257,3 @@ err:
 	return rv;
 }
 
-#undef tracef

--- a/src/raft/uv_work.c
+++ b/src/raft/uv_work.c
@@ -75,4 +75,3 @@ err:
 	return rv;
 }
 
-#undef tracef


### PR DESCRIPTION
This PR removes a useless `#undef` at the end of every raft `.c` file.