### PR TITLE
fix: `RETURNING` semantics

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -663,6 +663,7 @@ static void handle_query_work_cb(struct exec *exec)
 
 	if (req->cancellation_requested) {
 		/* Nothing else to do. */
+		sqlite3_reset(exec->stmt);
 		TAIL return leader_exec_resume(exec);
 	}
 
@@ -1357,10 +1358,11 @@ int gateway__handle(struct gateway *g,
 handle:
 	req->type = type;
 	req->schema = schema;
-	req->cb = cb;
 	req->buffer = buffer;
 	req->db_id = 0;
+	req->cancellation_requested = false;
 	req->parameters_bound = 0;
+	req->cb = cb;
 	req->work = (pool_work_t){};
 
 	switch (type) {


### PR DESCRIPTION
This PR fixes a misbehaviour for the `RETURNING` keyword: once the first row is returned, the query is not rolled back unless the transaction which is part of is.

This means that aborting a statement with `RETURNING` will not rollback the rows. This is expected behaviour in SQLite and should really be reflected in dqlite.

This also fixes a problem where a connection, once interrupted, could not execute any other statement. Consider though that interrupt is not supported right now, so it is not a bug that can be hit by normal code (i.e. using the `go-dqlite` package).