### PR TITLE
chore: remove RAFT_LIBS reference from .pc

### DIFF
--- a/dqlite.pc.in
+++ b/dqlite.pc.in
@@ -7,5 +7,5 @@ Name: dqlite
 Description: Distributed SQLite engine
 Version:  @PACKAGE_VERSION@
 Libs: -L${libdir} -ldqlite
-Libs.private: @SQLITE_LIBS@ @UV_LIBS@ @RAFT_LIBS@
+Libs.private: @SQLITE_LIBS@ @UV_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
This PR removes the old `RAFT_LIBS` reference now that `libraft` is just an implementation detail.

Closes #726.