### PR TITLE
refactor: simplify fsm interface

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -120,9 +120,7 @@ static int apply_checkpoint(struct fsm *f, const struct command_checkpoint *c)
 	return 0;
 }
 
-static int fsm__apply(struct raft_fsm *fsm,
-		      const struct raft_buffer *buf,
-		      void **result)
+static int fsm__apply(struct raft_fsm *fsm, const struct raft_buffer *buf)
 {
 	tracef("fsm apply");
 	struct fsm *f = fsm->data;
@@ -155,7 +153,6 @@ static int fsm__apply(struct raft_fsm *fsm,
 
 	raft_free(command);
 err:
-	*result = NULL;
 	return rc;
 }
 
@@ -460,8 +457,8 @@ err:
 }
 
 static int fsm__snapshot_finalize(struct raft_fsm *fsm,
-				  struct raft_buffer *bufs[],
-				  unsigned *n_bufs)
+				  struct raft_buffer bufs[],
+				  unsigned n_bufs)
 {
 	(void)n_bufs;
 
@@ -470,9 +467,7 @@ static int fsm__snapshot_finalize(struct raft_fsm *fsm,
 	PRE(f->snapshot.header.len != 0 && f->snapshot.header.base != NULL);
 	PRE(f->snapshot.database_count == 0 || f->snapshot.databases != NULL);
 
-	raft_free(*bufs);
-	*bufs = NULL;
-	*n_bufs = 0;
+	raft_free(bufs);
 
 	for (unsigned int i = 0; i < f->snapshot.database_count; i++) {
 		if (f->snapshot.databases[i].conn != NULL) {

--- a/src/leader.c
+++ b/src/leader.c
@@ -24,7 +24,7 @@ static int exec_apply(struct exec *req,
 		      const struct vfsTransaction *transaction);
 static void exec_prepare_barrier_cb(struct raft_barrier *barrier, int status);
 static void exec_run_barrier_cb(struct raft_barrier *barrier, int status);
-static void exec_apply_cb(struct raft_apply *req, int status, void *result);
+static void exec_apply_cb(struct raft_apply *req, int status);
 static void exec_timer_cb(struct raft_timer *timer);
 static bool is_db_full(sqlite3_vfs *vfs, struct db *db, unsigned nframes);
 
@@ -617,9 +617,8 @@ static void exec_timer_cb(struct raft_timer *timer)
 	return exec_tick(req);
 }
 
-static void exec_apply_cb(struct raft_apply *apply, int status, void *result)
+static void exec_apply_cb(struct raft_apply *apply, int status)
 {
-	(void)result;
 	struct exec *req = CONTAINER_OF(apply, struct exec, apply);
 	struct leader *leader = req->leader;
 	PRE(leader != NULL);

--- a/src/raft.h
+++ b/src/raft.h
@@ -738,16 +738,15 @@ struct raft_fsm
 	int version; /* 1, 2 or 3 */
 	void *data;
 	int (*apply)(struct raft_fsm *fsm,
-		     const struct raft_buffer *buf,
-		     void **result);
+		     const struct raft_buffer *buf);
 	int (*snapshot)(struct raft_fsm *fsm,
 			struct raft_buffer *bufs[],
 			unsigned *n_bufs);
 	int (*restore)(struct raft_fsm *fsm, struct raft_buffer *buf);
 	/* Fields below added since version 2. */
 	int (*snapshot_finalize)(struct raft_fsm *fsm,
-				 struct raft_buffer *bufs[],
-				 unsigned *n_bufs);
+				 struct raft_buffer bufs[],
+				 unsigned n_bufs);
 	/* Fields below added since version 3. */
 	int (*snapshot_async)(struct raft_fsm *fsm,
 			      struct raft_buffer *bufs[],
@@ -1248,7 +1247,7 @@ RAFT_API int raft_voter_contacts(struct raft *r);
  * the FSM when a quorum is reached.
  */
 struct raft_apply;
-typedef void (*raft_apply_cb)(struct raft_apply *req, int status, void *result);
+typedef void (*raft_apply_cb)(struct raft_apply *req, int status);
 struct raft_apply
 {
 	RAFT__REQUEST;
@@ -1445,8 +1444,6 @@ DQLITE_VISIBLE_TO_TESTS void raft_heap_set_default(void);
  * the backing memory, is undefined.
  */
 DQLITE_VISIBLE_TO_TESTS const struct raft_heap *raft_heap_get(void);
-
-#undef RAFT__REQUEST
 
 struct raft_uv_transport;
 

--- a/src/raft/convert.c
+++ b/src/raft/convert.c
@@ -66,7 +66,7 @@ static void convertFailApply(struct raft_apply *req)
 {
 	PRE(req != NULL);
 	if (req->cb != NULL) {
-		req->cb(req, RAFT_LEADERSHIPLOST, NULL);
+		req->cb(req, RAFT_LEADERSHIPLOST);
 	}
 }
 

--- a/src/raft/replication.c
+++ b/src/raft/replication.c
@@ -511,7 +511,7 @@ static void appendLeaderCb(struct raft_io_append *append, int status)
 					struct raft_apply *apply =
 					    (struct raft_apply *)req;
 					if (apply->cb) {
-						apply->cb(apply, status, NULL);
+						apply->cb(apply, status);
 					}
 					break;
 				}
@@ -1556,10 +1556,9 @@ static int applyCommand(struct raft *r,
 			const struct raft_buffer *buf)
 {
 	struct raft_apply *req;
-	void *result;
 	int rv;
 
-	rv = r->fsm->apply(r->fsm, buf, &result);
+	rv = r->fsm->apply(r->fsm, buf);
 	if (rv != 0) {
 		return rv;
 	}
@@ -1574,7 +1573,7 @@ static int applyCommand(struct raft *r,
 	sm_move(&req->sm, REQUEST_COMPLETE);
 	sm_fini(&req->sm);
 	if (req->cb != NULL) {
-		req->cb(req, 0, result);
+		req->cb(req, 0);
 	}
 	return 0;
 }
@@ -1683,7 +1682,9 @@ static void takeSnapshotClose(struct raft *r, struct raft_snapshot *s)
 	}
 
 	configurationClose(&s->configuration);
-	r->fsm->snapshot_finalize(r->fsm, &s->bufs, &s->n_bufs);
+	r->fsm->snapshot_finalize(r->fsm, s->bufs, s->n_bufs);
+	s->bufs = NULL;
+	s->n_bufs = 0;
 }
 
 

--- a/src/raft/request.h
+++ b/src/raft/request.h
@@ -43,16 +43,7 @@ static inline bool request_invariant(const struct sm *sm, int prev)
 
 /* Abstract request type */
 struct request {
-	/* Must be kept in sync with RAFT__REQUEST in raft.h */
-	void *data;
-	int type;
-	raft_index index;
-	queue queue;
-	struct sm sm;
-	uint8_t req_id[16];
-	uint8_t client_id[16];
-	uint8_t unique_id[16];
-	uint64_t reserved[4];
+	RAFT__REQUEST;
 };
 
 #endif /* REQUEST_H_ */

--- a/test/raft/fuzzy/test_liveness.c
+++ b/test/raft/fuzzy/test_liveness.c
@@ -120,11 +120,10 @@ static void tear_down(void *data)
 
 SUITE(liveness)
 
-static void apply_cb(struct raft_apply *req, int status, void *result)
+static void apply_cb(struct raft_apply *req, int status)
 {
-    (void)status;
-    (void)result;
-    free(req);
+	(void)status;
+	free(req);
 }
 
 /* The system makes progress even in case of network disruptions. */

--- a/test/raft/fuzzy/test_replication.c
+++ b/test/raft/fuzzy/test_replication.c
@@ -92,11 +92,10 @@ TEST(replication, availability, setup, tear_down, 0, _params)
     return MUNIT_OK;
 }
 
-static void apply_cb(struct raft_apply *req, int status, void *result)
+static void apply_cb(struct raft_apply *req, int status)
 {
-    (void)status;
-    (void)result;
-    free(req);
+	(void)status;
+	free(req);
 }
 
 /* If no quorum is available, entries don't get committed. */

--- a/test/raft/integration/test_apply.c
+++ b/test/raft/integration/test_apply.c
@@ -43,10 +43,9 @@ struct result
     struct raft *raft;
 };
 
-static void applyCbAssertResult(struct raft_apply *req, int status, void *_)
+static void applyCbAssertResult(struct raft_apply *req, int status)
 {
     struct result *result = req->data;
-    (void)_;
     munit_assert_int(status, ==, result->status);
     if (status == 0) {
         munit_assert_ulong(result->prev_applied, <,

--- a/test/raft/integration/test_replication.c
+++ b/test/raft/integration/test_replication.c
@@ -1072,13 +1072,10 @@ TEST(replication, resultRetry, setUp, tearDown, 0, NULL)
     return MUNIT_OK;
 }
 
-static void applyAssertStatusCb(struct raft_apply *req,
-                                int status,
-                                void *result)
+static void applyAssertStatusCb(struct raft_apply *req, int status)
 {
-    (void)result;
-    int status_expected = (int)(intptr_t)(req->data);
-    munit_assert_int(status_expected, ==, status);
+	int status_expected = (int)(intptr_t)(req->data);
+	munit_assert_int(status_expected, ==, status);
 }
 
 /* When the leader fails to write some new entries to disk, it steps down. */

--- a/test/raft/lib/fsm.c
+++ b/test/raft/lib/fsm.c
@@ -15,9 +15,7 @@ struct fsm
 /* Command codes */
 enum { SET_X = 1, SET_Y, ADD_X, ADD_Y };
 
-static int fsmApply(struct raft_fsm *fsm,
-                    const struct raft_buffer *buf,
-                    void **result)
+static int fsmApply(struct raft_fsm *fsm, const struct raft_buffer *buf)
 {
     struct fsm *f = fsm->data;
     const void *cursor = buf->base;
@@ -47,8 +45,6 @@ static int fsmApply(struct raft_fsm *fsm,
         default:
             return -1;
     }
-
-    *result = NULL;
 
     return 0;
 }
@@ -144,20 +140,18 @@ static int fsmSnapshotAsync(struct raft_fsm *fsm,
 }
 
 static int fsmSnapshotFinalize(struct raft_fsm *fsm,
-                               struct raft_buffer *bufs[],
-                               unsigned *n_bufs)
+                               struct raft_buffer bufs[],
+                               unsigned n_bufs)
 {
     (void)bufs;
     (void)n_bufs;
     struct fsm *f = fsm->data;
-    if (*bufs != NULL) {
-        for (unsigned i = 0; i < *n_bufs; ++i) {
-            raft_free((*bufs)[i].base);
+    if (bufs != NULL) {
+        for (unsigned i = 0; i < n_bufs; ++i) {
+            raft_free(bufs[i].base);
         }
-        raft_free(*bufs);
+        raft_free(bufs);
     }
-    *bufs = NULL;
-    *n_bufs = 0;
     munit_assert_int(f->lock, ==, 1);
     f->lock = 0;
     munit_assert_ptr_not_null(f->data);


### PR DESCRIPTION
This PR simplifies the fsm interface by removing unnecessary indirection and useless fields. It was part of #774 which is likely not going to be merged.