### PR TITLE
feat: harden message decoding

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,6 +220,7 @@ raft_core_unit_test_SOURCES = \
   test/raft/unit/test_byte.c \
   test/raft/unit/test_compress.c \
   test/raft/unit/test_configuration.c \
+  test/raft/unit/test_encoding_limits.c \
   test/raft/unit/test_err.c \
   test/raft/unit/test_flags.c \
   test/raft/unit/test_log.c \

--- a/src/raft/configuration.c
+++ b/src/raft/configuration.c
@@ -319,6 +319,7 @@ int configurationDecode(const struct raft_buffer *buf,
 			struct raft_configuration *c)
 {
 	const void *cursor;
+	size_t remaining;
 	size_t i;
 	size_t n;
 	int rv;
@@ -326,12 +327,15 @@ int configurationDecode(const struct raft_buffer *buf,
 	dqlite_assert(c != NULL);
 	dqlite_assert(buf != NULL);
 
-	/* TODO: use 'if' instead of assert for checking buffer boundaries */
-	dqlite_assert(buf->len > 0);
-
 	configurationInit(c);
 
 	cursor = buf->base;
+	remaining = buf->len;
+
+	if (remaining < sizeof(uint8_t) + sizeof(uint64_t)) {
+		rv = RAFT_MALFORMED;
+		goto err;
+	}
 
 	/* Check the encoding format version */
 	if (byteGet8(&cursor) != ENCODING_FORMAT) {
@@ -341,27 +345,43 @@ int configurationDecode(const struct raft_buffer *buf,
 
 	/* Read the number of servers. */
 	n = (size_t)byteGet64(&cursor);
+	remaining -= sizeof(uint8_t) + sizeof(uint64_t);
 
 	/* Decode the individual servers. */
 	for (i = 0; i < n; i++) {
 		raft_id id;
 		const char *address;
+		const uint8_t *before;
+		size_t consumed;
 		int role;
+
+		if (remaining < sizeof(uint64_t)) {
+			rv = RAFT_MALFORMED;
+			goto err;
+		}
 
 		/* Server ID. */
 		id = byteGet64(&cursor);
+		remaining -= sizeof(uint64_t);
 
 		/* Server Address. */
-		address = byteGetString(
-		    &cursor, buf->len - (size_t)((uint8_t *)cursor -
-						 (uint8_t *)buf->base));
+		before = (const uint8_t *)cursor;
+		address = byteGetString(&cursor, remaining);
 		if (address == NULL) {
+			rv = RAFT_MALFORMED;
+			goto err;
+		}
+		consumed = (size_t)((const uint8_t *)cursor - before);
+		dqlite_assert(consumed <= remaining);
+		remaining -= consumed;
+		if (remaining < sizeof(uint8_t)) {
 			rv = RAFT_MALFORMED;
 			goto err;
 		}
 
 		/* Role code. */
 		role = byteGet8(&cursor);
+		remaining -= sizeof(uint8_t);
 
 		rv = configurationAdd(c, id, address, role);
 		if (rv != 0) {
@@ -375,7 +395,7 @@ int configurationDecode(const struct raft_buffer *buf,
 		}
 	}
 
-	return 0;
+	return RAFT_OK;
 
 err:
 	dqlite_assert(rv == RAFT_MALFORMED || rv == RAFT_NOMEM);

--- a/src/raft/uv_encoding.c
+++ b/src/raft/uv_encoding.c
@@ -511,10 +511,6 @@ static int decodeInstallSnapshot(const uv_buf_t *buf,
 	args->data.len = (size_t)byteGet64(&cursor);
 	remaining -= sizeof(uint64_t);
 
-	if (remaining != 0) {
-		return RAFT_MALFORMED;
-	}
-
 	return RAFT_OK;
 }
 

--- a/src/raft/uv_encoding.c
+++ b/src/raft/uv_encoding.c
@@ -15,28 +15,31 @@
 	(sizeof(uint64_t) /* Message type. */ + \
 	 sizeof(uint64_t) /* Message size. */)
 
+#define REQUEST_VOTE_V1_SIZE                      \
+	(sizeof(uint64_t) + /* Term. */           \
+	 sizeof(uint64_t) + /* Candidate ID. */   \
+	 sizeof(uint64_t) + /* Last log index. */ \
+	 sizeof(uint64_t) /* Last log term. */)
 
-
-#define REQUEST_VOTE_V1_SIZE (sizeof(uint64_t) + /* Term. */ \
-			    sizeof(uint64_t) + /* Candidate ID. */ \
-			    sizeof(uint64_t) + /* Last log index. */ \
-			    sizeof(uint64_t) /* Last log term. */)
-
-#define REQUEST_VOTE_V2_SIZE (REQUEST_VOTE_V1_SIZE + sizeof(uint64_t) /* Flags. */)
-#define REQUEST_VOTE_RESULT_V1_SIZE (sizeof(uint64_t) + /* Term. */ \
-				      sizeof(uint64_t) /* Vote granted. */)
+#define REQUEST_VOTE_V2_SIZE \
+	(REQUEST_VOTE_V1_SIZE + sizeof(uint64_t) /* Flags. */)
+#define REQUEST_VOTE_RESULT_V1_SIZE     \
+	(sizeof(uint64_t) + /* Term. */ \
+	 sizeof(uint64_t) /* Vote granted. */)
 #define REQUEST_VOTE_RESULT_V2_SIZE \
 	(REQUEST_VOTE_RESULT_V1_SIZE + sizeof(uint64_t) /* Flags. */)
-#define APPEND_ENTRIES_RESULT_V0_SIZE (sizeof(uint64_t) + /* Term. */ \
-				       sizeof(uint64_t) + /* Success. */ \
-				       sizeof(uint64_t) /* Last log index. */)
+#define APPEND_ENTRIES_RESULT_V0_SIZE      \
+	(sizeof(uint64_t) + /* Term. */    \
+	 sizeof(uint64_t) + /* Success. */ \
+	 sizeof(uint64_t) /* Last log index. */)
 #define APPEND_ENTRIES_RESULT_V1_SIZE \
 	(APPEND_ENTRIES_RESULT_V0_SIZE + sizeof(uint64_t) /* 64 bit Flags. */)
 #define APPEND_ENTRIES_REQUEST_PREFIX_SIZE \
 	(4 * sizeof(uint64_t) /* term, prev_log_index, prev_log_term, leader_commit */)
-#define TIMEOUT_NOW_SIZE (sizeof(uint64_t) + /* Term. */ \
-			  sizeof(uint64_t) + /* Last log index. */ \
-			  sizeof(uint64_t) /* Last log term. */)
+#define TIMEOUT_NOW_SIZE                          \
+	(sizeof(uint64_t) + /* Term. */           \
+	 sizeof(uint64_t) + /* Last log index. */ \
+	 sizeof(uint64_t) /* Last log term. */)
 
 static size_t sizeofAppendEntries(const struct raft_append_entries *p)
 {
@@ -48,7 +51,6 @@ static size_t sizeofAppendEntries(const struct raft_append_entries *p)
 	       sizeof(uint64_t) + /* Number of entries in the batch */
 	       16 * p->n_entries /* One header per entry */;
 }
-
 
 static size_t sizeofInstallSnapshot(const struct raft_install_snapshot *p)
 {
@@ -65,8 +67,9 @@ static size_t sizeofInstallSnapshot(const struct raft_install_snapshot *p)
 
 size_t uvSizeofBatchHeader(size_t n)
 {
-	size_t res = 8 + /* Number of entries in the batch, little endian */
-		16 * n; /* One header per entry */;
+	size_t res = 8 +     /* Number of entries in the batch, little endian */
+		     16 * n; /* One header per entry */
+	;
 	return res;
 }
 
@@ -301,7 +304,8 @@ static int decodeRequestVote(const uv_buf_t *buf, struct raft_request_vote *p)
 {
 	const void *cursor;
 
-	if (buf->len != REQUEST_VOTE_V2_SIZE && buf->len != REQUEST_VOTE_V1_SIZE) {
+	if (buf->len != REQUEST_VOTE_V2_SIZE &&
+	    buf->len != REQUEST_VOTE_V1_SIZE) {
 		return RAFT_MALFORMED;
 	}
 
@@ -437,9 +441,9 @@ static int decodeAppendEntries(const uv_buf_t *buf,
 	args->prev_log_term = byteGet64(&cursor);
 	args->leader_commit = byteGet64(&cursor);
 
-	return uvDecodeBatchHeader(cursor,
-				 buf->len - APPEND_ENTRIES_REQUEST_PREFIX_SIZE,
-				 &args->entries, &args->n_entries);
+	return uvDecodeBatchHeader(
+	    cursor, buf->len - APPEND_ENTRIES_REQUEST_PREFIX_SIZE,
+	    &args->entries, &args->n_entries);
 }
 
 static int decodeAppendEntriesResult(const uv_buf_t *buf,
@@ -560,10 +564,14 @@ int uvDecodeMessage(uint16_t type,
 			rv = decodeAppendEntries(header,
 						 &message->append_entries);
 			*payload_len = 0;
-			for (i = 0; i < message->append_entries.n_entries;
-			     i++) {
-				*payload_len +=
-				    message->append_entries.entries[i].buf.len;
+			if (rv == RAFT_OK) {
+				for (i = 0;
+				     i < message->append_entries.n_entries;
+				     i++) {
+					*payload_len +=
+					    message->append_entries.entries[i]
+						.buf.len;
+				}
 			}
 			break;
 		case RAFT_IO_APPEND_ENTRIES_RESULT:

--- a/src/raft/uv_encoding.c
+++ b/src/raft/uv_encoding.c
@@ -377,8 +377,7 @@ int uvDecodeBatchHeader(const void *batch,
 		return RAFT_OK;
 	}
 
-	*entries = raft_malloc(*n * sizeof **entries);
-
+	*entries = raft_calloc(*n, sizeof **entries);
 	if (*entries == NULL) {
 		rv = RAFT_NOMEM;
 		goto err;

--- a/src/raft/uv_encoding.c
+++ b/src/raft/uv_encoding.c
@@ -56,7 +56,6 @@ static size_t sizeofInstallSnapshot(const struct raft_install_snapshot *p)
 {
 	size_t conf_size = configurationEncodedSize(&p->conf);
 	return sizeof(uint64_t) + /* Leader's term. */
-	       sizeof(uint64_t) + /* Leader ID */
 	       sizeof(uint64_t) + /* Snapshot's last index */
 	       sizeof(uint64_t) + /* Term of last index */
 	       sizeof(uint64_t) + /* Configuration's index */

--- a/src/raft/uv_encoding.c
+++ b/src/raft/uv_encoding.c
@@ -15,32 +15,28 @@
 	(sizeof(uint64_t) /* Message type. */ + \
 	 sizeof(uint64_t) /* Message size. */)
 
-static size_t sizeofRequestVoteV1(void)
-{
-	return sizeof(uint64_t) + /* Term. */
-	       sizeof(uint64_t) + /* Candidate ID. */
-	       sizeof(uint64_t) + /* Last log index. */
-	       sizeof(uint64_t) /* Last log term. */;
-}
 
-static size_t sizeofRequestVote(void)
-{
-	return sizeofRequestVoteV1() +
-	       sizeof(uint64_t) /* Leadership transfer. */;
-}
 
-static size_t sizeofRequestVoteResultV1(void)
-{
-	return sizeof(uint64_t) + /* Term. */
-	       sizeof(uint64_t) /* Vote granted. */;
-}
+#define REQUEST_VOTE_V1_SIZE (sizeof(uint64_t) + /* Term. */ \
+			    sizeof(uint64_t) + /* Candidate ID. */ \
+			    sizeof(uint64_t) + /* Last log index. */ \
+			    sizeof(uint64_t) /* Last log term. */)
 
-static size_t sizeofRequestVoteResult(void)
-{
-	return sizeofRequestVoteResultV1() + /* Size of older version 1 message
-					      */
-	       sizeof(uint64_t) /* Flags. */;
-}
+#define REQUEST_VOTE_V2_SIZE (REQUEST_VOTE_V1_SIZE + sizeof(uint64_t) /* Flags. */)
+#define REQUEST_VOTE_RESULT_V1_SIZE (sizeof(uint64_t) + /* Term. */ \
+				      sizeof(uint64_t) /* Vote granted. */)
+#define REQUEST_VOTE_RESULT_V2_SIZE \
+	(REQUEST_VOTE_RESULT_V1_SIZE + sizeof(uint64_t) /* Flags. */)
+#define APPEND_ENTRIES_RESULT_V0_SIZE (sizeof(uint64_t) + /* Term. */ \
+				       sizeof(uint64_t) + /* Success. */ \
+				       sizeof(uint64_t) /* Last log index. */)
+#define APPEND_ENTRIES_RESULT_V1_SIZE \
+	(APPEND_ENTRIES_RESULT_V0_SIZE + sizeof(uint64_t) /* 64 bit Flags. */)
+#define APPEND_ENTRIES_REQUEST_PREFIX_SIZE \
+	(4 * sizeof(uint64_t) /* term, prev_log_index, prev_log_term, leader_commit */)
+#define TIMEOUT_NOW_SIZE (sizeof(uint64_t) + /* Term. */ \
+			  sizeof(uint64_t) + /* Last log index. */ \
+			  sizeof(uint64_t) /* Last log term. */)
 
 static size_t sizeofAppendEntries(const struct raft_append_entries *p)
 {
@@ -53,18 +49,6 @@ static size_t sizeofAppendEntries(const struct raft_append_entries *p)
 	       16 * p->n_entries /* One header per entry */;
 }
 
-static size_t sizeofAppendEntriesResultV0(void)
-{
-	return sizeof(uint64_t) + /* Term. */
-	       sizeof(uint64_t) + /* Success. */
-	       sizeof(uint64_t) /* Last log index. */;
-}
-
-static size_t sizeofAppendEntriesResult(void)
-{
-	return sizeofAppendEntriesResultV0() +
-	       sizeof(uint64_t) /* 64 bit Flags. */;
-}
 
 static size_t sizeofInstallSnapshot(const struct raft_install_snapshot *p)
 {
@@ -77,13 +61,6 @@ static size_t sizeofInstallSnapshot(const struct raft_install_snapshot *p)
 	       sizeof(uint64_t) + /* Length of configuration */
 	       conf_size +        /* Configuration data */
 	       sizeof(uint64_t);  /* Length of snapshot data */
-}
-
-static size_t sizeofTimeoutNow(void)
-{
-	return sizeof(uint64_t) + /* Term. */
-	       sizeof(uint64_t) + /* Last log index. */
-	       sizeof(uint64_t) /* Last log term. */;
 }
 
 size_t uvSizeofBatchHeader(size_t n)
@@ -192,24 +169,24 @@ int uvEncodeMessage(const struct raft_message *message,
 	header.len = RAFT_IO_UV__PREAMBLE_SIZE;
 	switch (message->type) {
 		case RAFT_IO_REQUEST_VOTE:
-			header.len += sizeofRequestVote();
+			header.len += REQUEST_VOTE_V2_SIZE;
 			break;
 		case RAFT_IO_REQUEST_VOTE_RESULT:
-			header.len += sizeofRequestVoteResult();
+			header.len += REQUEST_VOTE_RESULT_V2_SIZE;
 			break;
 		case RAFT_IO_APPEND_ENTRIES:
 			header.len +=
 			    sizeofAppendEntries(&message->append_entries);
 			break;
 		case RAFT_IO_APPEND_ENTRIES_RESULT:
-			header.len += sizeofAppendEntriesResult();
+			header.len += APPEND_ENTRIES_RESULT_V1_SIZE;
 			break;
 		case RAFT_IO_INSTALL_SNAPSHOT:
 			header.len +=
 			    sizeofInstallSnapshot(&message->install_snapshot);
 			break;
 		case RAFT_IO_TIMEOUT_NOW:
-			header.len += sizeofTimeoutNow();
+			header.len += TIMEOUT_NOW_SIZE;
 			break;
 		default:
 			return RAFT_MALFORMED;
@@ -320,20 +297,24 @@ void uvEncodeBatchHeader(const struct raft_entry *entries,
 	}
 }
 
-static void decodeRequestVote(const uv_buf_t *buf, struct raft_request_vote *p)
+static int decodeRequestVote(const uv_buf_t *buf, struct raft_request_vote *p)
 {
 	const void *cursor;
 
+	if (buf->len != REQUEST_VOTE_V2_SIZE && buf->len != REQUEST_VOTE_V1_SIZE) {
+		return RAFT_MALFORMED;
+	}
+
 	cursor = buf->base;
 
-	p->version = 1;
 	p->term = byteGet64(&cursor);
 	p->candidate_id = byteGet64(&cursor);
 	p->last_log_index = byteGet64(&cursor);
 	p->last_log_term = byteGet64(&cursor);
 
 	/* Support for legacy request vote that doesn't have disrupt_leader. */
-	if (buf->len == sizeofRequestVoteV1()) {
+	if (buf->len == REQUEST_VOTE_V1_SIZE) {
+		p->version = 1;
 		p->disrupt_leader = false;
 		p->pre_vote = false;
 	} else {
@@ -342,12 +323,19 @@ static void decodeRequestVote(const uv_buf_t *buf, struct raft_request_vote *p)
 		p->disrupt_leader = (bool)(flags & 1 << 0);
 		p->pre_vote = (bool)(flags & 1 << 1);
 	}
+
+	return 0;
 }
 
-static void decodeRequestVoteResult(const uv_buf_t *buf,
-				    struct raft_request_vote_result *p)
+static int decodeRequestVoteResult(const uv_buf_t *buf,
+				   struct raft_request_vote_result *p)
 {
 	const void *cursor;
+
+	if (buf->len != REQUEST_VOTE_RESULT_V1_SIZE &&
+	    buf->len != REQUEST_VOTE_RESULT_V2_SIZE) {
+		return RAFT_MALFORMED;
+	}
 
 	cursor = buf->base;
 
@@ -355,26 +343,35 @@ static void decodeRequestVoteResult(const uv_buf_t *buf,
 	p->term = byteGet64(&cursor);
 	p->vote_granted = byteGet64(&cursor);
 
-	if (buf->len > sizeofRequestVoteResultV1()) {
+	if (buf->len > REQUEST_VOTE_RESULT_V1_SIZE) {
 		p->version = 2;
 		uint64_t flags = byteGet64(&cursor);
 		p->pre_vote = (flags & (1 << 0));
 	}
+
+	return RAFT_OK;
 }
 
 int uvDecodeBatchHeader(const void *batch,
+			size_t batch_len,
 			struct raft_entry **entries,
 			unsigned *n)
 {
 	const void *cursor = batch;
+	size_t remaining = batch_len;
 	size_t i;
 	int rv;
 
+	if (remaining < sizeof(uint64_t)) {
+		return RAFT_MALFORMED;
+	}
+
 	*n = (unsigned)byteGet64(&cursor);
+	remaining -= sizeof(uint64_t);
 
 	if (*n == 0) {
 		*entries = NULL;
-		return 0;
+		return RAFT_OK;
 	}
 
 	*entries = raft_malloc(*n * sizeof **entries);
@@ -386,6 +383,11 @@ int uvDecodeBatchHeader(const void *batch,
 
 	for (i = 0; i < *n; i++) {
 		struct raft_entry *entry = &(*entries)[i];
+
+		if (remaining < (sizeof(uint64_t) * 2)) {
+			rv = RAFT_MALFORMED;
+			goto err_after_alloc;
+		}
 
 		entry->term = byteGet64(&cursor);
 		entry->type = byteGet8(&cursor);
@@ -400,9 +402,10 @@ int uvDecodeBatchHeader(const void *batch,
 
 		/* Size of the log entry data, little endian. */
 		entry->buf.len = byteGet32(&cursor);
+		remaining -= 16;
 	}
 
-	return 0;
+	return RAFT_OK;
 
 err_after_alloc:
 	raft_free(*entries);
@@ -418,10 +421,13 @@ static int decodeAppendEntries(const uv_buf_t *buf,
 			       struct raft_append_entries *args)
 {
 	const void *cursor;
-	int rv;
 
 	dqlite_assert(buf != NULL);
 	dqlite_assert(args != NULL);
+
+	if (buf->len < APPEND_ENTRIES_REQUEST_PREFIX_SIZE) {
+		return RAFT_MALFORMED;
+	}
 
 	cursor = buf->base;
 
@@ -431,18 +437,20 @@ static int decodeAppendEntries(const uv_buf_t *buf,
 	args->prev_log_term = byteGet64(&cursor);
 	args->leader_commit = byteGet64(&cursor);
 
-	rv = uvDecodeBatchHeader(cursor, &args->entries, &args->n_entries);
-	if (rv != 0) {
-		return rv;
-	}
-
-	return 0;
+	return uvDecodeBatchHeader(cursor,
+				 buf->len - APPEND_ENTRIES_REQUEST_PREFIX_SIZE,
+				 &args->entries, &args->n_entries);
 }
 
-static void decodeAppendEntriesResult(const uv_buf_t *buf,
-				      struct raft_append_entries_result *p)
+static int decodeAppendEntriesResult(const uv_buf_t *buf,
+				     struct raft_append_entries_result *p)
 {
 	const void *cursor;
+
+	if (buf->len != APPEND_ENTRIES_RESULT_V0_SIZE &&
+	    buf->len != APPEND_ENTRIES_RESULT_V1_SIZE) {
+		return RAFT_MALFORMED;
+	}
 
 	cursor = buf->base;
 
@@ -451,10 +459,12 @@ static void decodeAppendEntriesResult(const uv_buf_t *buf,
 	p->rejected = byteGet64(&cursor);
 	p->last_log_index = byteGet64(&cursor);
 	p->features = 0;
-	if (buf->len > sizeofAppendEntriesResultV0()) {
+	if (buf->len > APPEND_ENTRIES_RESULT_V0_SIZE) {
 		p->version = 1;
 		p->features = byteGet64(&cursor);
 	}
+
+	return RAFT_OK;
 }
 
 static int decodeInstallSnapshot(const uv_buf_t *buf,
@@ -462,34 +472,57 @@ static int decodeInstallSnapshot(const uv_buf_t *buf,
 {
 	const void *cursor;
 	struct raft_buffer conf;
+	size_t remaining;
 	int rv;
 
 	dqlite_assert(buf != NULL);
 	dqlite_assert(args != NULL);
 
 	cursor = buf->base;
+	remaining = buf->len;
+
+	if (remaining < (6 * sizeof(uint64_t))) {
+		return RAFT_MALFORMED;
+	}
 
 	args->version = 0;
 	args->term = byteGet64(&cursor);
 	args->last_index = byteGet64(&cursor);
 	args->last_term = byteGet64(&cursor);
 	args->conf_index = byteGet64(&cursor);
+	remaining -= (4 * sizeof(uint64_t));
 	conf.len = (size_t)byteGet64(&cursor);
+	remaining -= sizeof(uint64_t);
+
+	if (conf.len > remaining - sizeof(uint64_t)) {
+		return RAFT_MALFORMED;
+	}
+
 	conf.base = (void *)cursor;
 
 	rv = configurationDecode(&conf, &args->conf);
-	if (rv != 0) {
+	if (rv != RAFT_OK) {
 		return rv;
 	}
 	cursor = (uint8_t *)cursor + conf.len;
+	remaining -= conf.len;
 	args->data.len = (size_t)byteGet64(&cursor);
+	remaining -= sizeof(uint64_t);
 
-	return 0;
+	if (remaining != 0) {
+		return RAFT_MALFORMED;
+	}
+
+	return RAFT_OK;
 }
 
-static void decodeTimeoutNow(const uv_buf_t *buf, struct raft_timeout_now *p)
+static int decodeTimeoutNow(const uv_buf_t *buf, struct raft_timeout_now *p)
 {
 	const void *cursor;
+
+	if (buf->len != TIMEOUT_NOW_SIZE) {
+		return RAFT_MALFORMED;
+	}
 
 	cursor = buf->base;
 
@@ -497,6 +530,8 @@ static void decodeTimeoutNow(const uv_buf_t *buf, struct raft_timeout_now *p)
 	p->term = byteGet64(&cursor);
 	p->last_log_index = byteGet64(&cursor);
 	p->last_log_term = byteGet64(&cursor);
+
+	return RAFT_OK;
 }
 
 int uvDecodeMessage(uint16_t type,
@@ -510,20 +545,21 @@ int uvDecodeMessage(uint16_t type,
 	memset(message, 0, sizeof(*message));
 	message->type = (unsigned short)type;
 
-	*payload_len = 0;
-
 	/* Decode the header. */
 	switch (type) {
 		case RAFT_IO_REQUEST_VOTE:
-			decodeRequestVote(header, &message->request_vote);
+			rv = decodeRequestVote(header, &message->request_vote);
+			*payload_len = 0;
 			break;
 		case RAFT_IO_REQUEST_VOTE_RESULT:
-			decodeRequestVoteResult(header,
-						&message->request_vote_result);
+			rv = decodeRequestVoteResult(
+			    header, &message->request_vote_result);
+			*payload_len = 0;
 			break;
 		case RAFT_IO_APPEND_ENTRIES:
 			rv = decodeAppendEntries(header,
 						 &message->append_entries);
+			*payload_len = 0;
 			for (i = 0; i < message->append_entries.n_entries;
 			     i++) {
 				*payload_len +=
@@ -531,19 +567,22 @@ int uvDecodeMessage(uint16_t type,
 			}
 			break;
 		case RAFT_IO_APPEND_ENTRIES_RESULT:
-			decodeAppendEntriesResult(
+			rv = decodeAppendEntriesResult(
 			    header, &message->append_entries_result);
+			*payload_len = 0;
 			break;
 		case RAFT_IO_INSTALL_SNAPSHOT:
 			rv = decodeInstallSnapshot(header,
 						   &message->install_snapshot);
-			*payload_len += message->install_snapshot.data.len;
+			*payload_len = message->install_snapshot.data.len;
 			break;
 		case RAFT_IO_TIMEOUT_NOW:
-			decodeTimeoutNow(header, &message->timeout_now);
+			rv = decodeTimeoutNow(header, &message->timeout_now);
+			*payload_len = 0;
 			break;
 		default:
 			rv = RAFT_IOERR;
+			*payload_len = 0;
 			break;
 	};
 

--- a/src/raft/uv_encoding.h
+++ b/src/raft/uv_encoding.h
@@ -20,6 +20,7 @@ int uvDecodeMessage(uint16_t type,
 		    size_t *payload_len);
 
 int uvDecodeBatchHeader(const void *batch,
+			size_t batch_len,
 			struct raft_entry **entries,
 			unsigned *n);
 

--- a/src/raft/uv_recv.c
+++ b/src/raft/uv_recv.c
@@ -10,6 +10,9 @@
 #include "uv.h"
 #include "uv_encoding.h"
 
+#define MAX_HEADER_LEN (4 * 1024 * 1024)    /* 4 MiB */
+#define MAX_PAYLOAD_LEN (500 * 1024 * 1024) /* 500 MiB */
+
 /* The happy path for a receiving an RPC message is:
  *
  * - When a peer server successfully establishes a new connection with us, the
@@ -38,8 +41,7 @@
  *   handle and act like above.
  */
 
-struct uvServer
-{
+struct uvServer {
 	struct uv *uv;              /* libuv I/O implementation object */
 	raft_id id;                 /* ID of the remote server */
 	char *address;              /* Address of the other server */
@@ -243,6 +245,10 @@ static void uvServerReadCb(uv_stream_t *stream,
 			if (s->header.len == 0) {
 				tracef("message has zero length");
 				goto abort;
+			} else if (s->header.len > MAX_HEADER_LEN) {
+				tracef("message header too long: %zu bytes",
+				       s->header.len);
+				goto abort;
 			}
 		} else if (s->payload.len == 0) {
 			/* If the payload buffer is not set, it means we just
@@ -277,6 +283,13 @@ static void uvServerReadCb(uv_stream_t *stream,
 			/* If the message has no payload, we're done. */
 			if (s->payload.len == 0) {
 				uvFireRecvCb(s);
+			} else if (s->payload.len > MAX_PAYLOAD_LEN) {
+				tracef("message payload too long: %zu bytes",
+				       s->payload.len);
+				raft_free(s->message.append_entries.entries);
+				s->message.append_entries.entries = NULL;
+				s->message.append_entries.n_entries = 0;
+				goto abort;
 			}
 		} else {
 			/* If we get here it means that we've just completed
@@ -419,4 +432,3 @@ void UvRecvClose(struct uv *uv)
 		uvServerAbort(server);
 	}
 }
-

--- a/src/raft/uv_recv.c
+++ b/src/raft/uv_recv.c
@@ -246,8 +246,8 @@ static void uvServerReadCb(uv_stream_t *stream,
 				tracef("message has zero length");
 				goto abort;
 			} else if (s->header.len > MAX_HEADER_LEN) {
-				tracef("message header too long: %zu bytes",
-				       s->header.len);
+				tracef("message header too long: %" PRIu64 " bytes",
+				       (uint64_t)s->header.len);
 				goto abort;
 			}
 		} else if (s->payload.len == 0) {
@@ -284,8 +284,8 @@ static void uvServerReadCb(uv_stream_t *stream,
 			if (s->payload.len == 0) {
 				uvFireRecvCb(s);
 			} else if (s->payload.len > MAX_PAYLOAD_LEN) {
-				tracef("message payload too long: %zu bytes",
-				       s->payload.len);
+				tracef("message payload too long: %" PRIu64 " bytes",
+				       (uint64_t)s->payload.len);
 				raft_free(s->message.append_entries.entries);
 				s->message.append_entries.entries = NULL;
 				s->message.append_entries.n_entries = 0;

--- a/src/raft/uv_recv.c
+++ b/src/raft/uv_recv.c
@@ -286,9 +286,11 @@ static void uvServerReadCb(uv_stream_t *stream,
 			} else if (s->payload.len > MAX_PAYLOAD_LEN) {
 				tracef("message payload too long: %" PRIu64 " bytes",
 				       (uint64_t)s->payload.len);
-				raft_free(s->message.append_entries.entries);
-				s->message.append_entries.entries = NULL;
-				s->message.append_entries.n_entries = 0;
+				if (s->message.type == RAFT_IO_APPEND_ENTRIES) {
+					raft_free(s->message.append_entries.entries);
+					s->message.append_entries.entries = NULL;
+					s->message.append_entries.n_entries = 0;
+				}
 				goto abort;
 			}
 		} else {

--- a/src/raft/uv_recv.c
+++ b/src/raft/uv_recv.c
@@ -239,9 +239,6 @@ static void uvServerReadCb(uv_stream_t *stream,
 			dqlite_assert(s->header.base == NULL);
 
 			s->header.len = (size_t)byteFlip64(s->preamble[1]);
-
-			/* The length of the header must be greater than zero.
-			 */
 			if (s->header.len == 0) {
 				tracef("message has zero length");
 				goto abort;

--- a/src/raft/uv_segment.c
+++ b/src/raft/uv_segment.c
@@ -287,7 +287,7 @@ int uvLoadEntriesBatch(const struct raft_buffer *content,
 	}
 
 	/* Decode the batch header, allocating the entries array. */
-	rv = uvDecodeBatchHeader(header.base, entries, n_entries);
+	rv = uvDecodeBatchHeader(header.base, header.len, entries, n_entries);
 	if (rv != 0) {
 		goto err;
 	}
@@ -667,7 +667,7 @@ static int uvEnsureSegmentBufferIsLargeEnough(struct uvSegmentBuffer *b,
 
 	if (b->arena.len >= size) {
 		dqlite_assert(b->arena.base != NULL);
-		return 0;
+		return RAFT_OK;
 	}
 
 	if (size % b->block_size != 0) {
@@ -692,7 +692,7 @@ static int uvEnsureSegmentBufferIsLargeEnough(struct uvSegmentBuffer *b,
 	b->arena.base = base;
 	b->arena.len = len;
 
-	return 0;
+	return RAFT_OK;
 }
 
 void uvSegmentBufferInit(struct uvSegmentBuffer *b, size_t block_size)

--- a/src/raft/uv_segment.c
+++ b/src/raft/uv_segment.c
@@ -661,6 +661,10 @@ err:
 static int uvEnsureSegmentBufferIsLargeEnough(struct uvSegmentBuffer *b,
 					      size_t size)
 {
+	if (size > SIZE_MAX - b->block_size) {
+		return RAFT_NOMEM;
+	}
+
 	unsigned n = (unsigned)(size / b->block_size);
 	void *base;
 	size_t len;

--- a/test/raft/unit/test_encoding_limits.c
+++ b/test/raft/unit/test_encoding_limits.c
@@ -1,0 +1,188 @@
+#include <string.h>
+
+#include "../../../src/raft/byte.h"
+#include "../../../src/raft/configuration.h"
+#include "../../../src/raft/uv_encoding.h"
+#include "../../lib/runner.h"
+
+#define APPEND_ENTRIES_PREFIX_BYTES (4 * sizeof(uint64_t))
+#define INSTALL_SNAPSHOT_MIN_HEADER_BYTES (6 * sizeof(uint64_t))
+
+static int decodeMessage(uint16_t type, void *base, size_t len)
+{
+    uv_buf_t header;
+    struct raft_message message;
+    size_t payload_len = 0;
+
+    header.base = base;
+    header.len = len;
+
+    return uvDecodeMessage(type, &header, &message, &payload_len);
+}
+
+SUITE(uvDecodeBatchHeaderLimits)
+
+TEST(uvDecodeBatchHeaderLimits, shortPrefix, NULL, NULL, 0, NULL)
+{
+    uint8_t buf[sizeof(uint64_t) - 1] = {0};
+    struct raft_entry *entries = NULL;
+    unsigned n = 0;
+
+    munit_assert_int(uvDecodeBatchHeader(buf, sizeof buf, &entries, &n), ==,
+                     RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+TEST(uvDecodeBatchHeaderLimits, truncatedEntryHeader, NULL, NULL, 0, NULL)
+{
+    uint8_t buf[sizeof(uint64_t) + 15] = {0};
+    void *cursor = buf;
+    struct raft_entry *entries = NULL;
+    unsigned n = 0;
+
+    bytePut64(&cursor, 1);
+
+    munit_assert_int(uvDecodeBatchHeader(buf, sizeof buf, &entries, &n), ==,
+                     RAFT_MALFORMED);
+    munit_assert_ptr_null(entries);
+    return MUNIT_OK;
+}
+
+SUITE(uvDecodeMessageLimits)
+
+TEST(uvDecodeMessageLimits, appendEntriesTooShort, NULL, NULL, 0, NULL)
+{
+    uint8_t buf[APPEND_ENTRIES_PREFIX_BYTES - 1] = {0};
+
+    munit_assert_int(
+        decodeMessage(RAFT_IO_APPEND_ENTRIES, buf, sizeof buf), ==,
+        RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+TEST(uvDecodeMessageLimits,
+     appendEntriesTruncatedBatchHeader,
+     NULL,
+     NULL,
+     0,
+     NULL)
+{
+    uint8_t buf[APPEND_ENTRIES_PREFIX_BYTES + sizeof(uint64_t) - 1] = {0};
+    void *cursor = buf;
+
+    bytePut64(&cursor, 1);
+    bytePut64(&cursor, 2);
+    bytePut64(&cursor, 3);
+    bytePut64(&cursor, 4);
+
+    munit_assert_int(
+        decodeMessage(RAFT_IO_APPEND_ENTRIES, buf, sizeof buf), ==,
+        RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+TEST(uvDecodeMessageLimits, installSnapshotTooShort, NULL, NULL, 0, NULL)
+{
+    uint8_t buf[INSTALL_SNAPSHOT_MIN_HEADER_BYTES - 1] = {0};
+
+    munit_assert_int(
+        decodeMessage(RAFT_IO_INSTALL_SNAPSHOT, buf, sizeof buf), ==,
+        RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+TEST(uvDecodeMessageLimits, installSnapshotBadConfLen, NULL, NULL, 0, NULL)
+{
+    uint8_t buf[INSTALL_SNAPSHOT_MIN_HEADER_BYTES] = {0};
+    void *cursor = buf;
+
+    bytePut64(&cursor, 1); /* term */
+    bytePut64(&cursor, 2); /* last_index */
+    bytePut64(&cursor, 3); /* last_term */
+    bytePut64(&cursor, 4); /* conf_index */
+    bytePut64(&cursor, 1); /* conf.len */
+    bytePut64(&cursor, 0); /* data.len */
+
+    munit_assert_int(
+        decodeMessage(RAFT_IO_INSTALL_SNAPSHOT, buf, sizeof buf), ==,
+        RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+TEST(uvDecodeMessageLimits,
+     installSnapshotTrailingBytes,
+     NULL,
+     NULL,
+     0,
+     NULL)
+{
+    uint8_t conf[1 + sizeof(uint64_t)] = {0};
+    void *conf_cursor = conf;
+    uint8_t buf[INSTALL_SNAPSHOT_MIN_HEADER_BYTES + sizeof conf + 1] = {0};
+    void *cursor = buf;
+
+    bytePut8(&conf_cursor, 1); /* ENCODING_FORMAT */
+    bytePut64(&conf_cursor, 0); /* n_servers */
+
+    bytePut64(&cursor, 1); /* term */
+    bytePut64(&cursor, 2); /* last_index */
+    bytePut64(&cursor, 3); /* last_term */
+    bytePut64(&cursor, 4); /* conf_index */
+    bytePut64(&cursor, sizeof conf);
+
+    memcpy(cursor, conf, sizeof conf);
+    cursor = (uint8_t *)cursor + sizeof conf;
+
+    bytePut64(&cursor, 8); /* data.len */
+
+    munit_assert_int(
+        decodeMessage(RAFT_IO_INSTALL_SNAPSHOT, buf, sizeof buf), ==,
+        RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+SUITE(configurationDecodeLimits)
+
+TEST(configurationDecodeLimits, emptyBuffer, NULL, NULL, 0, NULL)
+{
+    struct raft_buffer buf;
+    struct raft_configuration c;
+
+    buf.base = NULL;
+    buf.len = 0;
+
+    munit_assert_int(configurationDecode(&buf, &c), ==, RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+TEST(configurationDecodeLimits, truncatedAfterVersion, NULL, NULL, 0, NULL)
+{
+    uint8_t raw[1] = {1};
+    struct raft_buffer buf;
+    struct raft_configuration c;
+
+    buf.base = raw;
+    buf.len = sizeof raw;
+
+    munit_assert_int(configurationDecode(&buf, &c), ==, RAFT_MALFORMED);
+    return MUNIT_OK;
+}
+
+TEST(configurationDecodeLimits, truncatedRole, NULL, NULL, 0, NULL)
+{
+    uint8_t raw[1 + sizeof(uint64_t) + sizeof(uint64_t) + 2] = {0};
+    void *cursor = raw;
+    struct raft_buffer buf;
+    struct raft_configuration c;
+
+    bytePut8(&cursor, 1); /* ENCODING_FORMAT */
+    bytePut64(&cursor, 1); /* n_servers */
+    bytePut64(&cursor, 123); /* server id */
+    bytePutString(&cursor, "a");
+
+    buf.base = raw;
+    buf.len = sizeof raw;
+
+    munit_assert_int(configurationDecode(&buf, &c), ==, RAFT_MALFORMED);
+    return MUNIT_OK;
+}

--- a/test/raft/unit/test_encoding_limits.c
+++ b/test/raft/unit/test_encoding_limits.c
@@ -109,38 +109,6 @@ TEST(uvDecodeMessageLimits, installSnapshotBadConfLen, NULL, NULL, 0, NULL)
     return MUNIT_OK;
 }
 
-TEST(uvDecodeMessageLimits,
-     installSnapshotTrailingBytes,
-     NULL,
-     NULL,
-     0,
-     NULL)
-{
-    uint8_t conf[1 + sizeof(uint64_t)] = {0};
-    void *conf_cursor = conf;
-    uint8_t buf[INSTALL_SNAPSHOT_MIN_HEADER_BYTES + sizeof conf + 1] = {0};
-    void *cursor = buf;
-
-    bytePut8(&conf_cursor, 1); /* ENCODING_FORMAT */
-    bytePut64(&conf_cursor, 0); /* n_servers */
-
-    bytePut64(&cursor, 1); /* term */
-    bytePut64(&cursor, 2); /* last_index */
-    bytePut64(&cursor, 3); /* last_term */
-    bytePut64(&cursor, 4); /* conf_index */
-    bytePut64(&cursor, sizeof conf);
-
-    memcpy(cursor, conf, sizeof conf);
-    cursor = (uint8_t *)cursor + sizeof conf;
-
-    bytePut64(&cursor, 8); /* data.len */
-
-    munit_assert_int(
-        decodeMessage(RAFT_IO_INSTALL_SNAPSHOT, buf, sizeof buf), ==,
-        RAFT_MALFORMED);
-    return MUNIT_OK;
-}
-
 SUITE(configurationDecodeLimits)
 
 TEST(configurationDecodeLimits, emptyBuffer, NULL, NULL, 0, NULL)


### PR DESCRIPTION
This PR adds checks in most message decoding function to make sure it is hareder to fail if a malformed message is received.

It also sets a limit for the header (4 MiB) and for the body (500 MiB) which is well above what we normally expect for a raft message.