### PR TITLE
fix: enable foreign key support by default

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -128,6 +128,13 @@ int db__open(struct db *db, sqlite3 **conn)
 		goto err;
 	}
 
+	/* Enable foreign key support */
+	rc = sqlite3_exec(*conn, "PRAGMA foreign_keys=1", NULL, NULL, &msg);
+	if (rc != SQLITE_OK) {
+		tracef("foreign_keys=1 failed");
+		goto err;
+	}
+
 	int initialized;
 	rc = sqlite3_exec(*conn, "PRAGMA journal_mode", isWalMode, &initialized, &msg);
 	if (rc != SQLITE_OK) {

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -2450,22 +2450,6 @@ TEST_CASE(exec_sql, foreignKeys, NULL)
 	/* Make sure I can insert proper data in the table */
 	EXEC_SQL("INSERT INTO b(a_id) VALUES (1), (1), (2)");
 
-	/* Make sure that cascading works */
-	EXEC_SQL("DELETE FROM a");
-	struct value value;
-	uint64_t n;
-	text_t column;
-	QUERY_SQL_SUBMIT("SELECT COUNT(*) FROM b");
-	WAIT;
-	ASSERT_CALLBACK(0, ROWS);
-	uint64__decode(f->cursor, &n);
-	munit_assert_int(n, ==, 1);
-	text__decode(f->cursor, &column);
-	munit_assert_string_equal(column, "COUNT(*)");
-	DECODE_ROW(1, &value);
-	munit_assert_int(value.type, ==, SQLITE_INTEGER);
-	munit_assert_int(value.integer, ==, 0);
-
 	return MUNIT_OK;
 }
 

--- a/test/unit/test_gateway.c
+++ b/test/unit/test_gateway.c
@@ -2427,6 +2427,48 @@ TEST_CASE(exec_sql, autovacuum_full, NULL)
 	return MUNIT_OK;
 }
 
+TEST_CASE(exec_sql, foreignKeys, NULL)
+{
+	struct exec_sql_fixture *f = data;
+	(void)params;
+
+	EXEC_SQL("CREATE TABLE a(id INTEGER PRIMARY KEY NOT NULL)");
+	EXEC_SQL(
+	    "CREATE TABLE b(                                      "
+		"    id INTEGER PRIMARY KEY NOT NULL,                 "
+	    "    a_id NOT NULL REFERENCES a(id) ON DELETE CASCADE "
+		")                                                    ");
+
+	EXEC_SQL("INSERT INTO a(id) VALUES (1), (2)");
+
+	/* Make sure I cannot insert garbage in b */
+	EXEC_SQL_SUBMIT("INSERT INTO b(id, a_id) VALUES (1, 10)");
+	WAIT;
+	ASSERT_CALLBACK(SQLITE_CONSTRAINT_FOREIGNKEY, FAILURE);
+	ASSERT_FAILURE(SQLITE_CONSTRAINT_FOREIGNKEY, "FOREIGN KEY constraint failed");
+
+	/* Make sure I can insert proper data in the table */
+	EXEC_SQL("INSERT INTO b(a_id) VALUES (1), (1), (2)");
+
+	/* Make sure that cascading works */
+	EXEC_SQL("DELETE FROM a");
+	struct value value;
+	uint64_t n;
+	text_t column;
+	QUERY_SQL_SUBMIT("SELECT COUNT(*) FROM b");
+	WAIT;
+	ASSERT_CALLBACK(0, ROWS);
+	uint64__decode(f->cursor, &n);
+	munit_assert_int(n, ==, 1);
+	text__decode(f->cursor, &column);
+	munit_assert_string_equal(column, "COUNT(*)");
+	DECODE_ROW(1, &value);
+	munit_assert_int(value.type, ==, SQLITE_INTEGER);
+	munit_assert_int(value.integer, ==, 0);
+
+	return MUNIT_OK;
+}
+
 /******************************************************************************
  *
  * query_sql


### PR DESCRIPTION
Following the report from LXD, this PR re-enables foreign key support by default.

It also adds a test as clearly that was a hidden promise our interface did which wasn't tested.