### PR TITLE
chore: remove useless tracing interface

### DIFF
--- a/src/raft.h
+++ b/src/raft.h
@@ -579,38 +579,6 @@ struct raft_io_async_work
 	raft_io_async_work_cb cb; /* Request callback */
 };
 
-/**
- * Customizable tracer, for debugging purposes.
- */
-struct raft_tracer
-{
-	/**
-	 * Implementation-defined state object.
-	 */
-	void *impl;
-
-	/**
-	 * Whether this tracer should emit messages.
-	 */
-	bool enabled;
-
-	/**
-	 * Trace level.
-	 */
-	unsigned level;
-
-	/**
-	 * Emit the given trace message, possibly decorating it with the
-	 * provided metadata.
-	 */
-	void (*emit)(struct raft_tracer *t,
-		     const char *file,
-		     unsigned int line,
-		     const char *func,
-		     unsigned int level,
-		     const char *message);
-};
-
 struct raft_io; /* Forward declaration. */
 
 /**
@@ -1559,12 +1527,6 @@ RAFT_API int raft_uv_set_snapshot_compression(struct raft_io *io,
  */
 RAFT_API void raft_uv_set_connect_retry_delay(struct raft_io *io,
 					      unsigned msecs);
-
-/**
- * Emit low-level debug messages using the given tracer.
- */
-RAFT_API void raft_uv_set_tracer(struct raft_io *io,
-				 struct raft_tracer *tracer);
 
 /**
  * Enable or disable auto-recovery on startup. Default enabled.

--- a/src/raft/fixture.c
+++ b/src/raft/fixture.c
@@ -36,7 +36,6 @@ struct raft_fixture_server
 	bool alive;                /* If false, the server is down. */
 	raft_id id;                /* Server ID. */
 	char address[16];          /* Server address (stringified ID). */
-	struct raft_tracer tracer; /* Tracer. */
 	struct raft_io io;         /* In-memory raft_io implementation. */
 	struct raft raft;          /* Raft instance. */
 };
@@ -1045,20 +1044,6 @@ void ioClose(struct raft_io *raft_io)
 	raft_free(io);
 }
 
-/* Custom emit tracer function which include the server ID. */
-static void emit(struct raft_tracer *t,
-		 const char *file,
-		 unsigned int line,
-		 const char *func,
-		 unsigned int level,
-		 const char *message)
-{
-	unsigned id = *(unsigned *)t->impl;
-	(void)func;
-	(void)level;
-	fprintf(stderr, "%d: %30s:%*d - %s\n", id, file, 3, line, message);
-}
-
 static int serverInit(struct raft_fixture *f, unsigned i, struct raft_fsm *fsm)
 {
 	int rv;
@@ -1082,9 +1067,6 @@ static int serverInit(struct raft_fixture *f, unsigned i, struct raft_fsm *fsm)
 	raft_set_election_timeout(&s->raft, ELECTION_TIMEOUT);
 	raft_set_heartbeat_timeout(&s->raft, HEARTBEAT_TIMEOUT);
 	raft_set_install_snapshot_timeout(&s->raft, INSTALL_SNAPSHOT_TIMEOUT);
-	s->tracer.impl = (void *)&s->id;
-	s->tracer.emit = emit;
-	s->raft.tracer = NULL;
 	return 0;
 }
 

--- a/src/raft/uv.c
+++ b/src/raft/uv.c
@@ -813,13 +813,6 @@ void raft_uv_set_connect_retry_delay(struct raft_io *io, unsigned msecs)
 	uv->connect_retry_delay = msecs;
 }
 
-void raft_uv_set_tracer(struct raft_io *io, struct raft_tracer *tracer)
-{
-	struct uv *uv;
-	uv = io->impl;
-	uv->tracer = tracer;
-}
-
 void raft_uv_set_auto_recovery(struct raft_io *io, bool flag)
 {
 	struct uv *uv;


### PR DESCRIPTION
This PR removes a useless trace hook from raft source so that once we add one we can use, there will be no confusion.