### PR TITLE
fix: remove forced tail calls

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -519,7 +519,7 @@ static void handle_exec_work_cb(struct exec *exec)
 	int rv = g->raft->io->async_work(g->raft->io, &g->work, exec_work_done);
 	if (rv != RAFT_OK) {
 		leader_exec_result(exec, rv);
-		TAIL return leader_exec_resume(exec);
+		return leader_exec_resume(exec);
 	}
 }
 
@@ -747,12 +747,12 @@ static void handle_query_work_cb(struct exec *exec)
 	if (req->cancellation_requested) {
 		/* Nothing else to do. */
 		sqlite3_reset(exec->stmt);
-		TAIL return leader_exec_resume(exec);
+		return leader_exec_resume(exec);
 	}
 
 	if (!is_statement_empty(exec->leader->conn, exec->tail)) {
 		leader_exec_result(exec, RAFT_ERROR);
-		TAIL return leader_exec_resume(exec);
+		return leader_exec_resume(exec);
 	}
 
 	exec->tail = NULL;
@@ -764,7 +764,7 @@ static void handle_query_work_cb(struct exec *exec)
 	int rv = g->raft->io->async_work(g->raft->io, &g->work, query_work_done);
 	if (rv != RAFT_OK) {
 		leader_exec_result(exec, rv);
-		TAIL return leader_exec_resume(exec);
+		return leader_exec_resume(exec);
 	}
 }
 

--- a/src/leader.c
+++ b/src/leader.c
@@ -251,7 +251,7 @@ void leader_exec_abort(struct exec *req)
 	case EXEC_WAITING_QUEUE:
 		/* timers are cancellable, so the request can move on directly. */
 		leader_exec_result(req, RAFT_CANCELED);
-		TAIL return exec_tick(req);
+		return exec_tick(req);
 	}
 
 	/* Raft-related requests cannot be cancelled, so the only step that can be taken
@@ -278,7 +278,7 @@ void leader_exec_result(struct exec *req, int status)
 void leader_exec_resume(struct exec *req)
 {
 	PRE(sm_state(&req->sm) == EXEC_RUNNING);
-	TAIL return exec_tick(req);
+	return exec_tick(req);
 }
 
 static int exec_apply(struct exec *req, const struct vfsTransaction *transaction)
@@ -511,7 +511,7 @@ static void exec_tick(struct exec *req)
 
 			leader_trace(leader, "executing query");
 			sm_move(&req->sm, EXEC_RUNNING);
-			TAIL return req->work_cb(req);
+			return req->work_cb(req);
 		case EXEC_RUNNING:
 			leader_trace(leader, "executed query on leader (status=%d)", req->status);
 			if (req->status != RAFT_OK) {
@@ -589,7 +589,7 @@ static void exec_tick(struct exec *req)
 			if (req != NULL) {
 				PRE(IN(db->active_leader, NULL, req->leader));
 				db->active_leader = req->leader;
-				TAIL return exec_tick(req);
+				return exec_tick(req);
 			}
 			return;
 		default:

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,12 +37,6 @@
 #define IN(E, ...) \
   (GET_IN_MACRO(__VA_ARGS__,IN_9,IN_8,IN_7,IN_6,IN_5,IN_4,IN_3,IN_2,IN_1)(E,__VA_ARGS__))
 
-#if defined(__has_attribute) && __has_attribute (musttail)
-# define TAIL __attribute__ ((musttail))
-#else
-# define TAIL
-#endif
-
 #if defined(__has_attribute) && __has_attribute (noinline)
 # define NOINLINE __attribute__ ((noinline))
 #else


### PR DESCRIPTION
This PR removes tail calls as they are not needed anymore and they are creating problems on gcc 15.2.

Closes #842 .