### PR TITLE
fix: always call `VfsAbort` on error

### DIFF
--- a/src/leader.c
+++ b/src/leader.c
@@ -552,7 +552,8 @@ static void exec_tick(struct exec *req)
 			}
 		case EXEC_WAITING_APPLY:
 			if (req->status != 0) {
-				VfsAbort(leader->conn);
+				int rv = VfsAbort(leader->conn);
+				assert(rv == SQLITE_OK);
 			}
 			sm_move(&req->sm, EXEC_DONE);
 			continue;

--- a/src/leader.c
+++ b/src/leader.c
@@ -388,9 +388,9 @@ static void exec_tick(struct exec *req)
 	struct leader *leader = req->leader;
 	struct db *db = leader->db;
 
+	leader_trace(leader, "exec resume %s (status = %d)",
+		     exec_state_name(sm_state(&req->sm)), req->status);
 	for (;;) {
-		leader_trace(leader, "exec tick %s (status = %d)",
-			     exec_state_name(sm_state(&req->sm)), req->status);
 		switch (sm_state(&req->sm)) {
 		case EXEC_INITED:
 			PRE(leader->exec == NULL);


### PR DESCRIPTION
This PR fixes the leader state machine so that it always call `VfsAbort` in case something went wrong during replication. 

This is yet another instance of problems created by the double return path: `raft_apply` will call the callback with the error normally EXCEPT that when it already knows it is not the leader, then it will not and it will just return immediately without calling any callback.

This misdesign is plaguing this codebase and should be avoided in the future: only systematic errors like "wrong parameters" or "out of memory" should be returned immediately, **not** domain errors.

The fix for this specific bug is to route all errors through the state machine, so that now the state `EXEC_WAITING_APPLY` is not a phantom (trace-only) state anymore, but takes care of the required cleanup.