### PR TITLE
chore: fix pipeline

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -14,7 +14,9 @@ jobs:
           - jammy
           - noble
           - oracular
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:20.04
     environment:
       name: ppa
     steps:


### PR DESCRIPTION
This PR tries to fix the PPA publishing pipeline *for the LTS 1.17.x* by running the job on a container.