### PR TITLE
fix(roles): Initialize variables to fix LTO build

### DIFF
--- a/src/roles.c
+++ b/src/roles.c
@@ -565,8 +565,8 @@ static void handoverVoterAfterWorkCb(uv_work_t *work, int status)
 static void handoverVoterCb(struct polling *polling)
 {
 	struct dqlite_node *node;
-	raft_id leader_id;
-	const char *borrowed_addr;
+	raft_id leader_id = 0;
+	const char *borrowed_addr = NULL;
 	char *leader_addr;
 	struct compare_data voter_compare = {0};
 	unsigned i;


### PR DESCRIPTION
This PR resolves a build failure that occurs when Link-Time Optimization is enabled.

The build fails with the following error, as the compiler cannot guarantee that leader_id and borrowed_addr are initialized before use in all code paths:

```log
  CCLD     libdqlite.la
src/roles.c: In function 'handoverVoterCb':
src/roles.c:593:35: error: 'borrowed_addr' may be used uninitialized [-Werror=maybe-uninitialized]
  593 |         leader_addr = raft_malloc(strlen(borrowed_addr) + 1);
      |                                   ^
src/roles.c:569:21: note: 'borrowed_addr' was declared here
  569 |         const char *borrowed_addr;
      |                     ^
src/roles.c:590:12: error: 'leader_id' may be used uninitialized [-Werror=maybe-uninitialized]
  590 |         if (leader_id == node->raft.id || leader_id == 0) {
      |            ^
src/roles.c:568:17: note: 'leader_id' was declared here
  568 |         raft_id leader_id;
      |                 ^
lto1: all warnings being treated as errors
make[1]: *** [/tmp/ccZP0T8u.mk:4: /tmp/ccKkjjOG.ltrans1.ltrans.o] Error 1
make[1]: *** Waiting for unfinished jobs....
lto-wrapper: fatal error: make returned 2 exit status
```

Instead of suppressing the compiler warning via build flags, this change addresses the root cause by initializing 
the variables directly at declaration within the handoverVoterCb function. This ensures the variables always have a safe, known value.
