### PR TITLE
chore: release on PPA only when a version is published

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,6 +1,7 @@
 name: Build PPA source packages
 on:
-  push:
+  release:
+    types: [published]
     branches:
       - 'lts-1.17.x'
 jobs:


### PR DESCRIPTION
This PR makes sure the PPA packages publishing workflow only runs if a version is published, so that stable version packages are not overwritten by interim packages.