### PR TITLE
chore: fix leak in tests

### DIFF
--- a/test/integration/test_node.c
+++ b/test/integration/test_node.c
@@ -173,6 +173,11 @@ TEST(node, stopBeforeStart, setUpLocal, tearDown, 0, node_params)
 	rv = dqlite_node_stop(f->node);
 	munit_assert_int(rv, ==, DQLITE_MISUSE);
 
+	rv = dqlite_node_start(f->node);
+	munit_assert_int(rv, ==, DQLITE_OK);
+	rv = dqlite_node_stop(f->node);
+	munit_assert_int(rv, ==, DQLITE_OK);
+
 	return MUNIT_OK;
 }
 
@@ -183,6 +188,15 @@ TEST(node, handoverBeforeStart, setUpLocal, tearDown, 0, node_params)
 
 	rv = dqlite_node_handover(f->node);
 	munit_assert_int(rv, ==, DQLITE_MISUSE);
+
+	rv = dqlite_node_start(f->node);
+	munit_assert_int(rv, ==, DQLITE_OK);
+
+	rv = dqlite_node_handover(f->node);
+	munit_assert_int(rv, ==, DQLITE_ERROR); // Can't handover in a single node cluster!
+
+	rv = dqlite_node_stop(f->node);
+	munit_assert_int(rv, ==, DQLITE_OK);
 
 	return MUNIT_OK;
 }


### PR DESCRIPTION
This PR fixes the tests memory leaks introduced by #873. We missed that as we are not running tests from people from outside of Canonical for security reasons.

Clearly that PR fixes only partially the issue as the problem is that the node is partially started during init. Fixing that however requires thinking carefully about what are the consequences and it is for now out of scope.