### PR TITLE
chore: disable publishing on 20.04 and 24.10 and enable 25.04

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -10,10 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - focal
           - jammy
           - noble
-          - oracular
+          - plucky
     runs-on: ubuntu-22.04
     environment:
       name: ppa


### PR DESCRIPTION
This PR removes PPA pubilshing for `v1.18.x` series for:
 - Focal Fossa (20.04) as it is not supported anymore for this branch;
 - Oracle Oriole (24.10) as this interim release is not supported anymore.

It also enables publishing for Plucky Puffin as it is the new supported interim release.