### PR TITLE
perf: improve barrier request logic

### DIFF
--- a/src/leader.c
+++ b/src/leader.c
@@ -36,6 +36,11 @@ static void exec_enqueue(struct db *db, struct exec *exec);
  * index. */
 static bool exec_needs_barrier(struct leader *l)
 {
+	if (sqlite3_txn_state(l->conn, NULL) != SQLITE_TXN_NONE) {
+		/* If a transaction is already in progress, there is little benefit
+		 * in submitting a barrier as the read mark is already set. */
+		return false;
+	}
 	return raft_last_applied(l->raft) < raft_last_index(l->raft);
 }
 


### PR DESCRIPTION
This PR improves the logic around barrier request so that barriers are not requested for already started transactions as sequencing is not necessary anymore for them.