### PR TITLE
test: fix wait times for gateway tests

### DIFF
--- a/src/raft.h
+++ b/src/raft.h
@@ -2114,6 +2114,10 @@ RAFT_API void raft_fixture_set_send_latency(struct raft_fixture *f,
 					    unsigned j,
 					    unsigned msecs);
 
+RAFT_API void raft_fixture_set_work_duration(struct raft_fixture *f,
+					     unsigned i,
+					     unsigned msecs);
+
 /**
  * Set the persisted term of the @i'th server.
  */

--- a/src/raft/fixture.c
+++ b/src/raft/fixture.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -2045,6 +2046,14 @@ void raft_fixture_set_term(struct raft_fixture *f, unsigned i, raft_term term)
 {
 	struct io *io = f->servers[i]->io.impl;
 	io->term = term;
+}
+
+void raft_fixture_set_work_duration(struct raft_fixture *f,
+				    unsigned i,
+				    unsigned msecs)
+{
+	struct io *io = f->servers[i]->io.impl;
+	io->work_duration = msecs;
 }
 
 void raft_fixture_set_snapshot(struct raft_fixture *f,

--- a/test/unit/test_concurrency.c
+++ b/test/unit/test_concurrency.c
@@ -285,7 +285,8 @@ TEST_CASE(exec, busy_wait_statement, NULL)
 {
 	struct exec_fixture *f = data;
 	(void)params;
-	
+
+	raft_fixture_set_work_duration(&f->cluster, 0, 50);
 	f->servers[0].config.busy_timeout = 100;
 
 	/* Create a test table using connection 0 */
@@ -310,7 +311,8 @@ TEST_CASE(exec, busy_wait_transaction, NULL)
 {
 	struct exec_fixture *f = data;
 	(void)params;
-	
+
+	raft_fixture_set_work_duration(&f->cluster, 0, 50);
 	f->servers[0].config.busy_timeout = 100;
 
 	/* Create a test table using connection 0 */


### PR DESCRIPTION
This PR fixes a bunch of tests in the gateway suite so that they always wait (where appropriate) and do not rely on some async operation to end synchronously.

It also adds the capability to change the expected async work duration so that it is possible to rely on that timing during test time.