### PR TITLE
chore: fix pipeline

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -14,7 +14,7 @@ jobs:
           - jammy
           - noble
           - oracular
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment:
       name: ppa
     steps:


### PR DESCRIPTION
This PR tries to fix the PPA publishing pipeline by running the job on 22.04 instead of 20.04. This will not work for the LTS. Please see #784 for a PR that does the same for the LTS 1.17.x.