### PR TITLE
chore: add more threads when testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
           ./test/raft/lib/fs.sh setup tmpfs ext4 btrfs zfs
           export $(./test/raft/lib/fs.sh detect tmpfs ext4 btrfs zfs)
-          make check || (cat test-suite.log && false)
+          UV_THREADPOOL_SIZE=$(($(nproc) * 2)) make check || (cat test-suite.log && false)
           ./test/raft/lib/fs.sh teardown tmpfs ext4 btrfs zfs
 
     - name: Coverage


### PR DESCRIPTION
This PR attempts at increasing the parallelism for testing.

The choice is twice the CPU cores as the thread pool is also used for file operations which are not CPU-bound and will be blocked on file operations.