### PR TITLE
fix: preserve SQLITE_NULL type for NULL values in BOOLEAN / DATETIME columns

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -8,6 +8,11 @@
 static int value_type(sqlite3_stmt *stmt, int i)
 {
 	int type = sqlite3_column_type(stmt, i);
+
+	if (type == SQLITE_NULL) {
+		return SQLITE_NULL;
+	}
+
 	const char *column_type_name = sqlite3_column_decltype(stmt, i);
 	if (column_type_name != NULL) {
 		if ((strcasecmp(column_type_name, "DATETIME") == 0) ||
@@ -16,12 +21,11 @@ static int value_type(sqlite3_stmt *stmt, int i)
 			if (type == SQLITE_INTEGER) {
 				type = DQLITE_UNIXTIME;
 			} else {
-				dqlite_assert(type == SQLITE_TEXT ||
-				       type == SQLITE_NULL);
+				dqlite_assert(type == SQLITE_TEXT);
 				type = DQLITE_ISO8601;
 			}
 		} else if (strcasecmp(column_type_name, "BOOLEAN") == 0) {
-			dqlite_assert(type == SQLITE_INTEGER || type == SQLITE_NULL);
+			dqlite_assert(type == SQLITE_INTEGER);
 			type = DQLITE_BOOLEAN;
 		}
 	}

--- a/test/integration/test_client.c
+++ b/test/integration/test_client.c
@@ -180,3 +180,42 @@ TEST(client, semicolons, setUp, tearDown, 0, NULL)
 
 	return MUNIT_OK;
 }
+
+/* A NULL value must be encoded with the SQLITE_NULL type tag regardless of
+ * the column's declared type. */
+TEST(client, nullPreservedAcrossDeclaredTypes, setUp, tearDown, 0, NULL)
+{
+	struct fixture *f = data;
+	uint64_t last_insert_id;
+	uint64_t rows_affected;
+	struct row *row;
+	(void)params;
+
+	EXEC_SQL("CREATE TABLE t ("
+	         "  int_col       INTEGER,"
+	         "  text_col      TEXT,"
+	         "  real_col      REAL,"
+	         "  blob_col      BLOB,"
+	         "  bool_col      BOOLEAN,"
+	         "  datetime_col  DATETIME,"
+	         "  date_col      DATE,"
+	         "  timestamp_col TIMESTAMP)",
+	         &last_insert_id, &rows_affected);
+	EXEC_SQL("INSERT INTO t VALUES "
+	         "(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)",
+	         &last_insert_id, &rows_affected);
+
+	QUERY_SQL("SELECT int_col, text_col, real_col, blob_col, "
+	          "       bool_col, datetime_col, date_col, timestamp_col "
+	          "FROM t",
+	          &f->rows);
+	munit_assert_uint(f->rows.column_count, ==, 8);
+	row = f->rows.next;
+	munit_assert_not_null(row);
+	for (unsigned i = 0; i < f->rows.column_count; i++) {
+		munit_assert_int(row->values[i].type, ==, SQLITE_NULL);
+	}
+	munit_assert_ptr_null(row->next);
+
+	return MUNIT_OK;
+}


### PR DESCRIPTION
Fixes #882.

`value_type()` in `src/query.c` was remapping NULL values to
`DQLITE_BOOLEAN` / `DQLITE_ISO8601` based on the column's declared type,
so a NULL in a `BOOLEAN` column was sent on the wire as `BOOLEAN(11)`
with value 0 (indistinguishable from `FALSE`) and a NULL in a `DATETIME`
/ `DATE` / `TIMESTAMP` column was sent as `ISO8601(10)` with `""`. The
fix returns early when `sqlite3_column_type()` reports `SQLITE_NULL`,
matching plain SQLite's behaviour.

Adds a regression test
(`test/integration/test_client.c::client/nullPreservedAcrossDeclaredTypes`)
that asserts every column of a row of NULLs comes back with
`type == SQLITE_NULL`, covering `BOOLEAN`, `DATETIME`, `DATE`, `TIMESTAMP`
as well as the unaffected types as a sanity check.

Running the same code samples that reproduced the issue in #882
shows that all types appear correctly as `NULL`.

C (`null_types_repro.c`):
```
    === SQLite (sqlite3_column_type for each column) ===
      int_col       : NULL                              ok
      text_col      : NULL                              ok
      real_col      : NULL                              ok
      blob_col      : NULL                              ok
      bool_col      : NULL                              ok
      datetime_col  : NULL                              ok
      date_col      : NULL                              ok
      timestamp_col : NULL                              ok

    === dqlite (wire-level type tag from server) ===
      int_col       : NULL                              ok
      text_col      : NULL                              ok
      real_col      : NULL                              ok
      blob_col      : NULL                              ok
      bool_col      : NULL                              ok
      datetime_col  : NULL                              ok
      date_col      : NULL                              ok
      timestamp_col : NULL                              ok
```

Go (`main.go`, via go-dqlite):

```
    === SQLite ===
      int_col       : NULL                       ok
      text_col      : NULL                       ok
      real_col      : NULL                       ok
      blob_col      : NULL                       ok
      bool_col      : NULL                       ok
      datetime_col  : NULL                       ok
      date_col      : NULL                       ok
      timestamp_col : NULL                       ok

    === dqlite ===
      int_col       : NULL                       ok
      text_col      : NULL                       ok
      real_col      : NULL                       ok
      blob_col      : NULL                       ok
      bool_col      : NULL                       ok
      datetime_col  : NULL                       ok
      date_col      : NULL                       ok
      timestamp_col : NULL                       ok
```

Python (`null_types_repro.py`, via dqlite-client / dqlite-wire):

```
    === SQLite (stdlib sqlite3) ===
      int_col       : NULL                              ok
      text_col      : NULL                              ok
      real_col      : NULL                              ok
      blob_col      : NULL                              ok
      bool_col      : NULL                              ok
      datetime_col  : NULL                              ok
      date_col      : NULL                              ok
      timestamp_col : NULL                              ok

    === dqlite (wire-level type tag from server) ===
      int_col       : NULL                              ok
      text_col      : NULL                              ok
      real_col      : NULL                              ok
      blob_col      : NULL                              ok
      bool_col      : NULL                              ok
      datetime_col  : NULL                              ok
      date_col      : NULL                              ok
      timestamp_col : NULL                              ok
```