### PR TITLE
raft: allow disabling fallocate with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,7 @@ Detailed tracing will be enabled when the environment variable
 range and represents a tracing level, where `0` means "no traces" emitted, `5`
 enables minimum (FATAL records only), and `1` enables maximum verbosity (all:
 DEBUG, INFO, WARN, ERROR, FATAL records).
+
+Set `LIBDQLITE_DISABLE_FALLOCATE` before startup to disable the use of
+`posix_fallocate()` during filesystem capability probing and file allocation.
+Any value other than `0` disables fallocate.

--- a/src/raft/uv_fs.c
+++ b/src/raft/uv_fs.c
@@ -1281,6 +1281,15 @@ static int probeAsyncIO(int fd, size_t size, bool *ok, char *errmsg)
 	return 0;
 }
 
+#define LIBDQLITE_DISABLE_FALLOCATE "LIBDQLITE_DISABLE_FALLOCATE"
+
+static bool fallocateDisabledByEnv(void)
+{
+        const char *value = getenv(LIBDQLITE_DISABLE_FALLOCATE);
+
+        return value != NULL && strcmp(value, "0") != 0;
+}
+
 #define UV__FS_PROBE_FALLOCATE_FILE ".probe_fallocate"
 /* Leave detection of other error conditions to other probe* functions, only
  * bother checking if posix_fallocate returns success. */
@@ -1292,6 +1301,9 @@ static void probeFallocate(const char *dir, bool *fallocate)
 	int fd = -1;
 
 	*fallocate = false;
+	if (fallocateDisabledByEnv()) {
+		return;
+	}
 	UvFsRemoveFile(dir, UV__FS_PROBE_FALLOCATE_FILE, ignored);
 	rv = uvFsOpenFile(dir, UV__FS_PROBE_FALLOCATE_FILE, flags,
 			  S_IRUSR | S_IWUSR, &fd, ignored);

--- a/test/raft/unit/test_uv_fs.c
+++ b/test/raft/unit/test_uv_fs.c
@@ -1,5 +1,6 @@
 #include <sys/utsname.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 #include "../../../src/raft/uv_fs.h"
 #include "../../../src/raft/uv_os.h"
@@ -405,6 +406,30 @@ TEST(UvFsProbeCapabilities, noResources, DirBtrfsSetUp, DirTearDown, 0, NULL)
         dir, RAFT_IOERR,
         "probe Async I/O: io_setup: resource temporarily unavailable");
     AioDestroy(ctx);
+    return MUNIT_OK;
+}
+
+TEST(UvFsProbeCapabilities, fallocateDisabledByEnv, DirSetUp, DirTearDown, 0,
+     NULL)
+{
+    const char *dir = data;
+    size_t direct_io;
+    bool async_io;
+    bool fallocate;
+    char errmsg[RAFT_ERRMSG_BUF_SIZE];
+    int rv;
+
+    if (dir == NULL) {
+        return MUNIT_SKIP;
+    }
+
+    munit_assert_int(setenv("LIBDQLITE_DISABLE_FALLOCATE", "1", 1), ==, 0);
+    rv = UvFsProbeCapabilities(dir, &direct_io, &async_io, &fallocate, errmsg);
+    unsetenv("LIBDQLITE_DISABLE_FALLOCATE");
+
+    munit_assert_int(rv, ==, 0);
+    munit_assert_false(fallocate);
+
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
## Summary

Add a `LIBDQLITE_DISABLE_FALLOCATE` environment variable to disable
`posix_fallocate()` during filesystem capability probing and file allocation.

## Motivation

On some filesystems, notably ext3, `posix_fallocate()` on files opened with
`O_DSYNC` can be extremely slow. This provides a general override mechanism
without adding filesystem-specific carveouts.

## Changes

- add `LIBDQLITE_DISABLE_FALLOCATE` handling in `probeFallocate()`
- add a unit test covering the override
- document the environment variable in `README.md`

## Testing

- `make -j"$(nproc)"`
- `./raft-uv-unit-test`
- `LIBDQLITE_DISABLE_FALLOCATE=1 ./raft-uv-unit-test`
- manually reproduced the slow `posix_fallocate()` behavior on an ext3 loopback mount
