### PR TITLE
fix: null deref when stopping or handing over before start

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -872,6 +872,10 @@ int dqlite_node_handover(dqlite_node *d)
 {
 	int rv;
 
+	if (!d->running) {
+		return DQLITE_MISUSE;
+	}
+
 	rv = uv_async_send(&d->handover);
 	dqlite_assert(rv == 0);
 
@@ -885,6 +889,10 @@ int dqlite_node_stop(dqlite_node *d)
 	tracef("dqlite node stop");
 	void *result;
 	int rv;
+
+	if (!d->running) {
+		return DQLITE_MISUSE;
+	}
 
 	/* Prevents using @d multiple times from different contexts */
 	if (d->lock_fd == -EBADF) {

--- a/test/integration/test_node.c
+++ b/test/integration/test_node.c
@@ -160,7 +160,29 @@ TEST(node, startInetStopTwice, setUpInet, tearDown, 0, node_params)
 	munit_assert_int(rv, ==, 0);
 
 	rv = dqlite_node_stop(f->node);
-	munit_assert_int(rv, ==, EBADF);
+	munit_assert_int(rv, ==, DQLITE_MISUSE);
+
+	return MUNIT_OK;
+}
+
+TEST(node, stopBeforeStart, setUpLocal, tearDown, 0, node_params)
+{
+	struct fixture *f = data;
+	int rv;
+
+	rv = dqlite_node_stop(f->node);
+	munit_assert_int(rv, ==, DQLITE_MISUSE);
+
+	return MUNIT_OK;
+}
+
+TEST(node, handoverBeforeStart, setUpLocal, tearDown, 0, node_params)
+{
+	struct fixture *f = data;
+	int rv;
+
+	rv = dqlite_node_handover(f->node);
+	munit_assert_int(rv, ==, DQLITE_MISUSE);
 
 	return MUNIT_OK;
 }


### PR DESCRIPTION
## Summary
- Calling `dqlite_node_stop()` or `dqlite_node_handover()` before `dqlite_node_start()` caused a segfault — the `d->stop` and `d->handover` uv_async handles are only initialized in the worker thread created by start
- Added `!d->running` guards to both functions, returning `DQLITE_MISUSE` (consistent with existing codebase conventions for misuse)
- Added two new integration tests: `stopBeforeStart` and `handoverBeforeStart`

Fixes #848

## Test plan
- [x] `make check` passes — all 7 test suites green
- [x] New tests `stopBeforeStart` and `handoverBeforeStart` verify `DQLITE_MISUSE` is returned without crashing
- [x] Existing `startInetStopTwice` test updated to expect `DQLITE_MISUSE` (double-stop now hits the `!d->running` guard since `stop_cb` sets `d->running = false`)