### PR TITLE
README: add dqlite-utils note

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,16 @@ sudo apt update
 sudo apt install libdqlite-dev
 ```
 
-Debugging
+Operating
 ---------
 
-To inspect the state of a running dqlite instance or to create a snapshot of data to load onto a node, install the `dqlite-utils` program:
+To inspect the state of a running dqlite instance, create a snapshot of data to load onto a node or even to inspect past database states, install `dqlite-utils`:
 
 ```bash
 sudo snap install dqlite-utils --classic
 ```
 
-Then, run `dqlite-utils --dir /path/to/data-dir`.
-See the [dqlite documentation](https://canonical.com/dqlite/docs) for more guidance.
+See the [dqlite documentation](https://canonical.com/dqlite/docs) for more information.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ sudo apt update
 sudo apt install libdqlite-dev
 ```
 
+Debugging
+---------
+
+To inspect the state of a running dqlite instance or to create a snapshot of data to load onto a node, install the `dqlite-utils` program:
+
+```bash
+sudo snap install dqlite-utils --classic
+```
+
+Then, run `dqlite-utils --dir /path/to/data-dir`.
+See the [dqlite documentation](https://canonical.com/dqlite/docs) for more guidance.
+
 Contributing
 ------------
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -49,6 +49,17 @@ sudo apt-get update
 sudo apt-get install libdqlite-dev
 ```
 
+## 调试
+
+要检查正在运行的 dqlite 实例的状态，或创建数据快照以加载到节点上，请安装 `dqlite-utils` 程序：
+
+```bash
+sudo snap install dqlite-utils --classic
+```
+
+然后运行 `dqlite-utils --dir /path/to/data-dir`。
+获取更多指导，请参阅 [dqlite 文档](https://canonical.com/dqlite/docs)。
+
 ## 源码构建
 
 为了编译构建libdqlite，您需要准备：

--- a/README_CH.md
+++ b/README_CH.md
@@ -51,13 +51,13 @@ sudo apt-get install libdqlite-dev
 
 ## 运维
 
-要检查正在运行的 dqlite 实例的状态，创建数据快照以加载到节点上，甚至检查过去的数据库状态，请安装 `dqlite-utils`：
+若要检查正在运行的 dqlite 实例的状态、创建数据快照以加载到节点上、甚至检查过去的数据库状态，请安装 `dqlite-utils`：
 
 ```bash
 sudo snap install dqlite-utils --classic
 ```
 
-获取更多信息，请参阅 [dqlite 文档](https://canonical.com/dqlite/docs)。
+如需了解更多信息，请参阅 [dqlite 文档](https://canonical.com/dqlite/docs)。
 
 ## 源码构建
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -49,16 +49,15 @@ sudo apt-get update
 sudo apt-get install libdqlite-dev
 ```
 
-## 调试
+## 运维
 
-要检查正在运行的 dqlite 实例的状态，或创建数据快照以加载到节点上，请安装 `dqlite-utils` 程序：
+要检查正在运行的 dqlite 实例的状态，创建数据快照以加载到节点上，甚至检查过去的数据库状态，请安装 `dqlite-utils`：
 
 ```bash
 sudo snap install dqlite-utils --classic
 ```
 
-然后运行 `dqlite-utils --dir /path/to/data-dir`。
-获取更多指导，请参阅 [dqlite 文档](https://canonical.com/dqlite/docs)。
+获取更多信息，请参阅 [dqlite 文档](https://canonical.com/dqlite/docs)。
 
 ## 源码构建
 


### PR DESCRIPTION
This PR adds a note on `dqlite-utils` and into the readme under a new 'debugging' section.

Content is replicated in the simplified chinese readme too
