### PR TITLE
 refactor: remove wal from snapshot

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -15,7 +15,7 @@
 struct fsmDatabaseSnapshot {
 	sqlite3 *conn;
 	struct raft_buffer header;
-	struct vfsSnapshot files;
+	struct vfsSnapshot content;
 };
 
 struct fsmSnapshot {
@@ -225,17 +225,9 @@ static int decodeDatabase(const struct registry *r,
 	cursor->p += header.main_size;
 
 	*snapshot = (struct vfsSnapshot) {
-		.main = {
-			.page_count = (size_t)header.main_size / page_size,
-			.page_size = page_size,
-			.pages = pages,
-		},
-		// FIXME this breaks compatibility with very old dqlite 1.17.x (the one before shallow snapshot got in)
-		.wal = {
-			.page_count = 0,
-			.page_size = page_size,
-			.pages = NULL,
-		}
+		.page_count = header.main_size / page_size,
+		.page_size = page_size,
+		.pages = pages,
 	};
 	*filename = header.filename;
 
@@ -316,7 +308,7 @@ static int snapshotDatabase(struct db *db, struct fsmDatabaseSnapshot *snapshot)
 		tracef("checkpoint failed: %d", rv);
 	}
 
-	rv = VfsAcquireSnapshot(snapshot->conn, &snapshot->files);
+	rv = VfsAcquireSnapshot(snapshot->conn, &snapshot->content);
 	/* I think this can be an assert. */
 	if (rv != SQLITE_OK) {
 		sqlite3_close(snapshot->conn);
@@ -328,14 +320,14 @@ static int snapshotDatabase(struct db *db, struct fsmDatabaseSnapshot *snapshot)
 
 	const struct snapshotDatabase header = {
 		.filename = db->filename,
-		.main_size = snapshot->files.main.page_count * snapshot->files.main.page_size,
-		.wal_size = snapshot->files.wal.page_count * snapshot->files.wal.page_size,
+		.main_size = snapshot->content.page_count * snapshot->content.page_size,
+		.wal_size = 0,
 	};
 
 	const size_t header_size = snapshotDatabase__sizeof(&header);
 	void *header_buffer = raft_malloc(header_size);
 	if (header_buffer == NULL) {
-		VfsReleaseSnapshot(snapshot->conn, &snapshot->files);
+		VfsReleaseSnapshot(snapshot->conn, &snapshot->content);
 		sqlite3_close(snapshot->conn);
 		return RAFT_NOMEM;
 	}
@@ -393,8 +385,7 @@ static int fsm__snapshot(struct raft_fsm *fsm,
 		}
 
 		buffer_count += 1 /* For the database header */ +
-				databases[i].files.main.page_count +
-				databases[i].files.wal.page_count;
+				databases[i].content.page_count;
 		i++;
 	}
 
@@ -414,24 +405,13 @@ static int fsm__snapshot(struct raft_fsm *fsm,
 		buffers[buff_i] = databases[i].header;
 		buff_i++;
 
-		assert((buff_i + databases[i].files.main.page_count) <=
+		assert((buff_i + databases[i].content.page_count) <=
 		       buffer_count);
-		for (unsigned j = 0; j < databases[i].files.main.page_count;
+		for (unsigned j = 0; j < databases[i].content.page_count;
 		     j++) {
 			buffers[buff_i] = (struct raft_buffer){
-				.base = databases[i].files.main.pages[j],
-				.len = databases[i].files.main.page_size,
-			};
-			buff_i++;
-		}
-
-		assert((buff_i + databases[i].files.wal.page_count) <=
-		       buffer_count);
-		for (unsigned j = 0; j < databases[i].files.wal.page_count;
-		     j++) {
-			buffers[buff_i] = (struct raft_buffer){
-				.base = databases[i].files.wal.pages[j],
-				.len = databases[i].files.wal.page_size,
+				.base = databases[i].content.pages[j],
+				.len = databases[i].content.page_size,
 			};
 			buff_i++;
 		}
@@ -450,7 +430,7 @@ err:
 		if (databases[i].conn != NULL) {
 			raft_free(databases[i].header.base);
 			VfsReleaseSnapshot(databases[i].conn,
-					   &databases[i].files);
+					   &databases[i].content);
 			sqlite3_close(databases[i].conn);
 		}
 	}
@@ -478,7 +458,7 @@ static int fsm__snapshot_finalize(struct raft_fsm *fsm,
 		if (f->snapshot.databases[i].conn != NULL) {
 			raft_free(f->snapshot.databases[i].header.base);
 			VfsReleaseSnapshot(f->snapshot.databases[i].conn,
-					   &f->snapshot.databases[i].files);
+					   &f->snapshot.databases[i].content);
 			sqlite3_close(f->snapshot.databases[i].conn);
 		}
 	}
@@ -517,7 +497,7 @@ static int fsm__restore(struct raft_fsm *fsm, struct raft_buffer *buf)
 			return rv;
 		}
 		rv = restoreDatabase(f->registry, filename, &snapshot);
-		raft_free(snapshot.main.pages);
+		raft_free(snapshot.pages);
 		if (rv != RAFT_OK) {
 			tracef("restore failed");
 			return rv;

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -1096,7 +1096,7 @@ static int handle_remove(struct gateway *g, struct handle *req)
 }
 
 static int dumpFile(const char *filename,
-		     const struct vfsSnapshotFile *file,
+		     const struct vfsSnapshot *file,
 		     struct buffer *buffer)
 {
 	char *cur;
@@ -1166,7 +1166,7 @@ static int handle_dump(struct gateway *g, struct handle *req)
 	assert(cur != NULL);
 	response_files__encode(&response, &cur);
 
-	rv = dumpFile(request.filename, &snapshot.main, req->buffer);
+	rv = dumpFile(request.filename, &snapshot, req->buffer);
 	if (rv != 0) {
 		tracef("main dump failed");
 		failure(req, rv, "failed to dump main database file");
@@ -1181,7 +1181,8 @@ static int handle_dump(struct gateway *g, struct handle *req)
 	strncpy(filename, request.filename,
 		sizeof(filename) - strlen(wal_suffix) - 1);
 	strcat(filename, wal_suffix);
-	rv = dumpFile(filename, &snapshot.wal, req->buffer);
+	static const struct vfsSnapshot empty_wal = {}; 
+	rv = dumpFile(filename, &empty_wal, req->buffer);
 	if (rv != 0) {
 		tracef("WAL dump failed");
 		failure(req, rv, "failed to dump WAL file");

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -41,15 +41,10 @@ int VfsAbort(sqlite3 *conn);
 /* Performs a controlled checkpoint on conn */
 int VfsCheckpoint(sqlite3 *conn, unsigned int threshold);
 
-struct vfsSnapshotFile {
+struct vfsSnapshot {
 	void **pages;
 	size_t page_count;
 	size_t page_size;
-};
-
-struct vfsSnapshot {
-	struct vfsSnapshotFile main;
-	struct vfsSnapshotFile wal;
 };
 
 /* Acquires a snapshot from the connection conn. The snapshot wil be valid until

--- a/test/unit/test_vfs_extra.c
+++ b/test/unit/test_vfs_extra.c
@@ -1388,12 +1388,10 @@ TEST(vfs_extra, snapshotInitialDatabase, setUp, tearDown, 0, NULL)
 
 	int rv = VfsAcquireSnapshot(db, &snapshot);
 	munit_assert_int(rv, ==, SQLITE_OK);
-	munit_assert_int(snapshot.main.page_count, ==, 1);
-	munit_assert_int(snapshot.main.page_size, ==, DB_PAGE_SIZE);
-	munit_assert_int(snapshot.wal.page_count, ==, 0);
-	munit_assert_int(snapshot.wal.page_size, ==, DB_PAGE_SIZE);
+	munit_assert_int(snapshot.page_count, ==, 1);
+	munit_assert_int(snapshot.page_size, ==, DB_PAGE_SIZE);
 
-	page = snapshot.main.pages[0];
+	page = snapshot.pages[0];
 
 	munit_assert_int(memcmp(&page[16], page_size, 2), ==, 0);
 	munit_assert_int(memcmp(&page[28], database_size, 4), ==, 0);
@@ -1426,12 +1424,10 @@ TEST(vfs_extra, snapshotAfterFirstTransaction, setUp, tearDown, 0, NULL)
 	 * Page number 2 contains the (empty) root for test table.
 	 */
 	const uint32_t pages = 2;
-	munit_assert_int(snapshot.main.page_count, ==, pages);
-	munit_assert_int(snapshot.main.page_size, ==, DB_PAGE_SIZE);
-	munit_assert_int(snapshot.wal.page_count, ==, 0);
-	munit_assert_int(snapshot.wal.page_size, ==, DB_PAGE_SIZE);
+	munit_assert_int(snapshot.page_count, ==, pages);
+	munit_assert_int(snapshot.page_size, ==, DB_PAGE_SIZE);
 
-	uint8_t *page = snapshot.main.pages[0];
+	uint8_t *page = snapshot.pages[0];
 	munit_assert_int(ByteGetBe16(&page[16]), ==, DB_PAGE_SIZE);
 	munit_assert_int(ByteGetBe32(&page[28]), ==, pages);
 
@@ -1462,12 +1458,10 @@ TEST(vfs_extra, snapshotAfterCheckpoint, setUp, tearDown, 0, NULL)
 	munit_assert_int(rv, ==, SQLITE_OK);
 
 	const uint32_t pages = 2;
-	munit_assert_int(snapshot.main.page_count, ==, pages);
-	munit_assert_int(snapshot.main.page_size, ==, DB_PAGE_SIZE);
-	munit_assert_int(snapshot.wal.page_count, ==, 0);
-	munit_assert_int(snapshot.wal.page_size, ==, DB_PAGE_SIZE);
+	munit_assert_int(snapshot.page_count, ==, pages);
+	munit_assert_int(snapshot.page_size, ==, DB_PAGE_SIZE);
 
-	uint8_t *page = snapshot.main.pages[0];
+	uint8_t *page = snapshot.pages[0];
 	munit_assert_int(ByteGetBe16(&page[16]), ==, DB_PAGE_SIZE);
 	munit_assert_int(ByteGetBe32(&page[28]), ==, pages);
 
@@ -1485,7 +1479,6 @@ TEST(vfs_extra, restoreInitialDatabase, setUp, tearDown, 0, NULL)
 
 	OPEN("1", db1);
 
-	// TODO
 	int rv = VfsAcquireSnapshot(db1, &snapshot);
 	munit_assert_int(rv, ==, SQLITE_OK);
 


### PR DESCRIPTION
This PR follows up #811 and simplifies even more the snapshot interface by removing the always empty wal.

Please note that since #710 was merged before `v1.17.0` then this is compatible with any LTS version.