### PR TITLE
chore: remove support for pre-lts coordinated checkpoint

### DIFF
--- a/test/unit/test_replication.c
+++ b/test/unit/test_replication.c
@@ -476,7 +476,7 @@ TEST(replication, checkpoint, setUp, tearDown, 0, NULL)
 
 	PREPARE(0, "INSERT INTO test(n) VALUES(1)");
 	fixture_exec(f, 0);
-	CLUSTER_APPLIED(5);
+	CLUSTER_APPLIED(4);
 	FINALIZE;
 
 	/* The WAL was truncated. */


### PR DESCRIPTION
This PR removes the code that coordinates checkpoint which has been a no-op since `v1.10.0`.