### PR TITLE
bugfix: allow opening in-memory databases

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -2520,7 +2520,7 @@ static int vfsOpenHook(sqlite3 *db,
 	sqlite3_file *file = NULL;
 	int rv = sqlite3_file_control(db, NULL, SQLITE_FCNTL_FILE_POINTER, &file);
 	assert(rv == SQLITE_OK);
-	if (file->pMethods->xRead != vfsMainFileRead) {
+	if (file->pMethods == NULL || file->pMethods->xRead != vfsMainFileRead) {
 		/* Not this vfs. */
 		return SQLITE_OK;
 	}

--- a/test/unit/test_vfs.c
+++ b/test/unit/test_vfs.c
@@ -1585,3 +1585,29 @@ TEST(VfsIntegration, checkpoint, setUp, tearDown, 0, NULL)
 
 	return SQLITE_OK;
 }
+
+/* Check that the VFS does not interfere with normal sqlite execution */
+TEST(VfsIntegration, sqlite, setUp, tearDown, 0, NULL)
+{
+	(void)data;
+	(void)params;
+
+	const int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_EXRESCODE | SQLITE_OPEN_DELETEONCLOSE;
+
+	const char *filenames[] = {
+		"/tmp/dqlite-test-normal-sqlite",
+		"", /* temp db */
+		":memory:", /* in-memory db*/
+		NULL,
+	};
+
+	for (int i = 0; filenames[i]; i++) {
+		sqlite3 *db;
+		int rc = sqlite3_open_v2(filenames[i], &db, flags, NULL);
+		munit_assert_int(rc, ==, SQLITE_OK);
+		EXEC(db, "CREATE TABLE asd(i)");
+		sqlite3_close(db);
+	}
+
+	return SQLITE_OK;
+}


### PR DESCRIPTION
This PR fixes a bug introduced with #830 . Apparently, even if not documented, in-memory `sqlite3_file`s have a `NULL` `pMethods` field.

I added a test, just in case.