### PR TITLE
feat: set SOCK_CLOEXEC on socket creation to prevent FD leak to child processes

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -244,13 +244,8 @@ int dqlite_node_set_bind_address(dqlite_node *t, const char *address)
 	}
 	domain = addr->sa_family;
 
-	fd = socket(domain, SOCK_STREAM, 0);
+	fd = socket(domain, SOCK_STREAM | SOCK_CLOEXEC, 0);
 	if (fd == -1) {
-		return DQLITE_ERROR;
-	}
-	rv = fcntl(fd, FD_CLOEXEC);
-	if (rv != 0) {
-		close(fd);
 		return DQLITE_ERROR;
 	}
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -223,7 +223,7 @@ int transportDefaultConnect(void *arg, const char *address, int *fd)
 	}
 
 	dqlite_assert(addr->sa_family == AF_INET || addr->sa_family == AF_INET6);
-	*fd = socket(addr->sa_family, SOCK_STREAM, 0);
+	*fd = socket(addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0);
 	if (*fd == -1) {
 		return RAFT_NOCONNECTION;
 	}

--- a/test/lib/endpoint.c
+++ b/test/lib/endpoint.c
@@ -144,13 +144,13 @@ int test_endpoint_accept(struct test_endpoint *e)
 	}
 
 	/* Accept the client connection. */
-	fd = accept(e->fd, address, &size);
+	fd = accept4(e->fd, address, &size, SOCK_CLOEXEC);
 	if (fd < 0) {
 		/* Check if the endpoint has been closed, so this is benign. */
 		if (errno == EBADF || errno == EINVAL || errno == ENOTSOCK) {
 			return -1;
 		}
-		munit_errorf("accept(): %s", strerror(errno));
+		munit_errorf("accept4(): %s", strerror(errno));
 	}
 
 	/* Set non-blocking mode */

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -13,7 +13,7 @@ static int endpointConnect(void *data, const char *address, int *fd)
 	memset(&addr, 0, sizeof addr);
 	addr.sun_family = AF_UNIX;
 	strcpy(addr.sun_path + 1, address + 1);
-	*fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	*fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 	munit_assert_int(*fd, !=, -1);
 	rv = connect(*fd, (struct sockaddr *)&addr,
 		     sizeof(sa_family_t) + strlen(address + 1) + 1);

--- a/test/raft/lib/tcp.c
+++ b/test/raft/lib/tcp.c
@@ -69,9 +69,9 @@ int TcpServerAccept(struct TcpServer *s)
 
     size = sizeof(address);
 
-    socket = accept(s->socket, (struct sockaddr *)&address, &size);
+    socket = accept4(s->socket, (struct sockaddr *)&address, &size, SOCK_CLOEXEC);
     if (socket < 0) {
-        munit_errorf("tcp server: accept(): %s", strerror(errno));
+        munit_errorf("tcp server: accept4(): %s", strerror(errno));
     }
 
     return socket;
@@ -227,9 +227,9 @@ int test_tcp_accept(struct test_tcp *t)
 
     size = sizeof(address);
 
-    socket = accept(t->server.socket, (struct sockaddr *)&address, &size);
+    socket = accept4(t->server.socket, (struct sockaddr *)&address, &size, SOCK_CLOEXEC);
     if (socket < 0) {
-        munit_errorf("tcp: accept(): %s", strerror(errno));
+        munit_errorf("tcp: accept4(): %s", strerror(errno));
     }
 
     return socket;


### PR DESCRIPTION
On Linux 6.17+, AppArmor enforces `AF_UNIX` peer mediation. When the
`dqlite` listening socket FD is inherited by a child process (e.g.
`dnsmasq` spawned by LXD), AppArmor checks the child's profile for
accept permission on `connect()`, causing connections to be denied.

Fix this by passing `SOCK_CLOEXEC` to `socket()` so the FD is
automatically closed on `exec()`.

In `server.c`, the old code attempted to set close-on-exec via
`fcntl(fd, FD_CLOEXEC)`, but this was a bug: `FD_CLOEXEC` has the
integer value 1, which equals the `F_GETFD` command, so the call was
reading the flags instead of setting them. The flag was never
actually applied. The correct form would have been
`fcntl(fd, F_SETFD, FD_CLOEXEC)`, but using `SOCK_CLOEXEC` is
preferred because it is atomic (no race window between `socket()`
and a concurrent `fork()+exec()` in another thread).

In `transport.c`, there was no `CLOEXEC` handling at all.


The accidentally inherited FDs would be noticed on 6.17 kernels causing issues to LXD:

```
[5](https://github.com/canonical/lxd/actions/runs/24151769294/job/70481389830#step:22:466)
+ lxc exec m2 -- lxd init --preseed
Error: Failed to join cluster: Failed request to add member: Failed to get the address of the cluster leader: Failed to get dqlite client: failed to establish network connection: dial unix @58535: connect: permission denied
...
+ dmesg
... apparmor="DENIED" operation="connect" class="net" namespace="root//lxd-m1_<var-snap-lxd-common-lxd>" profile="lxd_dnsmasq-lxdbr0_</var/snap/lxd/common/lxd>" pid=13408 comm="lxd" family="unix" sock_type="stream" protocol=0 requested="send receive accept" denied="send accept" addr="@58535" peer_addr=none peer="unconfined"
...
```

Or Juju:

```
2026-02-11T17:08:33.894226+00:00 reactive-amd64-noble-medium-ps7-1-r-04f90c91f071 kernel: audit: type=1400 audit(1770829713.893:6232): apparmor="DENIED" operation="connect" class="net" info="failed af match" erro
r=-13 namespace="root//lxd-juju-ba1a06-0_<var-snap-lxd-common-lxd>" profile="snap.juju-db.mongod" pid=12439 comm="jujud" family="unix" sock_type="stream" protocol=0 requested="send receive accept" denied="send ac
cept" addr="@dqlite-3297041220608546238" peer_addr=none peer="unconfined"
```